### PR TITLE
cam6_2_013: Changes to efield module to workaround an issue with intel 19

### DIFF
--- a/cime_config/testdefs/testlist_cam.xml
+++ b/cime_config/testdefs/testlist_cam.xml
@@ -572,13 +572,13 @@
       <machine name="cheyenne" compiler="intel" category="waccm"/>
     </machines>
   </test>
-  <test compset="FW1850" grid="f09_f09_mg17" name="SMS_Ld1" testmods="cam/reduced_hist1d">
+  <test compset="FW1850" grid="f09_f09_mg17" name="SMS_Ln9" testmods="cam/reduced_hist3s">
     <machines>
       <machine name="cheyenne" compiler="intel" category="aux_cam"/>
       <machine name="cheyenne" compiler="intel" category="prealpha"/>
     </machines>
     <options>
-      <option name="wallclock">00:30:00</option>
+      <option name="wallclock">00:10:00</option>
     </options>
   </test>
   <test compset="FWHIST_BGC" grid="f09_f09_mg17" name="ERP_Ld3" testmods="cam/reduced_hist1d">

--- a/cime_config/testdefs/testlist_cam.xml
+++ b/cime_config/testdefs/testlist_cam.xml
@@ -986,6 +986,23 @@
       <machine name="cheyenne" compiler="intel" category="waccm"/>
     </machines>
   </test>
+  <test compset="FW2000climo" grid="ne30pg3_ne30pg3_mg17" name="ERP_Ln9" testmods="cam/outfrq9s_wcm_ne30">
+    <machines>
+      <machine name="cheyenne" compiler="intel" category="waccm"/>
+      <machine name="cheyenne" compiler="intel" category="aux_cam"/>
+    </machines>
+  </test>
+  <test compset="FW2000climo" grid="ne30pg3_ne30pg3_mg17" name="SMS_D_Ln9" testmods="cam/outfrq9s_wcm_ne30">
+    <machines>
+      <machine name="cheyenne" compiler="intel" category="waccm"/>
+    </machines>
+  </test>
+  <test compset="FW2000climo" grid="ne30_ne30_mg17" name="SMS_Ln9" testmods="cam/outfrq9s_wcm_ne30">
+    <machines>
+      <machine name="cheyenne" compiler="intel" category="waccm"/>
+      <machine name="cheyenne" compiler="intel" category="prealpha"/>
+    </machines>
+  </test>
   <test compset="PC4" grid="f19_f19_mg17" name="SMS" testmods="cam/cam4_port">
     <machines>
       <machine name="cheyenne" compiler="intel" category="prealpha"/>

--- a/cime_config/testdefs/testlist_cam.xml
+++ b/cime_config/testdefs/testlist_cam.xml
@@ -578,7 +578,7 @@
       <machine name="cheyenne" compiler="intel" category="prealpha"/>
     </machines>
     <options>
-      <option name="wallclock">00:10:00</option>
+      <option name="wallclock">00:30:00</option>
     </options>
   </test>
   <test compset="FWHIST_BGC" grid="f09_f09_mg17" name="ERP_Ld3" testmods="cam/reduced_hist1d">

--- a/cime_config/testdefs/testmods_dirs/cam/outfrq9s_wcm_ne30/shell_commands
+++ b/cime_config/testdefs/testmods_dirs/cam/outfrq9s_wcm_ne30/shell_commands
@@ -1,0 +1,2 @@
+./xmlchange ROF_NCPL=\$ATM_NCPL
+./xmlchange GLC_NCPL=\$ATM_NCPL

--- a/cime_config/testdefs/testmods_dirs/cam/outfrq9s_wcm_ne30/user_nl_cam
+++ b/cime_config/testdefs/testmods_dirs/cam/outfrq9s_wcm_ne30/user_nl_cam
@@ -1,0 +1,12 @@
+mfilt=1,1,1,1,1,1,1,1,1
+ndens=1,1,1,1,1,1,1,1,1
+nhtfrq=9,9,9,9,9,9,9,9,9
+inithist='ENDOFRUN'
+
+se_nsplit = 30
+se_rayk0= 10
+se_raykrange= 5
+se_raytau0=0.002 
+ 
+state_debug_checks = .true.
+

--- a/cime_config/testdefs/testmods_dirs/cam/outfrq9s_wcm_ne30/user_nl_clm
+++ b/cime_config/testdefs/testmods_dirs/cam/outfrq9s_wcm_ne30/user_nl_clm
@@ -1,0 +1,27 @@
+!----------------------------------------------------------------------------------
+! Users should add all user specific namelist changes below in the form of 
+! namelist_var = new_namelist_value 
+!
+! Include namelist variables for drv_flds_in ONLY if -megan and/or -drydep options
+! are set in the CLM_NAMELIST_OPTS env variable.
+!
+! EXCEPTIONS: 
+! Set use_cndv           by the compset you use and the CLM_BLDNML_OPTS -dynamic_vegetation setting
+! Set use_vichydro       by the compset you use and the CLM_BLDNML_OPTS -vichydro           setting
+! Set use_cn             by the compset you use and CLM_BLDNML_OPTS -bgc  setting
+! Set use_crop           by the compset you use and CLM_BLDNML_OPTS -crop setting
+! Set spinup_state       by the CLM_BLDNML_OPTS -bgc_spinup      setting
+! Set irrigate           by the CLM_BLDNML_OPTS -irrig           setting
+! Set dtime              with L_NCPL                             option
+! Set fatmlndfrc         with LND_DOMAIN_PATH/LND_DOMAIN_FILE    options
+! Set finidat            with RUN_REFCASE/RUN_REFDATE/RUN_REFTOD options for hybrid or branch cases
+!                        (includes $inst_string for multi-ensemble cases)
+! Set glc_grid           with CISM_GRID                          option
+! Set glc_smb            with GLC_SMB                            option
+! Set maxpatch_glcmec    with GLC_NEC                            option
+! Set glc_do_dynglacier  with GLC_TWO_WAY_COUPLING               env variable
+!----------------------------------------------------------------------------------
+hist_nhtfrq = 9
+hist_mfilt  = 1
+hist_ndens  = 1
+

--- a/src/physics/waccm/efield.F90
+++ b/src/physics/waccm/efield.F90
@@ -1036,6 +1036,9 @@
 !$omp parallel do private(ilat)
       do ilat = idlat,nmlath-idlat
          pot_smo(:,ilat) = matmul( pot(:,ilat-idlat:ilat+idlat),w )*wgt
+      end do
+
+      do ilat = idlat,nmlath-idlat
          pot(:,ilat) = pot_smo(:,ilat)
       end do
 

--- a/src/physics/waccm/efield.F90
+++ b/src/physics/waccm/efield.F90
@@ -73,10 +73,15 @@
 !------------------------------------------------------------------------------
 ! mag. grid dimensions (assumed resolution of 2deg)
 !------------------------------------------------------------------------------
-      integer, parameter ::  &
-      nmlon = 180,       &  ! mlon
-      nmlat = 90,        &  ! mlat
-      nmlath= nmlat/2       ! mlat/2
+      integer, parameter ::   &
+           nmlon = 180,       & ! mlon
+           nmlat = 90,        & ! mlat
+           nmlath= nmlat/2      ! mlat/2
+
+      integer, parameter ::   &
+           nmlon1f = nmlon/4, & ! 1 fourth mlon
+           nmlon2f = nmlon/2, & ! 2 fourths mlon
+           nmlon3f = 3*nmlon/4  ! 3 fourths mlon 
 
       real(r8) ::        &
         ylatm(0:nmlat),  &   ! magnetic latitudes (deg)
@@ -166,6 +171,10 @@
 
       real(r8) :: epotential_max = huge(1._r8) ! max cross cap potential kV
 
+      integer :: ip1f(0:nmlon)=-huge(1)
+      integer :: ip2f(0:nmlon)=-huge(1)
+      integer :: ip3f(0:nmlon)=-huge(1)
+
       contains
 
       subroutine efield_init(efield_lflux_file, efield_hflux_file, efield_potential_max)
@@ -181,6 +190,7 @@
       character(len=*), intent(in) :: efield_hflux_file
       real(r8),         intent(in) :: efield_potential_max ! cross cap electric potential maximum
 
+      integer :: i
       real(r8) :: nanval
       nanval=nan
 
@@ -198,6 +208,21 @@
       call prep_pnm     ! set up the constant factors for P_n^m & dP/d phi
 
       epotential_max = efield_potential_max
+
+      do i = 0,nmlon
+        ip1f(i) = i + nmlon1f
+        if( ip1f(i) > nmlon ) then
+           ip1f(i) = ip1f(i) - nmlon
+        end if
+        ip2f(i) = i + nmlon2f
+        if( ip2f(i) > nmlon ) then
+           ip2f(i) = ip2f(i) - nmlon
+        end if
+        ip3f(i) = i + nmlon3f
+        if( ip3f(i) > nmlon ) then
+           ip3f(i) = ip3f(i) - nmlon
+        end if
+      end do
 
       end subroutine efield_init
 
@@ -1011,9 +1036,6 @@
 !$omp parallel do private(ilat)
       do ilat = idlat,nmlath-idlat
          pot_smo(:,ilat) = matmul( pot(:,ilat-idlat:ilat+idlat),w )*wgt
-      end do
-
-      do ilat = idlat,nmlath-idlat
          pot(:,ilat) = pot_smo(:,ilat)
       end do
 
@@ -1422,7 +1444,7 @@
 ! Author: A. Maute Dec 2003  am 12/16/03
 !-----------------------------------------------------------------------
 
-      integer  :: i, j, ip1f, ip2f, ip3f
+      integer  :: i, j
       real(r8) :: coslm, r, fac, wrk
       real(r8) :: wrk1d(0:nmlon)
 
@@ -1481,26 +1503,14 @@
 !-----------------------------------------------------------------------
 ! Poles:
 !-----------------------------------------------------------------------
-!$omp parallel do private(i, ip1f,ip2f,ip3f)
+!$omp parallel do private(i)
       do i = 0,nmlon
-        ip1f = i + nmlon/4
-        if( ip1f > nmlon ) then
-           ip1f = ip1f - nmlon
-        end if
-        ip2f = i + nmlon/2
-        if( ip2f > nmlon ) then
-           ip2f = ip2f - nmlon
-        end if
-        ip3f = i + 3*nmlon/4
-        if( ip3f > nmlon ) then
-           ip3f = ip3f - nmlon
-        end if
-        ed1(i,0)     = .25_r8*(ed1(i,1) - ed1(ip2f,1) + ed2(ip1f,1) - ed2(ip3f,1))
-        ed1(i,nmlat) = .25_r8*(ed1(i,nmlat-1) - ed1(ip2f,nmlat-1) &
-                               + ed2(ip1f,nmlat-1) - ed2(ip3f,nmlat-1))
-        ed2(i,0)     = .25_r8*(ed2(i,1) - ed2(ip2f,1) - ed1(ip1f,1) + ed1(ip3f,1))
-        ed2(i,nmlat) = .25_r8*(ed2(i,nmlat-1) - ed2(ip2f,nmlat-1) &
-                               - ed1(ip1f,nmlat-1) + ed1(ip3f,nmlat-1))
+        ed1(i,0)     = .25_r8*(ed1(i,1) - ed1(ip2f(i),1) + ed2(ip1f(i),1) - ed2(ip3f(i),1))
+        ed1(i,nmlat) = .25_r8*(ed1(i,nmlat-1) - ed1(ip2f(i),nmlat-1) &
+                               + ed2(ip1f(i),nmlat-1) - ed2(ip3f(i),nmlat-1))
+        ed2(i,0)     = .25_r8*(ed2(i,1) - ed2(ip2f(i),1) - ed1(ip1f(i),1) + ed1(ip3f(i),1))
+        ed2(i,nmlat) = .25_r8*(ed2(i,nmlat-1) - ed2(ip2f(i),nmlat-1) &
+                               - ed1(ip1f(i),nmlat-1) + ed1(ip3f(i),nmlat-1))
       end do
 
       end subroutine DerivPotential


### PR DESCRIPTION
A proposed workaround for an issue with intel/19.0.2 on cheyenne

New tests added :
aux_cam:
 ERP_Ln9.ne30pg3_ne30pg3_mg17.FW2000climo.cheyenne_intel.cam-outfrq9s_wcm_ne30
prealpha:
 SMS_Ln9.ne30_ne30_mg17.FW2000climo.cheyenne_intel.cam-outfrq9s_wcm_ne30

fixes #68

