### PR TITLE
Bug fixes in COSP MODIS simulator.

### DIFF
--- a/src/physics/cosp2/optics/cosp_optics.F90
+++ b/src/physics/cosp2/optics/cosp_optics.F90
@@ -34,7 +34,7 @@ module cosp_optics
   USE COSP_KINDS, ONLY: wp,dp
   USE COSP_MATH_CONSTANTS,  ONLY: pi
   USE COSP_PHYS_CONSTANTS,  ONLY: rholiq,km,rd,grav
-  USE MOD_MODIS_SIM,        ONLY: phaseIsLiquid,phaseIsIce,get_g_nir=>get_g_nir_old,get_ssa_nir=>get_ssa_nir_old
+  USE MOD_MODIS_SIM,        ONLY: phaseIsLiquid,phaseIsIce,get_g_nir,get_ssa_nir
   implicit none
   
   real(wp),parameter ::        & !
@@ -202,14 +202,14 @@ contains
           ! Combine ice, snow and water optical properties
           tau(1:nLevels) = tauICE(j,i,1:nLevels) + tauLIQ(j,i,1:nLevels) + tauSNOW(j,i,1:nLevels)
           where (tau(1:nLevels) > 0) 
-             g(j,i,1:nLevels)  = (tauLIQ(j,i,1:nLevels)*water_g(1:nLevels)  + &
-                                  tauICE(j,i,1:nLevels)*ice_g(1:nLevels)    + &
-                                  tauSNOW(j,i,1:nLevels)*snow_g(1:nLevels)) / & 
+             w0(j,i,1:nLevels) = (tauLIQ(j,i,1:nLevels)*water_w0(1:nLevels)  + &
+                                  tauICE(j,i,1:nLevels)*ice_w0(1:nLevels)    + &
+                                  tauSNOW(j,i,1:nLevels)*snow_w0(1:nLevels)) / & 
                                   tau(1:nLevels) 
-             w0(j,i,1:nLevels) = (tauLIQ(j,i,1:nLevels)*water_g(1:nLevels)*water_w0(1:nLevels) + &
+             g(j,i,1:nLevels)  = (tauLIQ(j,i,1:nLevels)*water_g(1:nLevels)*water_w0(1:nLevels) + &
                                   tauICE(j,i,1:nLevels)*ice_g(1:nLevels)*ice_w0(1:nLevels)    + &
                                   tauSNOW(j,i,1:nLevels)*snow_g(1:nLevels)*snow_w0(1:nLevels)) / &
-                                  (g(j,i,1:nLevels) * tau(1:nLevels))
+                                  (w0(j,i,1:nLevels) * tau(1:nLevels))
           end where
        enddo
     enddo


### PR DESCRIPTION
Recently an issue with the COSP2 MODIS diagnostics in CESM2 was uncovered by a collaborator at LLNL (and subsequently by someone at UMBC). 
The MODIS simulator cloud diagnostics were not in close agreement with the cloud fields produced by other COSP simulators, such as ISCCP. Attached are images provided by Yuying Zhang illustrating the change in the MODIS and ISCCP cloud-fractions from COSP1.4 to COSP2.
[COSP2_modis_CESM2.pdf](https://github.com/ESCOMP/CAM/files/4344675/COSP2_modis_CESM2.pdf)

Issue 1:
From COSP1.4 to COSP2 there was a change in the LUTs used by the particle-size retrieval within the MODIS simulator, but this change was not accounted for on the CAM side. This mismatch in LUTs resulted in the retrieval failing more often, hence the reduction in MODIS total cloud fraction.
Solution 1:
Use the new LUTs in the COSP/CAM interface (cosp2/optics/cosp_optics.F90). 


Additionally there was a bug-fix to the MODIS optics in COSP2 that hadn't yet been propagated into CAM.  The implementation of COSP2 in CAM occurred around the same time when this fix was implemented in COSP2 (and as a patch to COSP1.4) and I forgot to include it in CAM. 

Issue 2: The combining of the MODIS optical fields, single-scattering albedo and asymmetry parameter, were incorrect. 
Solution 2: Propagate changes in the computation of optical properties into CAM.

fixes #97 