### PR TITLE
Add issue-closing python script for github action

### DIFF
--- a/.github/scripts/branch_pr_issue_closer.py
+++ b/.github/scripts/branch_pr_issue_closer.py
@@ -55,7 +55,7 @@ def  project_card_move(oa_token, column_id, card_id):
     #create required argument strings from inputs:
     github_oa_header = ''' "Authorization: token {0}" '''.format(oa_token)
     github_url_str = '''https://api.github.com/projects/columns/cards/{0}/moves'''.format(card_id)
-    json_post_inputs = ''' '{"position":"top", "column_id":%i}' ''' %column_id  #format() can't be used due to curly brackets in string.
+    json_post_inputs = ''' '{{"position":"top", "column_id":{}}}' '''.format(column_id)
 
     #Create curl command line string:
     curl_cmdline = '''curl -H '''+github_oa_header+''' -H "Accept: application/vnd.github.inertia-preview+json" -X POST -d '''+\
@@ -101,9 +101,7 @@ def end_script(msg):
     """
     Prints message to screen, and then exits script.
     """
-    print("\n")
-    print(msg)
-    print("\n")
+    print("\n{}\n".format(msg))
     print("Issue closing check has completed successfully.")
     sys.exit(0)
 
@@ -154,8 +152,6 @@ def _main_prog():
 
     commit_message = github_commit.commit.message
 
-    print(commit_message)
-
     #+++++++++++++++++++++++++++++++
     #Search for github PR merge text
     #+++++++++++++++++++++++++++++++
@@ -177,7 +173,8 @@ def _main_prog():
         #Extract first word:
         first_word = post_msg_word_list[0]
 
-        print(first_word)
+        #Print merged pr number to screen:
+        print("Merged PR: {}".format(first_word))
 
         try:
             #Try assuming the word is just a number:
@@ -222,31 +219,21 @@ def _main_prog():
     #Create integer list of all open issues:
     #++++++++++++++++++++++++++++++++++++++
 
-    #create new list:
-    open_issues = list()
-
     #Extract list of open issues from repo:
     open_repo_issues = cam_repo.get_issues(state='open')
 
-    #Loop over all open repo issues:
-    for issue in open_repo_issues:
-        #Add issue number to "open_issues" list:
-        open_issues.append(issue.number)
+    #Collect all open repo issues:
+    open_issues = [issue.number for issue in open_repo_issues]
 
     #+++++++++++++++++++++++++++++++++++++++++++++
     #Create integer list of all open pull requests
     #+++++++++++++++++++++++++++++++++++++++++++++
 
-    #create new list:
-    open_pulls = list()
-
     #Extract list of open PRs from repo:
     open_repo_pulls = cam_repo.get_pulls(state='open')
 
-    #Loop over all open repo issues:
-    for pull in open_repo_pulls:
-        #Add pr number to "open_pulls" list:
-        open_pulls.append(pull.number)
+    #Collect all open pull requests:
+    open_pulls = [pr.number for pr in open_repo_pulls]
 
     #+++++++++++++++++++++++++++++++++++++++++++++++++
     #Check if one of the keywords exists in PR message
@@ -260,11 +247,8 @@ def _main_prog():
     #Create regex pattern to find keywords:
     keyword_pattern = re.compile(r'(^|\s)close(\s|s\s|d\s)|(^|\s)fix(\s|es\s|ed\s)|(^|\s)resolve(\s|s\s|d\s)')
 
-    #Extract Pull Request message:
-    pr_message = merged_pull.body
-
-    #Make entire message lower-case:
-    pr_msg_lower = pr_message.lower()
+    #Extract (lower case) Pull Request message:
+    pr_msg_lower = merged_pull.body.lower()
 
     #search for at least one keyword:
     if keyword_pattern.search(pr_msg_lower) is not None:
@@ -279,7 +263,8 @@ def _main_prog():
    #++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
     #create issue pattern ("the number symbol {#} + a number"),
-    #which ends with either a space or a comma:
+    #which ends with either a space, a comma, a period, or
+    #the end of the string itself:
     issue_pattern = re.compile(r'#[0-9]+(\s|,|$)|.')
 
     #Create new "close" issues list:
@@ -297,11 +282,8 @@ def _main_prog():
         #Check if first word matches issue pattern:
         if issue_pattern.match(tmp_msg_str) is not None:
 
-            #If so, then split string into words:
-            tmp_word_list = tmp_msg_str.split()
-
-            #Extract first word:
-            first_word = tmp_word_list[0]
+            #If so, then look for an issue number immediately following
+            first_word = tmp_msg_str.split()[0]
 
             #Extract issue number from first word:
             try:
@@ -310,7 +292,7 @@ def _main_prog():
             except ValueError:
                 #If not, then ignore last letter:
                 try:
-                    issue_num = int(first_word[1:len(first_word)-1])
+                    issue_num = int(first_word[1:-1])
                 except ValueError:
                     #If ignoring the first and last letter doesn't work,
                     #then the match was likely a false positive,
@@ -329,6 +311,16 @@ def _main_prog():
     if not close_issues and not close_pulls:
         endmsg = "No issue or PR numbers were found in the merged PR message.  Thus there is nothing to close."
         end_script(endmsg)
+
+    #Print list of referenced issues to screen:
+    if close_issues:
+        print("Issues referenced by the merged PR: "+", ".join(\
+              str(issue) for issue in close_issues))
+
+    #Print list of referenced PRs to screen:
+    if close_pulls:
+        print("PRs referenced by the merged PR: "+", ".join(\
+              str(pull) for pull in close_pulls))
 
     #+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
     #Determine name of project associated with merged Pull Request
@@ -371,15 +363,15 @@ def _main_prog():
                         endmsg = "Merged Pull Request found in two different projects, so script will do nothing."
                         end_script(endmsg)
 
+    #Print project name associated with merged PR:
+    print("merged PR project name: {}".format(proj_mod_name))
+
     #++++++++++++++++++++++++++++++++++++++++
     #Extract repo project "To do" card issues
     #++++++++++++++++++++++++++++++++++++++++
 
-    #Intialize project issue number list:
-    proj_issues = list()
-
-    #Initalize project issue count list:
-    proj_issue_count = list()
+    #Initalize issue counting dictionary:
+    proj_issues_count = dict()
 
     #Initalize issue id to project card id dictionary:
     proj_issue_card_ids = dict()
@@ -397,7 +389,7 @@ def _main_prog():
                 #If so, then extract cards:
                 cards = column.get_cards()
 
-                #Loop over cards:
+               #Loop over cards:
                 for card in cards:
                     #Extract card content:
                     card_content = card.get_content()
@@ -405,30 +397,31 @@ def _main_prog():
                     #Next, check if card issue number matches any of the "close" issue numbers from the PR:
                     if card_content.number in close_issues:
 
-                        #If so, then check if issue number is already in proj_issues:
-                        if card_content.number in proj_issues:
-                            #If it is already present, then extract index of issue:
-                            iss_idx = proj_issues.index(card_content.number)
-
+                        #If so, then check if issue number is already in proj_issues_count:
+                        if card_content.number in proj_issues_count:
                             #Add one to project issue counter:
-                            proj_issue_count[iss_idx] += 1
-
-                        else:
-                            #If not, then append to project issues and counter list:
-                            proj_issues.append(card_content.number)
-                            proj_issue_count.append(1)
+                            proj_issues_count[card_content.number] += 1
 
                             #Also add issue id and card id to id dictionary used for card move, if in relevant project:
                             if project.name == proj_mod_name:
-                                proj_issue_card_ids.update({card_content.number:card.id})
+                                proj_issue_card_ids[card_content.number] = card.id
+
+                        else:
+                            #If not, then append to project issues count dictionary:
+                            proj_issues_count[card_content.number] = 1
+
+                            #Also add issue id and card id to id dictionary used for card move, if in relevant project:
+                            if project.name == proj_mod_name:
+                                proj_issue_card_ids[card_content.number] = card.id
 
             #Otherwise, check if column name matches "closed issues" column:
             elif column.name == "closed issues" and project.name == proj_mod_name:
                 #If so, then save column id:
-                column_id = column.id
+                #column_id = column.id
+                column_target_id = column.id
 
     #If no project cards are found that match the issue, then exit script:
-    if not proj_issues:
+    if not proj_issues_count:
         endmsg = "No project cards match the issue being closed, so the script will do nothing."
         end_script(endmsg)
 
@@ -442,16 +435,10 @@ def _main_prog():
     #"closed issues" column.
     #+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
-    #Loop over project issues that have been "closed" by merged PR:
-    for issue_num in proj_issues:
+    #Loop over project issues and counts that have been "closed" by merged PR:
+    for issue_num, issue_count in proj_issues_count.items():
 
-        #Determine list index:
-        iss_idx = proj_issues.index(issue_num)
-
-        #determine project issue count:
-        issue_count = proj_issue_count[iss_idx]
-
-        #if issue count is just one, then close issue:
+        #If issue count is just one, then close issue:
         if issue_count == 1:
             #Extract github issue object:
             cam_issue = cam_repo.get_issue(number=issue_num)
@@ -463,7 +450,7 @@ def _main_prog():
             card_id = proj_issue_card_ids[issue_num]
 
             #Then move the card on the relevant project page to the "closed issues" column:
-            project_card_move(token.strip(), column_id, card_id)
+            project_card_move(token.strip(), column_target_id, card_id)
 
     #++++++++++++++++++++++++++++++++++++++++++++++++++++++
     #Finally, close all Pull Requests in "close_pulls" list:

--- a/.github/scripts/branch_pr_issue_closer.py
+++ b/.github/scripts/branch_pr_issue_closer.py
@@ -144,10 +144,7 @@ def _main_prog():
     #++++++++++++++++++++
 
     #Official CAM repo:
-    #cam_repo = ghub.get_repo("ESCOMP/CAM")
-
-    #Test repo:
-    cam_repo = ghub.get_repo("NCAR/repoForTestingCAM")
+    cam_repo = ghub.get_repo("ESCOMP/CAM")
 
     #+++++++++++++++++++++++++++++
     #Get triggering commit message

--- a/.github/scripts/branch_pr_issue_closer.py
+++ b/.github/scripts/branch_pr_issue_closer.py
@@ -1,0 +1,493 @@
+#!/usr/bin/env python
+
+"""
+Script name:  branch_PR_issue_closer.py
+
+Goal:  To check if the newly-merged PR's commit message attempted to close an issue.
+       If so, then move the associated project card to the "closed issues" column.
+
+       Also checks if the newly-merged PR is the final PR needed to fix the issue
+       for all related branches.  If so, then the issue is formally closed.
+
+       Finally, this script also checks to see if the merged PR attempted
+       to close other PRs, and does so if the merge was not to the repo's default branch.
+
+Written by:  Jesse Nusbaumer <nusbaume@ucar.edu> - October, 2019
+"""
+
+#+++++++++++++++++++++
+#Import needed modules
+#+++++++++++++++++++++
+
+import re
+import sys
+import subprocess
+import shlex
+import argparse
+
+from github import Github
+
+#################
+#HELPER FUNCTIONS
+#################
+
+#+++++++++++++++++++++++++++++++++++++++++
+#Curl command needed to move project cards
+#+++++++++++++++++++++++++++++++++++++++++
+
+def  project_card_move(oa_token, column_id, card_id):
+
+    """
+    Currently pyGithub doesn't contain the methods required
+    to move project cards from one column to another, so
+    the unix curl command must be called directly, which is
+    what this function does.
+
+    The specific command-line call made is:
+
+    curl -H "Authorization: token OA_token" -H \
+    "Accept: application/vnd.github.inertia-preview+json" \
+    -X POST -d '{"position":"top", "column_id":<column_id>}' \
+    https://api.github.com/projects/columns/cards/<card_id>/moves
+
+    """
+
+    #create required argument strings from inputs:
+    github_oa_header = ''' "Authorization: token {0}" '''.format(oa_token)
+    github_url_str = '''https://api.github.com/projects/columns/cards/{0}/moves'''.format(card_id)
+    json_post_inputs = ''' '{"position":"top", "column_id":%i}' ''' %column_id  #format() can't be used due to curly brackets in string.
+
+    #Create curl command line string:
+    curl_cmdline = '''curl -H '''+github_oa_header+''' -H "Accept: application/vnd.github.inertia-preview+json" -X POST -d '''+\
+                   json_post_inputs+''' '''+github_url_str
+
+    #Split command line string into argument list:
+    curl_arg_list = shlex.split(curl_cmdline)
+
+    #Run command using subprocess:
+    subprocess.run(curl_arg_list, check=True)
+
+#++++++++++++++++++++++++++++++
+#Input Argument parser function
+#++++++++++++++++++++++++++++++
+
+def parse_arguments():
+
+    """
+    Parses command-line input arguments using the argparse
+    python module and outputs the final argument object.
+    """
+
+    #Create parser object:
+    parser = argparse.ArgumentParser(description='Close issues and pull requests specified in merged pull request.')
+
+    #Add input arguments to be parsed:
+    parser.add_argument('--access_token', metavar='<GITHUB_TOKEN>', action='store', type=str,
+                        help="access token used to access GitHub API")
+
+    parser.add_argument('--trigger_sha', metavar='<GITHUB SHA>', action='store', type=str,
+                        help="Commit SHA that triggered the workflow")
+
+    #Parse Argument inputs
+    args = parser.parse_args()
+    return args
+
+#++++++++++++++++++++++++++++++++
+#Script message and exit function
+#++++++++++++++++++++++++++++++++
+
+def end_script(msg):
+
+    """
+    Prints message to screen, and then exits script.
+    """
+    print("\n")
+    print(msg)
+    print("\n")
+    print("Issue closing check has completed successfully.")
+    sys.exit(0)
+
+#############
+#MAIN PROGRAM
+#############
+
+def _main_prog():
+
+    # pylint: disable=too-many-locals
+    # pylint: disable=too-many-branches
+    # pylint: disable=too-many-statements
+
+    #++++++++++++
+    #Begin script
+    #++++++++++++
+
+    print("Checking if issue needs to be closed...")
+
+    #+++++++++++++++++++++++
+    #Read in input arguments
+    #+++++++++++++++++++++++
+
+    args = parse_arguments()
+
+    #Add argument values to variables:
+    token = args.access_token
+    trigger_sha = args.trigger_sha
+
+    #++++++++++++++++++++++++++++++++
+    #Log-in to github API using token
+    #++++++++++++++++++++++++++++++++
+
+    ghub = Github(token)
+
+    #++++++++++++++++++++
+    #Open ESCOMP/CAM repo
+    #++++++++++++++++++++
+
+    #Official CAM repo:
+    #cam_repo = ghub.get_repo("ESCOMP/CAM")
+
+    #Test repo:
+    cam_repo = ghub.get_repo("NCAR/repoForTestingCAM")
+
+    #+++++++++++++++++++++++++++++
+    #Get triggering commit message
+    #+++++++++++++++++++++++++++++
+
+    github_commit = cam_repo.get_commit(trigger_sha)
+
+    commit_message = github_commit.commit.message
+
+    print(commit_message)
+
+    #+++++++++++++++++++++++++++++++
+    #Search for github PR merge text
+    #+++++++++++++++++++++++++++++++
+
+    #Compile Pull Request merge text expression:
+    pr_merge_pattern = re.compile(r'Merge pull request ')
+
+    #Search for merge text, starting at beginning of message:
+    commit_msg_match = pr_merge_pattern.match(commit_message)
+
+    #Check if match exists:
+    if commit_msg_match is not None:
+        #If it does then pull out text immediately after message:
+        post_msg_text = commit_message[commit_msg_match.end():]
+
+        #Split text into individual words:
+        post_msg_word_list = post_msg_text.split()
+
+        #Extract first word:
+        first_word = post_msg_word_list[0]
+
+        print(first_word)
+
+        try:
+            #Try assuming the word is just a number:
+            pr_num = int(first_word[1:]) #ignore "#" symbol
+        except ValueError:
+            #If the conversion fails, then this is likely not a real PR merge, so end the script:
+            endmsg = "No Pull Request number was found in the commit message, so there is nothing for the script to do."
+            end_script(endmsg)
+
+    else:
+        endmsg = "This push commit does not appear to be a merged pull request, so the script will do nothing."
+        end_script(endmsg)
+
+    #+++++++++++++++++++++++++++++++++++++
+    #Check that PR has in fact been merged
+    #+++++++++++++++++++++++++++++++++++++
+
+    #Extract pull request info:
+    merged_pull = cam_repo.get_pull(pr_num)
+
+    #If pull request has not been merged, then exit script:
+    if not merged_pull.merged:
+        endmsg = "Pull request in commit message was not actually merged, so the script will not close anything."
+        end_script(endmsg)
+
+    #++++++++++++++++++++++++++++++++++++++++
+    #Check that PR was not for default branch
+    #++++++++++++++++++++++++++++++++++++++++
+
+    #Determine default branch on repo:
+    default_branch = cam_repo.default_branch
+
+    #Extract merged branch from latest Pull request:
+    merged_branch = merged_pull.base.ref
+
+    #If PR was to default branch, then exit script (as github will handle it automatically):
+    if merged_branch == default_branch:
+        endmsg = "Pull request ws merged into default repo branch. Thus issue is closed automatically"
+        end_script(endmsg)
+
+    #++++++++++++++++++++++++++++++++++++++
+    #Create integer list of all open issues:
+    #++++++++++++++++++++++++++++++++++++++
+
+    #create new list:
+    open_issues = list()
+
+    #Extract list of open issues from repo:
+    open_repo_issues = cam_repo.get_issues(state='open')
+
+    #Loop over all open repo issues:
+    for issue in open_repo_issues:
+        #Add issue number to "open_issues" list:
+        open_issues.append(issue.number)
+
+    #+++++++++++++++++++++++++++++++++++++++++++++
+    #Create integer list of all open pull requests
+    #+++++++++++++++++++++++++++++++++++++++++++++
+
+    #create new list:
+    open_pulls = list()
+
+    #Extract list of open PRs from repo:
+    open_repo_pulls = cam_repo.get_pulls(state='open')
+
+    #Loop over all open repo issues:
+    for pull in open_repo_pulls:
+        #Add pr number to "open_pulls" list:
+        open_pulls.append(pull.number)
+
+    #+++++++++++++++++++++++++++++++++++++++++++++++++
+    #Check if one of the keywords exists in PR message
+    #+++++++++++++++++++++++++++++++++++++++++++++++++
+
+    #Keywords are:
+    #close, closes, closed
+    #fix, fixes, fixed
+    #resolve, resolves, resolved
+
+    #Create regex pattern to find keywords:
+    keyword_pattern = re.compile(r'(^|\s)close(\s|s\s|d\s)|(^|\s)fix(\s|es\s|ed\s)|(^|\s)resolve(\s|s\s|d\s)')
+
+    #Extract Pull Request message:
+    pr_message = merged_pull.body
+
+    #Make entire message lower-case:
+    pr_msg_lower = pr_message.lower()
+
+    #search for at least one keyword:
+    if keyword_pattern.search(pr_msg_lower) is not None:
+        #If at least one keyword is found, then determine location of every keyword instance:
+        word_matches = keyword_pattern.finditer(pr_msg_lower)
+    else:
+        endmsg = "Pull request was merged without using any of the keywords.  Thus there are no issues to close."
+        end_script(endmsg)
+
+   #++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+   #Extract issue and PR numbers associated with found keywords in merged PR message
+   #++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+    #create issue pattern ("the number symbol {#} + a number"),
+    #which ends with either a space or a comma:
+    issue_pattern = re.compile(r'#[0-9]+(\s|,|$)|.')
+
+    #Create new "close" issues list:
+    close_issues = list()
+
+    #Create new "closed" PR list:
+    close_pulls = list()
+
+    #Search text right after keywords for possible issue numbers:
+    for match in word_matches:
+
+        #create temporary string starting at end of match:
+        tmp_msg_str = pr_msg_lower[match.end():]
+
+        #Check if first word matches issue pattern:
+        if issue_pattern.match(tmp_msg_str) is not None:
+
+            #If so, then split string into words:
+            tmp_word_list = tmp_msg_str.split()
+
+            #Extract first word:
+            first_word = tmp_word_list[0]
+
+            #Extract issue number from first word:
+            try:
+                #First try assuming the string is just a number
+                issue_num = int(first_word[1:]) #ignore "#" symbol
+            except ValueError:
+                #If not, then ignore last letter:
+                try:
+                    issue_num = int(first_word[1:len(first_word)-1])
+                except ValueError:
+                    #If ignoring the first and last letter doesn't work,
+                    #then the match was likely a false positive,
+                    #so set the issue number to one that will never be found:
+                    issue_num = -9999
+
+            #Check that number is actually for an issue (as opposed to a PR):
+            if issue_num in open_issues:
+                #Add issue number to "close issues" list:
+                close_issues.append(issue_num)
+            elif issue_num in open_pulls:
+                #If in fact a PR, then add to PR list:
+                close_pulls.append(issue_num)
+
+    #If no issue numbers are present after any of the keywords, then exit script:
+    if not close_issues and not close_pulls:
+        endmsg = "No issue or PR numbers were found in the merged PR message.  Thus there is nothing to close."
+        end_script(endmsg)
+
+    #+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+    #Determine name of project associated with merged Pull Request
+    #+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+    #Pull-out all projects from repo:
+    projects = cam_repo.get_projects()
+
+    #Initalize modified project name:
+    proj_mod_name = None
+
+    #Loop over all repo projects:
+    for project in projects:
+        #Pull-out columns from each project:
+        proj_columns = project.get_columns()
+
+        #Loop over columns:
+        for column in proj_columns:
+
+            #check if column name is "Completed Tags"
+            if column.name == "Completed tags":
+                #If so, then extract cards:
+                cards = column.get_cards()
+
+                #Loop over cards:
+                for card in cards:
+                    #Extract card content:
+                    card_content = card.get_content()
+
+                    #Next, check if card number matches merged PR number:
+                    if card_content.number == pr_num:
+                        #If so, and if Project name is None, then set string:
+                        if proj_mod_name is None:
+                            proj_mod_name = project.name
+                            #Break out of card loop:
+                            break
+
+                        #If already set, then somehow merged PR is in two different projects,
+                        #which is not what this script is expecting, so just exit:
+                        endmsg = "Merged Pull Request found in two different projects, so script will do nothing."
+                        end_script(endmsg)
+
+    #++++++++++++++++++++++++++++++++++++++++
+    #Extract repo project "To do" card issues
+    #++++++++++++++++++++++++++++++++++++++++
+
+    #Intialize project issue number list:
+    proj_issues = list()
+
+    #Initalize project issue count list:
+    proj_issue_count = list()
+
+    #Initalize issue id to project card id dictionary:
+    proj_issue_card_ids = dict()
+
+    #Loop over all repo projects:
+    for project in projects:
+
+        #Next, pull-out columns from each project:
+        proj_columns = project.get_columns()
+
+        #Loop over columns:
+        for column in proj_columns:
+            #Check if column name is "To do"
+            if column.name == "To do":
+                #If so, then extract cards:
+                cards = column.get_cards()
+
+                #Loop over cards:
+                for card in cards:
+                    #Extract card content:
+                    card_content = card.get_content()
+
+                    #Next, check if card issue number matches any of the "close" issue numbers from the PR:
+                    if card_content.number in close_issues:
+
+                        #If so, then check if issue number is already in proj_issues:
+                        if card_content.number in proj_issues:
+                            #If it is already present, then extract index of issue:
+                            iss_idx = proj_issues.index(card_content.number)
+
+                            #Add one to project issue counter:
+                            proj_issue_count[iss_idx] += 1
+
+                        else:
+                            #If not, then append to project issues and counter list:
+                            proj_issues.append(card_content.number)
+                            proj_issue_count.append(1)
+
+                            #Also add issue id and card id to id dictionary used for card move, if in relevant project:
+                            if project.name == proj_mod_name:
+                                proj_issue_card_ids.update({card_content.number:card.id})
+
+            #Otherwise, check if column name matches "closed issues" column:
+            elif column.name == "closed issues" and project.name == proj_mod_name:
+                #If so, then save column id:
+                column_id = column.id
+
+    #If no project cards are found that match the issue, then exit script:
+    if not proj_issues:
+        endmsg = "No project cards match the issue being closed, so the script will do nothing."
+        end_script(endmsg)
+
+    #+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+    #Check if the number of "To-do" project cards matches the total number
+    #of merged PRs for each 'close' issue.
+    #
+    #Then, close all issues for which project cards equals merged PRs
+    #
+    #If not, then simply move the project card to the relevant project's
+    #"closed issues" column.
+    #+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+    #Loop over project issues that have been "closed" by merged PR:
+    for issue_num in proj_issues:
+
+        #Determine list index:
+        iss_idx = proj_issues.index(issue_num)
+
+        #determine project issue count:
+        issue_count = proj_issue_count[iss_idx]
+
+        #if issue count is just one, then close issue:
+        if issue_count == 1:
+            #Extract github issue object:
+            cam_issue = cam_repo.get_issue(number=issue_num)
+            #Close issue:
+            cam_issue.edit(state='closed')
+            print("Issue #{} has been closed.".format(issue_num))
+        else:
+            #Extract card id from id dictionary:
+            card_id = proj_issue_card_ids[issue_num]
+
+            #Then move the card on the relevant project page to the "closed issues" column:
+            project_card_move(token.strip(), column_id, card_id)
+
+    #++++++++++++++++++++++++++++++++++++++++++++++++++++++
+    #Finally, close all Pull Requests in "close_pulls" list:
+    #++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+    for pull_num in close_pulls:
+        #Extract Pull request object:
+        cam_pull = cam_repo.get_pull(number=pull_num)
+
+        #Close Pull Request:
+        cam_pull.edit(state='closed')
+        print("Pull Request #{} has been closed.".format(pull_num))
+
+    #++++++++++
+    #End script
+    #++++++++++
+
+    print("Issue closing check has completed successfully.")
+
+#############################################
+
+#Run the main script program:
+if __name__ == "__main__":
+    _main_prog()

--- a/.github/workflows/branch_push_workflow.yml
+++ b/.github/workflows/branch_push_workflow.yml
@@ -2,13 +2,15 @@ name: Pushed commit workflow
 
 on:
   #For some reason GitHub does not allow secrets
-  #when a PR from a fork is closed.  Thus instead
+  #when a PR from a fork is closeed.  Thus instead
   #the workflow must activate whenever a commit
   #is pushed to the repo.  Theoretically this should
   #behave the same way as if triggered from a pull
   #request, just as long as no user ever pushes
   #directly to the repo.
   push:
+    branches:
+      - cam_development
 
 jobs:
   #This job is designed to close any issues or pull requests specified

--- a/.github/workflows/branch_push_workflow.yml
+++ b/.github/workflows/branch_push_workflow.yml
@@ -1,0 +1,38 @@
+name: Pushed commit workflow
+
+on:
+  #For some reason GitHub does not allow secrets
+  #when a PR from a fork is closeed.  Thus instead
+  #the workflow must activate whenever a commit
+  #is pushed to the repo.  Theoretically this should
+  #behave the same way as if triggered from a pull
+  #request, just as long as no user ever pushes
+  #directly to the repo.
+  push:
+    branches:
+      - fake_development
+
+jobs:
+  #This job is designed to close any issues or pull requests specified
+  #in the body of a pull request merged into a non-default branch.
+  issue_closer:
+    runs-on: ubuntu-latest
+    steps:
+    # acquire github action routines
+    - uses: actions/checkout@v2
+    # acquire specific version of python
+    - name: Set up Python 3.6
+      uses: actions/setup-python@v1
+      with:
+        python-version: '3.6' # Semantic version range syntax or exact version of a Python version
+    # install required python packages
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip  # Install latest version of PIP
+        pip install PyGithub                 # Install PyGithub pythong package
+    # run CAM issue-closing script
+    - name: python action scripts
+      env:
+        ACCESS_TOKEN: ${{ secrets.WRITE_ACCESS_TOKEN }}
+        TRIGGER_SHA: ${{ github.sha }}
+      run: .github/scripts/branch_pr_issue_closer.py --access_token $ACCESS_TOKEN --trigger_sha $TRIGGER_SHA

--- a/.github/workflows/branch_push_workflow.yml
+++ b/.github/workflows/branch_push_workflow.yml
@@ -10,7 +10,7 @@ on:
   #directly to the repo.
   push:
     branches:
-      - fake_development
+      - cam_development
 
 jobs:
   #This job is designed to close any issues or pull requests specified

--- a/.github/workflows/branch_push_workflow.yml
+++ b/.github/workflows/branch_push_workflow.yml
@@ -29,7 +29,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip  # Install latest version of PIP
-        pip install PyGithub                 # Install PyGithub pythong package
+        pip install PyGithub                 # Install PyGithub python package
     # run CAM issue-closing script
     - name: python action scripts
       env:

--- a/.github/workflows/branch_push_workflow.yml
+++ b/.github/workflows/branch_push_workflow.yml
@@ -2,15 +2,13 @@ name: Pushed commit workflow
 
 on:
   #For some reason GitHub does not allow secrets
-  #when a PR from a fork is closeed.  Thus instead
+  #when a PR from a fork is closed.  Thus instead
   #the workflow must activate whenever a commit
   #is pushed to the repo.  Theoretically this should
   #behave the same way as if triggered from a pull
   #request, just as long as no user ever pushes
   #directly to the repo.
   push:
-    branches:
-      - cam_development
 
 jobs:
   #This job is designed to close any issues or pull requests specified

--- a/.github/workflows/branch_push_workflow.yml
+++ b/.github/workflows/branch_push_workflow.yml
@@ -2,7 +2,7 @@ name: Pushed commit workflow
 
 on:
   #For some reason GitHub does not allow secrets
-  #when a PR from a fork is closeed.  Thus instead
+  #when a PR from a fork is closed.  Thus instead
   #the workflow must activate whenever a commit
   #is pushed to the repo.  Theoretically this should
   #behave the same way as if triggered from a pull

--- a/test/system/TGIT.sh
+++ b/test/system/TGIT.sh
@@ -8,8 +8,9 @@
 # 1: Not a git repository.
 # 2: Missing ".git" directory.
 # 3: Missing ".gitignore" file.
-# 4: More than two ".git*" files.
-# 5: Error from running an external command
+# 4: Missing ".github" file.
+# 5: More than three ".git*" files.
+# 6: Error from running an external command
 
 # Utility to check return code.
 # Give it the code and an error message, and it will print stuff and exit.
@@ -17,7 +18,7 @@ check_code () {
     if [ "$1" -ne 0 ]; then
         echo "Error: return code from command was $1"
         echo "$2"
-        exit 5
+        exit 6
     fi
 }
 
@@ -58,7 +59,7 @@ EOF
         rc=2
     fi
 
-    # Check for missing ".gitignore" file.
+    # Check for ".gitignore" file:
     if [ ! -f "${cam_top_dir}/.gitignore" ]; then
         cat <<EOF
 The ".gitignore" file is missing from the CAM git repo.  Was this repo cloned, copied, or
@@ -67,16 +68,26 @@ EOF
         rc=3
     fi   
 
-    # Check if there are more ".git*" files or directories than just ".git" or ".gitignore".
+    # Check for ".github" directory:
+    if [ ! -d "${cam_top_dir}/.github" ]; then
+        cat <<EOF
+The ".github" directory is missing from the CAM git repo.  Was this repo cloned, copied, or
+modified incorrectly?  If so then copy the .github directory from a standard CAM git repo.
+EOF
+        rc=4
+    fi
+
+    # Check if there are more ".git*" files or directories than just ".git", ".gitignore",
+    # and ".github":
     git_file_num=$(find "${cam_top_dir}" -maxdepth 1 -name '.git*' | wc -l)
 
     check_code "$?" "Problem running 'find' command for multi-git file check."
 
-    if [ "${git_file_num}" -gt 2 ]; then
+    if [ "${git_file_num}" -gt 3 ]; then
         cat <<EOF
-More than two ".git*" files or sub-directories present in this CAM git repo.
+More than three ".git*" files or sub-directories present in this CAM git repo.
 EOF
-        rc=4
+        rc=5
     fi
 
 fi # git-repo check

--- a/test/system/TGIT.sh
+++ b/test/system/TGIT.sh
@@ -5,11 +5,11 @@
 # and no other git files or directories.
 
 # Return codes in use:
-# 1: Not a git repository.
-# 2: Missing ".git" directory.
-# 3: Missing ".gitignore" file.
-# 4: Missing ".github" file.
-# 5: More than three ".git*" files.
+# 1: Not a git repository
+# 2: Missing ".git" directory
+# 3: Missing ".gitignore" file
+# 4: Missing ".github" directory
+# 5: More than three ".git*" files or directories
 # 6: Error from running an external command
 
 # Utility to check return code.


### PR DESCRIPTION
Closes #82 

This script will allow for issues and pull requests to be closed when specified using the github keywords in the text of a merged pull request to the non-default cam_development branch (and any future branches which are created from cam_development).  If an issue is associated with more than one project, then this script will instead move the relevant project card to the "closed issues" column, and will only officially close the issue once the card has been moved for all relevant projects. 

This script requires that any new project must have the exact same column names and organization (including automation settings) as the "CAM Development branch" project.  This is because current limitations in the Github API require that column names must be hard-coded, although in the future this restriction may be removed.

Finally, in order for this script to run properly, a github secret must be added to the repo that contains a github OA token allowing full write privileges.  Otherwise the script will run into permission issues when it tries to actually close the issue and move project cards.  Sadly I believe only someone with full Admin privileges can add a github secret, which it doesn't look like I have (so I imagine @gold2718 will need to do it?).

Tests run:

The script and workflow file have been tested multiple times on this testing repo:

https://github.com/NCAR/repoForTestingCAM

To ensure that it works as expected.  The python script itself has also been tested manually on merged pull requests and issues present in the ESCOMP/CAM repo.  Finally, the script passes pylint, using the CAMDEN pylintrc file, with a perfect score.

This branch also passes all CAM regression tests (so these scripts do not influence CAM itself).