### PR TITLE
cam_cesm2_1_rel_39: update CIME external to bring in tag with fix for RCE

### DIFF
--- a/Externals.cfg
+++ b/Externals.cfg
@@ -9,7 +9,7 @@ required = True
 local_path = components/cice
 
 [cime]
-tag = cime5.6.25
+tag = cime5.6.27
 protocol = git
 repo_url = https://github.com/ESMCI/cime
 required = True


### PR DESCRIPTION
Fixes #39