### PR TITLE
cam_cesm2_1_rel_37: Bring in ww3 external from git

### DIFF
--- a/Externals.cfg
+++ b/Externals.cfg
@@ -47,8 +47,8 @@ local_path = components/rtm
 
 [ww3]
 tag = ww3_cesm2_0_rel_01
-protocol = svn
-repo_url =  https://svn-ccsm-models.cgd.ucar.edu/ww3/release_tags
+protocol = git
+repo_url = https://github.com/ESCOMP/WW3-CESM.git
 required = True
 local_path = components/ww3
 


### PR DESCRIPTION
SInce it appears that there are no more tags coming before the release, I am bringing this change of ww3 coming from git instead of svn in by itself.