### PR TITLE
Miscellaneous fixes

### DIFF
--- a/Externals.cfg
+++ b/Externals.cfg
@@ -46,13 +46,6 @@ repo_url = https://github.com/ESCOMP/rtm
 local_path = components/rtm
 required = True
 
-[ww3]
-tag = ww3_190402
-protocol = git
-repo_url =  https://github.com/ESCOMP/WW3-CESM.git
-required = True
-local_path = components/ww3
-
 [cam]
 local_path = .
 protocol = externals_only

--- a/src/physics/rrtmg/radiation.F90
+++ b/src/physics/rrtmg/radiation.F90
@@ -787,7 +787,7 @@ subroutine radiation_tend( &
    integer  :: troplev(pcols)
    real(r8) :: p_trop(pcols)
 
-   type(rrtmg_state_t), pointer :: r_state ! contains the atm concentrations in layers needed for RRTMG
+   type(rrtmg_state_t) :: r_state ! contains the atm concentrations in layers needed for RRTMG
 
    ! cloud radiative parameters are "in cloud" not "in cell"
    real(r8) :: ice_tau    (nswbands,pcols,pver) ! ice extinction optical depth
@@ -950,7 +950,7 @@ subroutine radiation_tend( &
    if (dosw .or. dolw) then
 
       ! construct an RRTMG state object
-      r_state => rrtmg_state_create( state, cam_in )
+      r_state = rrtmg_state_create( state, cam_in )
 
       call t_startf('cldoptics')
 

--- a/src/physics/rrtmg/rrtmg_state.F90
+++ b/src/physics/rrtmg/rrtmg_state.F90
@@ -83,13 +83,11 @@ contains
     type(physics_state), intent(in) :: pstate
     type(cam_in_t),      intent(in) :: cam_in
 
-    type(rrtmg_state_t), pointer  :: rstate
+    type(rrtmg_state_t) :: rstate
 
     real(r8) dy                   ! Temporary layer pressure thickness
     real(r8) :: tint(pcols,pverp)    ! Model interface temperature
     integer  :: ncol, i, kk, k
-
-    allocate( rstate )
 
     allocate( rstate%h2ovmr(pcols,num_rrtmg_levs) )
     allocate( rstate%o3vmr(pcols,num_rrtmg_levs) )
@@ -158,7 +156,7 @@ contains
     type(physics_state), intent(in), target :: pstate
     type(physics_buffer_desc),  pointer :: pbuf(:)
     integer,             intent(in) :: icall                     ! index through climate/diagnostic radiation calls
-    type(rrtmg_state_t), pointer    :: rstate
+    type(rrtmg_state_t)             :: rstate
 
     real(r8), pointer, dimension(:,:) :: sp_hum ! specific humidity
     real(r8), pointer, dimension(:,:) :: n2o    ! nitrous oxide mass mixing ratio
@@ -246,7 +244,7 @@ contains
 
     implicit none
 
-    type(rrtmg_state_t), pointer   :: rstate
+    type(rrtmg_state_t) :: rstate
 
     deallocate(rstate%h2ovmr)
     deallocate(rstate%o3vmr)
@@ -263,9 +261,6 @@ contains
     deallocate(rstate%pintmb)
     deallocate(rstate%tlay)
     deallocate(rstate%tlev)
-
-    deallocate( rstate )
-    nullify(rstate)
 
   endsubroutine rrtmg_state_destroy
 


### PR DESCRIPTION
 - **Fix deallocation bug in RRTMG**: Remove pointer property from  `r_state` so that it is no longer allocated or deallocated.
 - **Modify NUOPC cap to set orbital values**: Set orbital parameters directly in CAM NUOPC cap
 - **Remove unused WW3 external**

fixes #86 
fixes #88 
fixes #89 

All regression tests pass on Cheyenne and Izumi.

RRTMG fix already reviewd by @brian-eaton, @cacraigucar, and @nusbaume.
NUOPC modification reviewed by @gold2718 
