### PR TITLE
cam6_2_014: Empty htapes bug fix and misc changes

### DIFF
--- a/bld/build-namelist
+++ b/bld/build-namelist
@@ -2882,9 +2882,9 @@ $nl->set_variable_value('phys_ctl_nl', 'cam_chempkg', $cam_chempkg);
 
 
 # Check the snapshot settings.
-check_snapshot_settings();
 add_default($nl, 'cam_snapshot_before_num');
 add_default($nl, 'cam_snapshot_after_num');
+check_snapshot_settings();
 
 # Tropopause climatology
 if (!$simple_phys) {
@@ -4509,9 +4509,6 @@ sub check_snapshot_settings {
     my $cam_snapshot_after_num   =  $nl->get_variable_value('phys_ctl_nl', 'cam_snapshot_after_num');
     my $microphys = $cfg->get('microphys');
 
-    # Set the empty_htapes always to false for snapshot runs
-    $nl->set_variable_value('cam_history_nl', 'empty_htapes', $FALSE);
-
     if (($cam_snapshot_before_num >= 0) or ($cam_snapshot_after_num >= 0)) {
         print  "cam_snapshot settings\n";
         print "cam_take_snapshot_before = $cam_take_snapshot_before\n";
@@ -4521,6 +4518,9 @@ sub check_snapshot_settings {
     } else {
         return;  # No snapshots are requested
     }
+
+    # Set the empty_htapes always to false for snapshot runs
+    $nl->set_variable_value('cam_history_nl', 'empty_htapes', $FALSE);
 
     # Check for "take_snapshot" and history file number both being set or not set.  Only one set is an error
     if ( ((defined $cam_take_snapshot_before ) xor  (defined $cam_snapshot_before_num))) {

--- a/src/physics/cam/micro_mg3_0.F90
+++ b/src/physics/cam/micro_mg3_0.F90
@@ -1660,12 +1660,12 @@ subroutine micro_mg_tend ( &
 
      !  graupel/hail size distributions and properties
 
-     if (do_graupel) then
-        call size_dist_param_basic(mg_graupel_props, qgic(:,k), ngic(:,k), &
-          lamg(:,k), mgncol, n0=n0g(:,k))
-     end if
      if (do_hail) then
         call size_dist_param_basic(mg_hail_props, qgic(:,k), ngic(:,k), &
+          lamg(:,k), mgncol, n0=n0g(:,k))
+     end if
+     if (do_graupel) then
+        call size_dist_param_basic(mg_graupel_props, qgic(:,k), ngic(:,k), &
           lamg(:,k), mgncol, n0=n0g(:,k))
      end if
         
@@ -2661,14 +2661,16 @@ subroutine micro_mg_tend ( &
         end if
 
         ! fallspeed for graupel
-        if (do_graupel) then
-           call size_dist_param_basic(mg_graupel_props, dumg(i,k), dumng(i,k), &
-             lamg(i,k))
-        end if
+
         if (do_hail) then
            call size_dist_param_basic(mg_hail_props, dumg(i,k), dumng(i,k), &
              lamg(i,k))
         end if
+        if (do_graupel) then
+           call size_dist_param_basic(mg_graupel_props, dumg(i,k), dumng(i,k), &
+             lamg(i,k))
+        end if
+
             
         if (lamg(i,k).ge.qsmall) then
 
@@ -3525,12 +3527,12 @@ subroutine micro_mg_tend ( &
 
            dum = dumng(i,k)
 
-           if (do_graupel) then
-              call size_dist_param_basic(mg_graupel_props, dumg(i,k), dumng(i,k), &
-                lamg(i,k))
-           end if
            if (do_hail) then
               call size_dist_param_basic(mg_hail_props, dumg(i,k), dumng(i,k), &
+                lamg(i,k))
+           end if
+           if (do_graupel) then
+              call size_dist_param_basic(mg_graupel_props, dumg(i,k), dumng(i,k), &
                 lamg(i,k))
            end if
               

--- a/src/physics/cam/micro_mg_utils.F90
+++ b/src/physics/cam/micro_mg_utils.F90
@@ -431,7 +431,7 @@ elemental subroutine size_dist_param_liq_line(props, qcic, ncic, rho, pgam, lamc
      ! arguments.)
      props_loc = props
 
-     ! Get pgam from fit to observations of martin et al. 1994
+     ! Get pgam from fit Rotstayn and Liu 2003 (changed from Martin 1994 for CAM6)
      pgam = 1.0_r8 - 0.7_r8 * exp(-0.008_r8*1.e-6_r8*ncic*rho)
      pgam = 1._r8/(pgam**2) - 1._r8
      pgam = max(pgam, 2._r8)
@@ -481,7 +481,7 @@ subroutine size_dist_param_liq_vect(props, qcic, ncic, rho, pgam, lamc, mgncol)
         ! (Elemental routines that operate on arrays can't modify scalar
         ! arguments.)
         props_loc = props
-        ! Get pgam from fit to observations of martin et al. 1994
+        ! Get pgam from fit by Rotstayn and Liu 2003 (changed from Martin 1994 for CAM6)
         pgam(i) = 1.0_r8 - 0.7_r8 * exp(-0.008_r8*1.e-6_r8*ncic(i)*rho(i))
         pgam(i) = 1._r8/(pgam(i)**2) - 1._r8
         pgam(i) = max(pgam(i), 2._r8)

--- a/src/physics/cam/physics_types.F90
+++ b/src/physics/cam/physics_types.F90
@@ -4,7 +4,7 @@
 module physics_types
 
   use shr_kind_mod,     only: r8 => shr_kind_r8
-  use ppgrid,           only: pcols, pver, psubcols
+  use ppgrid,           only: pcols, pver
   use constituents,     only: pcnst, qmin, cnst_name
   use geopotential,     only: geopotential_dse, geopotential_t
   use physconst,        only: zvir, gravit, cpair, rair, cpairv, rairv
@@ -173,8 +173,6 @@ contains
     integer, intent(in) :: psetcols
 
     integer :: ierr=0, lchnk
-    type(physics_state), pointer :: state
-    type(physics_tend), pointer :: tend
 
     allocate(phys_state(begchunk:endchunk), stat=ierr)
     if( ierr /= 0 ) then
@@ -203,13 +201,11 @@ contains
 ! Update the state and or tendency structure with the parameterization tendencies
 !-----------------------------------------------------------------------
     use shr_sys_mod,  only: shr_sys_flush
-    use constituents, only: cnst_get_ind, cnst_mw
+    use constituents, only: cnst_get_ind
     use scamMod,      only: scm_crm_mode, single_column
     use phys_control, only: phys_getopts
     use physconst,    only: physconst_update ! Routine which updates physconst variables (WACCM-X)
-    use ppgrid,       only: begchunk, endchunk
     use qneg_module,  only: qneg3
-    use cam_history,  only: outfld
 
 !------------------------------Arguments--------------------------------
     type(physics_ptend), intent(inout)  :: ptend   ! Parameterization tendencies
@@ -222,7 +218,7 @@ contains
     ! tend is usually only needed by calls from physpkg.
 !
 !---------------------------Local storage-------------------------------
-    integer :: i,k,m                               ! column,level,constituent indices
+    integer :: k,m                                 ! column,level,constituent indices
     integer :: ixcldice, ixcldliq                  ! indices for CLDICE and CLDLIQ
     integer :: ixnumice, ixnumliq
     integer :: ixnumsnow, ixnumrain
@@ -487,10 +483,9 @@ contains
 ! Check a physics_state object for invalid data (e.g NaNs, negative
 ! temperatures).
 !-----------------------------------------------------------------------
-    use shr_infnan_mod, only: shr_infnan_inf_type, assignment(=), &
+    use shr_infnan_mod, only: assignment(=), &
                               shr_infnan_posinf, shr_infnan_neginf
-    use shr_assert_mod, only: shr_assert, shr_assert_in_domain
-    use physconst,      only: pi
+    use shr_assert_mod, only: shr_assert_in_domain
     use constituents,   only: pcnst
 
 !------------------------------Arguments--------------------------------
@@ -944,8 +939,6 @@ end subroutine physics_ptend_copy
 !------------------------------Arguments--------------------------------
     type(physics_ptend), intent(inout)  :: ptend   ! Parameterization tendencies
 !-----------------------------------------------------------------------
-    integer :: m             ! Index for constiuent
-!-----------------------------------------------------------------------
 
     if(ptend%ls) then
        ptend%s = 0._r8
@@ -1158,9 +1151,6 @@ end subroutine physics_ptend_copy
     !
     !-----------------------------------------------------------------------
 
-    use constituents, only : cnst_get_type_byind
-    use ppgrid,       only : begchunk, endchunk
-
     implicit none
     !
     ! Arguments
@@ -1174,7 +1164,7 @@ end subroutine physics_ptend_copy
     !
     integer  :: lchnk         ! chunk identifier
     integer  :: ncol          ! number of atmospheric columns
-    integer  :: i,k,m         ! Longitude, level indices
+    integer  :: k,m           ! Longitude, level indices
     real(r8) :: fdq(pcols)    ! mass adjustment factor
     real(r8) :: te(pcols)     ! total energy in a layer
     real(r8) :: utmp(pcols)   ! temp variable for recalculating the initial u values
@@ -1397,14 +1387,13 @@ end subroutine physics_tend_init
 subroutine set_state_pdry (state,pdeld_calc)
 
   use ppgrid,  only: pver
-  use pmgrid,  only: plev, plevp
   implicit none
 
   type(physics_state), intent(inout) :: state
   logical, optional, intent(in) :: pdeld_calc    !  .true. do calculate pdeld [default]
                                                  !  .false. don't calculate pdeld
   integer ncol
-  integer i, k
+  integer k
   logical do_pdeld_calc
 
   if ( present(pdeld_calc) ) then
@@ -1489,7 +1478,7 @@ subroutine physics_state_alloc(state,lchnk,psetcols)
 
   integer, intent(in)                :: psetcols
 
-  integer :: ierr=0, i
+  integer :: ierr=0
 
   state%lchnk    = lchnk
   state%psetcols = psetcols
@@ -1809,7 +1798,6 @@ subroutine physics_tend_dealloc(tend)
 ! deallocate the individual tend components
 
   type(physics_tend), intent(inout)  :: tend
-  integer :: psetcols
   integer :: ierr = 0
 
   deallocate(tend%dtdt, stat=ierr)

--- a/test/system/archive_baseline.sh
+++ b/test/system/archive_baseline.sh
@@ -33,7 +33,7 @@ BASELINE ARCHIVED LOCATION
 
 	hobart, izumi:     /fs/cgd/csm/models/atm/cam/pretag_bl/TAGNAME_pgi
 	                   /fs/cgd/csm/models/atm/cam/pretag_bl/TAGNAME_nag
-        cheyenne:  /glade/p/cesmdata/cseg/cam_baselines/TAGNAME
+        cheyenne:  /glade/p/cesm/amwg/cam_baselines/TAGNAME
 
 
 
@@ -105,7 +105,7 @@ case $hostname in
       CAM_FC="INTEL"
     fi
     test_file_list="tests_pretag_cheyenne"
-    baselinedir="/glade/p/cesmdata/cseg/cam_baselines/$1"
+    baselinedir="/glade/p/cesm/amwg/cam_baselines/$1"
   ;;
 
   * ) echo "ERROR: machine $hostname not currently supported"; exit 1 ;;
@@ -116,14 +116,17 @@ if [ -n "$CESM_TESTDIR" ]; then
     echo " "
     case $hostname in
 	ch*)
-	    echo "CESM Archiving to /glade/p/cesmdata/cseg/cesm_baselines/$1"
+	    echo "CESM Archiving to /glade/p/cesm/amwg/cesm_baselines/$1"
+            ../../cime/scripts/Tools/bless_test_results -p -t '' -c '' -r $CESM_TESTDIR --baseline-root /glade/p/cesm/amwg/cesm_baselines -b $1 -f -s
 	    ;;
 
 	hobart)
 	    echo "CESM Archiving to /fs/cgd/csm/models/atm/cam/cesm_baselines/$1"
+            ../../cime/scripts/Tools/bless_test_results -p -t '' -c '' -r $CESM_TESTDIR -b $1 -f -s
 	    ;;
 	izumi)
 	    echo "CESM Archiving to /fs/cgd/csm/models/atm/cam/cesm_baselines/$1"
+            ../../cime/scripts/Tools/bless_test_results -p -t '' -c '' -r $CESM_TESTDIR -b $1 -f -s
 	    ;;
     esac
     echo " "


### PR DESCRIPTION
Fixes bug introduced in #46 where empty_htapes is always set to false
Bring in Andrew Gettelman's MG3 misc changes
Remove unused variables in physics_types.F90
Change location for storage of CAM baseline tests to AMWG space on cheyenne

#72 and #75 were reviewed independently and #64 does not require review.  Hence there is no review requested for this tag (unless anyone decides to do so anyway)

Closes #64 
Closes #72 
Closes #75 
