### PR TITLE
cam6_2_024: Remove open file statements in MAM exchange code

### DIFF
--- a/src/chemistry/modal_aero/modal_aero_rename.F90
+++ b/src/chemistry/modal_aero/modal_aero_rename.F90
@@ -252,7 +252,6 @@ contains
 
 ! !USES:
    use physconst, only: gravit, mwdry
-   use units, only: getunit
    use shr_spfn_mod, only: erfc => shr_spfn_erfc
 
    implicit none
@@ -321,9 +320,6 @@ contains
    integer :: lsfrma, lsfrmc, lstooa, lstooc
    integer :: mfrm, mtoo, n, n1, n2, ntot_msa_a
    integer :: idomode(ntot_amode)
-   integer, save :: lun = -1  ! logical unit for diagnostics (6, or other
-                              ! if a special diagnostics file is opened)
-
 
    real (r8) :: deldryvol_a(ncol,pver,ntot_amode)
    real (r8) :: deldryvol_c(ncol,pver,ntot_amode)
@@ -359,15 +355,6 @@ contains
 
 ! begin
 	lunout = iulog
-
-!   get logical unit (for output to dumpconv, deactivate the "lun = 6")
- 	lun = iulog
-	if (lun < 1) then
-	   lun = getunit()
- 	   open( unit=lun, file='dump.rename',   &
- 			status='unknown', form='formatted' )
-	end if
-
 
 !
 !   calculations done once on initial entry
@@ -535,34 +522,6 @@ mainloop1_ipair:  do ipair = 1, npair_renamexf
 	xferfrac_vol = min( xferfrac_vol, xferfrac_max ) 
 	xferfrac_num = tailfr_numnew - tailfr_numold
 	xferfrac_num = max( 0.0_r8, min( xferfrac_num, xferfrac_vol ) )
-
-!   diagnostic output start ----------------------------------------
-!!$ 	if (ldiag1 > 0) then
-!!$ 	icol_diag = -1
-!!$ 	if ((lonndx(i) == 37) .and. (latndx(i) == 23)) icol_diag = i
-!!$ 	if ((i == icol_diag) .and. (mod(k-1,5) == 0)) then
-!!$ !	write(lun,97010) fromwhere, nstep, lchnk, i, k, ipair
-!!$ 	write(lun,97010) fromwhere, nstep, latndx(i), lonndx(i), k, ipair
-!!$ 	write(lun,97020) 'drv old/oldbnd/new/del     ',   &
-!!$ 		dryvol_t_old, dryvol_t_oldbnd, dryvol_t_new, dryvol_t_del
-!!$ 	write(lun,97020) 'num old/oldbnd, dgnold/new ',   &
-!!$ 		num_t_old, num_t_oldbnd, dgn_t_old, dgn_t_new
-!!$ 	write(lun,97020) 'tailfr v_old/new, n_old/new',   &
-!!$ 		tailfr_volold, tailfr_volnew, tailfr_numold, tailfr_numnew
-!!$ 	dum = max(1.0e-10_r8,xferfrac_vol) / max(1.0e-10_r8,xferfrac_num)
-!!$ 	dgn_xfer = dgn_t_new * dum**onethird
-!!$ 	dum = max(1.0e-10_r8,(1.0_r8-xferfrac_vol)) /   &
-!!$               max(1.0e-10_r8,(1.0_r8-xferfrac_num))
-!!$ 	dgn_aftr = dgn_t_new * dum**onethird
-!!$ 	write(lun,97020) 'xferfrac_v/n; dgn_xfer/aftr',   &
-!!$ 		xferfrac_vol, xferfrac_num, dgn_xfer, dgn_aftr
-!!$ !97010	format( / 'RENAME ', a, '  nx,lc,i,k,ip', i8, 4i4 )
-!!$ 97010	format( / 'RENAME ', a, '  nx,lat,lon,k,ip', i8, 4i4 )
-!!$ 97020	format( a, 6(1pe15.7) )
-!!$ 	end if
-!!$ 	end if
-!   diagnostic output end   ------------------------------------------
-
 
 !
 !   compute tendencies for the renaming transfer
@@ -884,7 +843,6 @@ aa_iqfrm: do iqfrm = -1, nspec_amode(mfrm)
 ! !USES:
 
    use physconst, only: gravit, mwdry
-   use units, only: getunit
    use shr_spfn_mod, only: erfc => shr_spfn_erfc
 
    implicit none
@@ -958,8 +916,6 @@ aa_iqfrm: do iqfrm = -1, nspec_amode(mfrm)
    integer :: l, l1, la, lc, lunout
    integer :: lsfrma, lsfrmc, lstooa, lstooc
    integer :: mfrm, mtoo, n, n1, n2, ntot_msa_a
-   integer, save :: lun = -1  ! logical unit for diagnostics (6, or other
-                              ! if a special diagnostics file is opened)
 
    logical :: l_dqdt_rnpos
    logical :: flagaa_shrink, flagbb_shrink
@@ -992,15 +948,6 @@ aa_iqfrm: do iqfrm = -1, nspec_amode(mfrm)
 
 ! begin
 	lunout = iulog
-
-!   get logical unit (for output to dumpconv, deactivate the "lun = 6")
- 	lun = iulog
-	if (lun < 1) then
-	   lun = getunit()
- 	   open( unit=lun, file='dump.rename',   &
- 			status='unknown', form='formatted' )
-	end if
-
 
 !
 !   calculations done once on initial entry
@@ -1323,40 +1270,6 @@ grow_shrink_conditional1: &
 	end if
 
 	endif grow_shrink_conditional1
-
-
-!!   diagnostic output start ----------------------------------------
-!!	if (ldiag1 > 0) then
-! 	icol_diag = -1
-! 	if ((lonndx(i) == 37) .and. (latndx(i) == 23)) icol_diag = i
-!!	if ((i == icol_diag) .and. (mod(k-1,5) == 0)) then
-!! qak
-! 	if (ldiag1 <= 0) then
-! 	if ((i == 1) .and. (k == 1)) then
-!! qak
-! !	write(lun,97010) fromwhere, nstep, lchnk, i, k, ipair
-!! 	write(lun,97010) fromwhere, nstep, latndx(i), lonndx(i), k, ipair
-!! 	write(lun,97020) 'drv old/oldb/oldbnd/new/del    ',   &
-!! 		dryvol_t_old, dryvol_t_oldb, dryvol_t_oldbnd, &
-!! 		dryvol_t_new, dryvol_t_del
-!! 	write(lun,97020) 'num old/oldbnd, dgnold/oldb/new',   &
-!! 		num_t_old, num_t_oldbnd, dgn_t_old, dgn_t_oldb, dgn_t_new
-!! 	write(lun,97020) 'tailfr v_old/new, n_old/new    ',   &
-!! 		tailfr_volold, tailfr_volnew, tailfr_numold, tailfr_numnew
-! 	tmpa = max(1.0e-10_r8,xferfrac_vol) / max(1.0e-10_r8,xferfrac_num)
-! 	dgn_xfer = dgn_t_new * tmpa**onethird
-! 	tmpa = max(1.0e-10_r8,(1.0_r8-xferfrac_vol)) /   &
-!               max(1.0e-10_r8,(1.0_r8-xferfrac_num))
-!! 	dgn_aftr = dgn_t_new * tmpa**onethird
-!! 	write(lun,97020) 'xferfrac_v/n; dgn_xfer/aftr    ',   &
-!! 		xferfrac_vol, xferfrac_num, dgn_xfer, dgn_aftr
-! !97010	format( / 'RENAME ', a, '  nx,lc,i,k,ip', i8, 4i4 )
-! 97010	format( / 'RENAME ', a, '  nx,lat,lon,k,ip', i8, 4i4 )
-! 97020	format( a, 6(1pe15.7) )
-! 	end if
-! 	end if
-!   diagnostic output end   ------------------------------------------
-
 
 !
 !   compute tendencies for the renaming transfer


### PR DESCRIPTION
Remove open file statements which are not needed 
Remove commented out debugging code

Closes issue #131

I have confirmed that the modal_aero_rename_no_acc_crs_sub routine has been exercised in our regression tests.  I don't know why this has not been a problem before.