### PR TITLE
Update to the new UCAR contributor code of conduct

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -79,6 +79,6 @@ This Code of Conduct was originally adapted from the [Contributor Covenant](http
 We then aligned it with the UCAR Participant Code of Conduct, which also borrows from the American Geophysical Union (AGU) Code of Conduct.
 The UCAR Participant Code of Conduct applies to both UCAR employees as well as participants in activities run by UCAR.
 The original version of this for all software projects that have strong management from UCAR or UCAR staff is available on the UCAR website at https://doi.org/10.5065/6w2c-a132.
-The date that it was adopted by this project was Mar/31st/2020
+The date that it was adopted by this project was 2020-04-08 and replaces the previous version.
 When responding to complaints, UCAR HR and ODEI will do so based on the latest published version.
 Therefore, any project-specific changes should follow the [Process for Changes](#process-for-changes) section above.

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,49 +1,84 @@
-# Contributor Covenant Code of Conduct
+# Contributor Code of Conduct
+_The Contributor Code of Conduct is for participants in our software projects and community._
 
 ## Our Pledge
-
-In the interest of fostering an open and welcoming environment, we as contributors and maintainers pledge to making participation in our project and our community a harassment-free experience for everyone, regardless of age, body size, disability, ethnicity, gender identity and expression, level of experience, nationality, politcal affiliation, veteran status, pregnancy, genetic information, personal appearance, choice of text editor or operating system, race, religion, or sexual identity and orientation, or any other characteristic protected under applicable US federal or state law.
+We, as contributors, creators, stewards, and maintainers (participants), of the Community Atmosphere Model (CAM) pledge to make participation in our software, system or hardware project and community a safe, productive, welcoming and inclusive experience for everyone.
+All participants are required to abide by this Code of Conduct.
+This includes respectful treatment of everyone regardless of age, body size, disability, ethnicity, gender identity or expression, level of experience, nationality, political affiliation, veteran status, pregnancy, genetic information, physical appearance, race, religion, or sexual orientation, as well as any other characteristic protected under applicable US federal or state law.
 
 ## Our Standards
+Examples of behaviors that contribute to a positive environment include:
 
-Examples of behavior that contributes to creating a positive environment include:
+* All participants are treated with respect and consideration, valuing a diversity of views and opinions
+* Be considerate, respectful, and collaborative
+* Communicate openly with respect for others, critiquing ideas rather than individuals and gracefully accepting criticism
+* Acknowledging the contributions of others
+* Avoid personal attacks directed toward other participants
+* Be mindful of your surroundings and of your fellow participants 
+* Alert UCAR staff and suppliers/vendors if you notice a dangerous situation or someone in distress
+* Respect the rules and policies of the project and venue
 
-* Using welcoming and inclusive language
-* Being respectful of differing viewpoints and experiences
-* Gracefully accepting constructive criticism
-* Focusing on what is best for the community
-* Showing empathy towards other community members
+Examples of unacceptable behavior include, but are not limited to:
 
-Examples of unacceptable behavior by participants include:
-
-* The use of sexualized language or imagery and unwelcome sexual attention or advances
-* Trolling, insulting/derogatory comments, and personal or political attacks
-* Public or private harassment
+* Harassment, intimidation, or discrimination in any form
+* Physical, verbal, or written abuse by anyone to anyone, including repeated use of pronouns other than those requested
+* Unwelcome sexual attention or advances
+* Personal attacks directed at other guests, members, participants, etc.
 * Publishing others' private information, such as a physical or electronic address, without explicit permission
+* Alarming, intimidating, threatening, or hostile comments or conduct
+* Inappropriate use of nudity and/or sexual images 
+* Threatening or stalking anyone, including a participant
 * Other conduct which could reasonably be considered inappropriate in a professional setting
-* Refusing to use the pronouns that someone requests
-* Intimidating, threatening, or hostile conduct; physical or verbal abuse; vandalism; arson; and sabotage
-* Alarming or threatening comments that might refer to, suggest, or promote a violent, intimidating, or threatening action
-
-## Our Responsibilities
-
-Project maintainers are responsible for clarifying the standards of acceptable behavior and are expected to take appropriate and fair corrective action in response to any instances of unacceptable behavior.
-
-Project maintainers have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, or to ban temporarily or permanently any contributor for other behaviors that they deem inappropriate, threatening, offensive, or harmful.
 
 ## Scope
+This Code of Conduct applies to all spaces managed by the Project whether they be physical, online or face-to-face.
+This includes project code, code repository, associated web pages, documentation, mailing lists, project websites and wiki pages, issue tracker, meetings, telecons, events, project social media accounts, and any other forums created by the project team which the community uses for communication.
+In addition, violations of this Code of Conduct outside these spaces may affect a person's ability to participate within them.
+Representation of a project may be further defined and clarified by project maintainers.
 
-This Code of Conduct applies both within project spaces and in public spaces when an individual is representing the project or its community. Examples of representing a project or community include using an official project e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event. Representation of a project may be further defined and clarified by project maintainers.
+## Community Responsibilities
+Everyone in the community is empowered to respond to people who are showing unacceptable behavior.
+They can talk to them privately or publicly.
+Anyone requested to stop unacceptable behavior is expected to comply immediately.
+If the behavior continues concerns may be brought to the project administrators or to any other party listed in the [Reporting](#reporting) section below.
 
-## Enforcement
+## Project Administrator Responsibilities
+Project administrators are responsible for clarifying the standards of acceptable behavior and are encouraged to model appropriate behavior and provide support when people in the community point out inappropriate behavior.
+Project administrator(s) are normally the ones that would be tasked to carry out the actions in the [Consequences](#consequences) section below.
 
-Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the project team at cam-core@ucar.edu. Alternatively, this behavior can be reported to individuals on the CAM team, who will then have the responsibility to talk about the behavior to the core team. Another alternative for NCAR employees (when all individuals involved are NCAR employees) is to use the reporting methods of NCAR for this behavior (these options include anonymous reporting methods). The project team will review and investigate all complaints, and will respond in a way that it deems appropriate to the circumstances. The project team is obligated to maintain confidentiality with regard to the reporter of an incident. Further details of specific enforcement policies may be posted separately. Retaliation against a person who initiates a complaint or an inquiry about such behaviors is equally prohibited.
+Project administrators are also expected to keep this Code of Conduct updated with the main one housed at UCAR, as listed below in the [Attribution](#attribution) section.
 
-Project maintainers who do not follow or enforce the Code of Conduct in good faith may face temporary or permanent repercussions as determined by other members of the project's leadership.
+## Reporting
+Instances of unacceptable behavior can be brought to the attention of the project administrator(s) who may take any action as outlined in the [Consequences](#consequences) section below.
+However, making a report to a project administrator is not considered an 'official report' to UCAR. 
+
+Instances of unacceptable behavior may also be reported directly to UCAR pursuant to [UCAR's Harassment Reporting and Complaint Procedure](https://www2.fin.ucar.edu/procedures/hr/harassment-reporting-and-complaint-procedure), or anonymously through [UCAR's EthicsPoint Hotline](https://www2.fin.ucar.edu/ethics/anonymous-reporting).
+
+Complaints received by UCAR will be handled pursuant to the procedures outlined in UCAR's Harassment Reporting and Complaint Procedure.
+Complaints to UCAR will be held as confidential as practicable under the circumstances, and retaliation against a person who initiates a complaint or an inquiry about inappropriate behavior will not be tolerated.
+
+Any Contributor can use these reporting methods even if they are not directly affiliated with UCAR.
+The Frequently Asked Questions (FAQ) page for reporting is [here](https://www2.fin.ucar.edu/procedures/hr/reporting-faqs).
+
+## Consequences
+Upon receipt of a complaint, the project administrator(s) may take any action deemed necessary and appropriate under the circumstances.
+Such action can include things such as: removing, editing, or rejecting comments, commits, code, wiki edits, email, issues, and other contributions that are not aligned to this Code of Conduct, or banning temporarily or permanently any contributor for other behaviors that are deemed inappropriate, threatening, offensive, or harmful.
+Project administrators also have the right to report violations to UCAR HR and/or UCAR's Office of Diversity, Equity and Inclusion (ODEI), as well as a participant's home institution and/or law enforcement.
+In the event an incident is reported to UCAR, UCAR will follow its Harassment Reporting and Complaint Procedure.
+
+## Process for Changes
+All UCAR managed projects are required to adopt this Contributor Code of Conduct.
+Adoption is assumed even if not expressly stated in the repository.
+Projects should fill in sections where prompted with project-specific information, including, project name and adoption date.
+
+Projects that adopt this Code of Conduct need to stay up to date with UCAR's Contributor Code of Conduct, linked with a DOI in the [Attribution](#attribution) section below.
+Projects can make limited substantive changes to the Code of Conduct, however, the changes must be limited in scope and may not contradict the UCAR Contributor Code of Conduct.
 
 ## Attribution
-
-This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4, available at [http://contributor-covenant.org/version/1/4][version]
-
-[homepage]: http://contributor-covenant.org
-[version]: http://contributor-covenant.org/version/1/4/
+This Code of Conduct was originally adapted from the [Contributor Covenant](http://contributor-covenant.org/version/1/4), version 1.4.
+We then aligned it with the UCAR Participant Code of Conduct, which also borrows from the American Geophysical Union (AGU) Code of Conduct.
+The UCAR Participant Code of Conduct applies to both UCAR employees as well as participants in activities run by UCAR.
+The original version of this for all software projects that have strong management from UCAR or UCAR staff is available on the UCAR website at https://doi.org/10.5065/6w2c-a132.
+The date that it was adopted by this project was Mar/31st/2020
+When responding to complaints, UCAR HR and ODEI will do so based on the latest published version.
+Therefore, any project-specific changes should follow the [Process for Changes](#process-for-changes) section above.


### PR DESCRIPTION
This updates the CAM code of conduct (COC) to the UCAR model version. 

https://doi.org/10.5065/6w2c-a132

I'm not sure if this should just go to this branch or other branches as well. I'm assuming you can bring this in and then push it to other branches that might need it.

The above COC needs to be used on projects with a strong UCAR/NCAR involvement/management. This is also important to have because of NSF funding requirements.

There are a few things added to the list of behaviors. But, it also maps out possible consequences for bad behavior. Even people not working for UCAR can involve UCAR resources to resolve issues.

It would be good for the CAM community to review the list and confirm everyone is onboard with it.