### PR TITLE
part of cam6_2_014: Fix bug where empty_htapes was always set to false 

### DIFF
--- a/bld/build-namelist
+++ b/bld/build-namelist
@@ -2882,9 +2882,9 @@ $nl->set_variable_value('phys_ctl_nl', 'cam_chempkg', $cam_chempkg);
 
 
 # Check the snapshot settings.
-check_snapshot_settings();
 add_default($nl, 'cam_snapshot_before_num');
 add_default($nl, 'cam_snapshot_after_num');
+check_snapshot_settings();
 
 # Tropopause climatology
 if (!$simple_phys) {
@@ -4509,9 +4509,6 @@ sub check_snapshot_settings {
     my $cam_snapshot_after_num   =  $nl->get_variable_value('phys_ctl_nl', 'cam_snapshot_after_num');
     my $microphys = $cfg->get('microphys');
 
-    # Set the empty_htapes always to false for snapshot runs
-    $nl->set_variable_value('cam_history_nl', 'empty_htapes', $FALSE);
-
     if (($cam_snapshot_before_num >= 0) or ($cam_snapshot_after_num >= 0)) {
         print  "cam_snapshot settings\n";
         print "cam_take_snapshot_before = $cam_take_snapshot_before\n";
@@ -4521,6 +4518,9 @@ sub check_snapshot_settings {
     } else {
         return;  # No snapshots are requested
     }
+
+    # Set the empty_htapes always to false for snapshot runs
+    $nl->set_variable_value('cam_history_nl', 'empty_htapes', $FALSE);
 
     # Check for "take_snapshot" and history file number both being set or not set.  Only one set is an error
     if ( ((defined $cam_take_snapshot_before ) xor  (defined $cam_snapshot_before_num))) {


### PR DESCRIPTION
All namelists were having empty_htapes be set to false (accidentally introduced in cam_snapshot tag). #46 

Tested this fix with and without cam_snapshot setting and resulting atm_in file has appropriate settings.