### PR TITLE
part of cam6_2_014: mg utils comment change, mg3 graupel order change

### DIFF
--- a/src/physics/cam/micro_mg3_0.F90
+++ b/src/physics/cam/micro_mg3_0.F90
@@ -1660,12 +1660,12 @@ subroutine micro_mg_tend ( &
 
      !  graupel/hail size distributions and properties
 
-     if (do_graupel) then
-        call size_dist_param_basic(mg_graupel_props, qgic(:,k), ngic(:,k), &
-          lamg(:,k), mgncol, n0=n0g(:,k))
-     end if
      if (do_hail) then
         call size_dist_param_basic(mg_hail_props, qgic(:,k), ngic(:,k), &
+          lamg(:,k), mgncol, n0=n0g(:,k))
+     end if
+     if (do_graupel) then
+        call size_dist_param_basic(mg_graupel_props, qgic(:,k), ngic(:,k), &
           lamg(:,k), mgncol, n0=n0g(:,k))
      end if
         
@@ -2661,14 +2661,16 @@ subroutine micro_mg_tend ( &
         end if
 
         ! fallspeed for graupel
-        if (do_graupel) then
-           call size_dist_param_basic(mg_graupel_props, dumg(i,k), dumng(i,k), &
-             lamg(i,k))
-        end if
+
         if (do_hail) then
            call size_dist_param_basic(mg_hail_props, dumg(i,k), dumng(i,k), &
              lamg(i,k))
         end if
+        if (do_graupel) then
+           call size_dist_param_basic(mg_graupel_props, dumg(i,k), dumng(i,k), &
+             lamg(i,k))
+        end if
+
             
         if (lamg(i,k).ge.qsmall) then
 
@@ -3525,12 +3527,12 @@ subroutine micro_mg_tend ( &
 
            dum = dumng(i,k)
 
-           if (do_graupel) then
-              call size_dist_param_basic(mg_graupel_props, dumg(i,k), dumng(i,k), &
-                lamg(i,k))
-           end if
            if (do_hail) then
               call size_dist_param_basic(mg_hail_props, dumg(i,k), dumng(i,k), &
+                lamg(i,k))
+           end if
+           if (do_graupel) then
+              call size_dist_param_basic(mg_graupel_props, dumg(i,k), dumng(i,k), &
                 lamg(i,k))
            end if
               

--- a/src/physics/cam/micro_mg_utils.F90
+++ b/src/physics/cam/micro_mg_utils.F90
@@ -431,7 +431,7 @@ elemental subroutine size_dist_param_liq_line(props, qcic, ncic, rho, pgam, lamc
      ! arguments.)
      props_loc = props
 
-     ! Get pgam from fit to observations of martin et al. 1994
+     ! Get pgam from fit Rotstayn and Liu 2003 (changed from Martin 1994 for CAM6)
      pgam = 1.0_r8 - 0.7_r8 * exp(-0.008_r8*1.e-6_r8*ncic*rho)
      pgam = 1._r8/(pgam**2) - 1._r8
      pgam = max(pgam, 2._r8)
@@ -481,7 +481,7 @@ subroutine size_dist_param_liq_vect(props, qcic, ncic, rho, pgam, lamc, mgncol)
         ! (Elemental routines that operate on arrays can't modify scalar
         ! arguments.)
         props_loc = props
-        ! Get pgam from fit to observations of martin et al. 1994
+        ! Get pgam from fit by Rotstayn and Liu 2003 (changed from Martin 1994 for CAM6)
         pgam(i) = 1.0_r8 - 0.7_r8 * exp(-0.008_r8*1.e-6_r8*ncic(i)*rho(i))
         pgam(i) = 1._r8/(pgam(i)**2) - 1._r8
         pgam(i) = max(pgam(i), 2._r8)


### PR DESCRIPTION
This changes 2 files; comments in micro_mg_utils.F90.

In micro_mg3_0.F90, the code will tolerate both do_graupel and do_hail = true (CAM at higher levels does not allow it, but the microphysics does permit it).  The changes move the places where  do_graupel and do_hail appear separately so that graupel is always last. This will give an equivalent result to do_graupel = true, do_hail = false when both are true.

It also needs to propagate to the PUMAS repository for the microphysics (@Katetc ) can handle that hopefully....

Fixes #74