### PR TITLE
Fix baseline archiving for certain work flows.

### DIFF
--- a/test/system/archive_baseline.sh
+++ b/test/system/archive_baseline.sh
@@ -1,4 +1,4 @@
-#!/bin/sh -f
+#!/bin/sh 
 
 echo
 
@@ -115,30 +115,52 @@ case $hostname in
 esac
 
 if [ -d ${baselinedir} ]; then
-   echo "ERROR: Baseline $baselinedir already exists."
-   exit 1
+   echo " "
+   echo "WARNING: Baseline $baselinedir already exists."
 fi
+
+#
+# CESM baseline archiving.
+#
 
 if [ -n "$CESM_TESTDIR" ]; then
 
     echo " "
-    echo "Making baselinedir 1"
-    mkdir $baselinedir
-    root_baselinedir=`dirname $baselinedir`
-    echo "CESM Archiving to $root_baselinedir/$cam_tag"
-    ../../cime/scripts/Tools/bless_test_results -p -t '' -c '' -r $CESM_TESTDIR --baseline-root $root_baselinedir -b $cam_tag -f -s
+    if [ ! -d ${baselinedir} ]; then
+        mkdir $baselinedir
+    fi
+    # Test to see if CESM baselines already exists.
+    BASELINE_EXISTS=`ls  ${baselinedir}/*/cpl.log.gz 2>/dev/null | wc -l `
+    if [ $BASELINE_EXISTS != 0 ]; then
+        echo "WARNING: CESM baselines already exists.  Continuing to CAM stand alone archiving."
+    else
+        root_baselinedir=`dirname $baselinedir`
+        echo "CESM archiving to $root_baselinedir/$cam_tag"
+        ../../cime/scripts/Tools/bless_test_results -p -t '' -c '' -r $CESM_TESTDIR --baseline-root $root_baselinedir -b $cam_tag -f -s
+    fi
 
-    echo " "
 fi
 
-echo
-echo "Archiving to ${baselinedir}"
-echo
+#
+#  CAM baseline archiving
+#
 
 if [ ! -d $baselinedir ]; then
-     echo "Making baselinedir 2"
      mkdir $baselinedir
+else
+    # Test to see if CAM baselines already exists.
+    BASELINE_EXISTS=`ls  ${baselinedir}/*/test.log 2>/dev/null | grep TSM | wc -l`
+    if [ $BASELINE_EXISTS != 0 ]; then
+        echo "WARNING: CAM baselines already exists,  Exiting"
+        echo
+        exit
+    fi
 fi
+
+echo
+echo "CAM archiving to ${baselinedir}"
+echo
+
 
 if [ ! -d ${baselinedir} ]; then
    echo "ERROR: Failed to make ${baselinedir}"

--- a/test/system/test_driver.sh
+++ b/test/system/test_driver.sh
@@ -91,7 +91,11 @@ while [ "${1:0:1}" == "-" ]; do
             if [ $# -lt 2 ]; then
                 perr "${1} requires a directory name)"
             fi
-            archive_dir="${2}"
+            if [ -z "$BL_TESTDIR" ]; then
+                echo "\$BL_TESTDIR needs to be set when using --archive-cime."
+                exit 1
+            fi
+            archive_dir="${BL_TESTDIR%/*}/${2}"
             shift
             ;;
 


### PR DESCRIPTION
Closes #93 

test_driver.sh and archive_baseline.sh scripts are updated to handle different cam testing workflows.

test_driver.sh:
The --archive-cime argument now requires that BL_TESTDIR to be set.  BL_TESTDIR is used to build
the new baseline directory ($BL_TESTDIR(minus tag name)/$archive-cime_argument).  This
does have an issue that the compare and generated baselines need to be in the same baseline root
directory.

archive_baseline.sh:
Checks to see if the CESM/cime or cam stand alone baseline have already been archived.  If the CESM/cime baselines already exists, it gives a warning message and continues on to the cam stand 
alone baselines.  Then checks for stand alone baselines, and exists if those baselines have been archived.

The biggest change is there's no ERROR messages if the baselines have already been archived,
just WARNING.  The script will continue trying to archive the next group of baselines.



