### PR TITLE
cam6_2_022: Update externals to at least match cesm2_2_beta04

### DIFF
--- a/Externals.cfg
+++ b/Externals.cfg
@@ -33,14 +33,14 @@ externals = Externals_CLM.cfg
 required = True
 
 [mosart]
-tag = mosart1_0_36
+tag = mosart1_0_35
 protocol = git
 repo_url = https://github.com/ESCOMP/mosart
 local_path = components/mosart 
 required = True
 
 [rtm]
-tag = rtm1_0_71
+tag = rtm1_0_70
 protocol = git
 repo_url = https://github.com/ESCOMP/rtm
 local_path = components/rtm

--- a/Externals.cfg
+++ b/Externals.cfg
@@ -9,7 +9,7 @@ local_path = components/cice
 required = True
 
 [cime]
-tag = cime5.8.16
+tag = cime5.8.20
 protocol = git
 repo_url = https://github.com/ESMCI/cime
 local_path = cime
@@ -33,14 +33,14 @@ externals = Externals_CLM.cfg
 required = True
 
 [mosart]
-tag = mosart1_0_35
+tag = mosart1_0_36
 protocol = git
 repo_url = https://github.com/ESCOMP/mosart
 local_path = components/mosart 
 required = True
 
 [rtm]
-tag = rtm1_0_70
+tag = rtm1_0_71
 protocol = git
 repo_url = https://github.com/ESCOMP/rtm
 local_path = components/rtm

--- a/Externals.cfg
+++ b/Externals.cfg
@@ -25,7 +25,7 @@ required = True
 
 [clm]
 #     Need to use a branch tag for ctsm to support experimental CAM-SE grids.
-tag = ctsm1.0.dev079.se_grids.n02
+tag = ctsm1.0.dev086.se_grids.n01
 protocol = git
 repo_url = https://github.com/fischer-ncar/ctsm
 local_path = components/clm
@@ -33,14 +33,14 @@ externals = Externals_CLM.cfg
 required = True
 
 [mosart]
-tag = mosart1_0_35
+tag = mosart1_0_36
 protocol = git
 repo_url = https://github.com/ESCOMP/mosart
 local_path = components/mosart 
 required = True
 
 [rtm]
-tag = rtm1_0_70
+tag = rtm1_0_71
 protocol = git
 repo_url = https://github.com/ESCOMP/rtm
 local_path = components/rtm

--- a/bld/configure
+++ b/bld/configure
@@ -2934,46 +2934,46 @@ sub write_filepath
             print $fh "$cam_root/cime/src/share/esmf_wrf_timemgr\n";
         }
 
-        # Sequential Driver
+       # Sequential Driver
         print $fh "$cam_root/cime/src/drivers/mct/main\n";
         print $fh "$cam_root/cime/src/drivers/mct/shr\n";
 
-	# Ocean package.
-	if ($ocn eq 'dom') {
-	    print $fh "$camsrcdir/src/utils/cam_dom\n";
-	}
-	elsif ($ocn eq 'docn' or $ocn eq 'som') {
-	    print $fh "$cam_root/cime/src/components/data_comps/docn\n";
-	    print $fh "$cam_root/cime/src/components/data_comps/docn/mct\n";
-	}
-	elsif ($ocn eq 'aquaplanet') {
-	    print $fh "$camsrcdir/src/utils/cam_aqua\n";
-	    print $fh "$camsrcdir/src/utils/cam_aqua/cpl\n";
-	}
-	elsif ($ocn eq 'socn') {
-	    print $fh "$cam_root/cime/src/components/stub_comps/socn/mct\n";
-	}
+        # Ocean package.
+        if ($ocn eq 'dom') {
+            print $fh "$camsrcdir/src/utils/cam_dom\n";
+        }
+        elsif ($ocn eq 'docn' or $ocn eq 'som') {
+            print $fh "$cam_root/cime/src/components/data_comps_mct/docn\n";
+            print $fh "$cam_root/cime/src/components/data_comps_mct/docn/src\n";
+        }
+        elsif ($ocn eq 'aquaplanet') {
+            print $fh "$camsrcdir/src/utils/cam_aqua\n";
+            print $fh "$camsrcdir/src/utils/cam_aqua/cpl\n";
+        }
+        elsif ($ocn eq 'socn') {
+            print $fh "$cam_root/cime/src/components/stub_comps_mct/socn/src\n";
+        }
 
         # Land package
-        print $fh "$cam_root/cime/src/components/stub_comps/slnd/mct\n";
+        print $fh "$cam_root/cime/src/components/stub_comps_mct/slnd/src\n";
 
         # Sea ice package
-        print $fh "$cam_root/cime/src/components/stub_comps/sice/mct\n";
+        print $fh "$cam_root/cime/src/components/stub_comps_mct/sice/src\n";
 
         # Land ice package
-        print $fh "$cam_root/cime/src/components/stub_comps/sglc/mct\n";
+        print $fh "$cam_root/cime/src/components/stub_comps_mct/sglc/src\n";
 
         # include stub ESP component
-        print $fh "$cam_root/cime/src/components/stub_comps/sesp/mct\n";
+        print $fh "$cam_root/cime/src/components/stub_comps_mct/sesp/src\n";
 
         # Runoff package
-        print $fh "$cam_root/cime/src/components/stub_comps/srof/mct\n";
+        print $fh "$cam_root/cime/src/components/stub_comps_mct/srof/src\n";
 
         # Wave package
-        print $fh "$cam_root/cime/src/components/stub_comps/swav/mct\n";
+        print $fh "$cam_root/cime/src/components/stub_comps_mct/swav/src\n";
 
         # IAC package
-        print $fh "$cam_root/cime/src/components/stub_comps/siac/mct\n";
+        print $fh "$cam_root/cime/src/components/stub_comps_mct/siac/src\n";
 
         # Share utilities
         print $fh "$cam_root/cime/src/share/util\n";


### PR DESCRIPTION
The external for cice was already further along, so did not move it backwards.

Using the latest cime tag (one beyond what was used in cesm2_2_beta04) as it was tested and helped the problem that some of the scientists have been experiencing 

Note-- configure needed to be slightly modified to support CAM standalone testing as the MCT locations changed for the slab models in the updated cime

Closes #116 