### PR TITLE
cam6_2_025?: Mods to resolve issue #130 SCAM6 namelist definitions inconsistent

### DIFF
--- a/bld/namelist_files/namelist_definition.xml
+++ b/bld/namelist_files/namelist_definition.xml
@@ -4862,6 +4862,12 @@ Column bfb match with cam generated IOP.
 Default: FALSE
 </entry>
 
+<entry id="scm_backfill_iop_w_init" type="logical" category="scam"
+       group="scam_nl" valid_values="">
+Backfill missing IOP values for omega/T/q/Ps from initial data file.
+Default: FALSE
+</entry>
+
 <entry id="scm_crm_mode" type="logical" category="scam"
        group="scam_nl" valid_values="">
 Column radiation mode.
@@ -4963,19 +4969,19 @@ Default: 'slt'
 </entry>
 
 <entry id="scm_iop_lhflxshflxTg" type="logical" category="scam"
-       group="scam_nl" valid_values="iop,eulc,slt,off">
+       group="scam_nl" valid_values="">
 Use the SCAM-IOP specified surface LHFLX/SHFLX/ustar/Tg instead of using internally-computed values
 Default: FALSE
 </entry>
 
 <entry id="scm_use_obs_qv" type="logical" category="scam"
-       group="scam_nl" valid_values="iop,eulc,slt,off">
+       group="scam_nl" valid_values="">
 Use the SCAM-IOP specified observed water vapor at each time step instead of forecast value
 Default: FALSE
 </entry>
 
 <entry id="scm_force_latlon" type="logical" category="scam"
-       group="scam_nl" valid_values="iop,eulc,slt,off">
+       group="scam_nl" valid_values="">
 Force scam to use the lat lon fields specified in the scam namelist not what is closest to IOP avail lat lon
 Default: FALSE
 </entry>

--- a/src/control/scamMod.F90
+++ b/src/control/scamMod.F90
@@ -164,11 +164,11 @@ logical, public ::  have_asdir             = .false. ! dataset contains asdir
 logical, public ::  have_asdif             = .false. ! dataset contains asdif
 logical, public ::  use_camiop             = .false. ! use cam generated forcing 
 logical, public ::  use_3dfrc              = .false. ! use 3d forcing
-logical, public ::  use_userdata           = .false. 
 logical, public ::  isrestart              = .false. ! If this is a restart step or not
   
 ! SCAM namelist defaults
 
+logical, public ::  scm_backfill_iop_w_init = .false. ! Backfill missing IOP data from initial file
 logical, public ::  scm_relaxation         = .false. ! Use relaxation
 logical, public ::  scm_crm_mode           = .false. ! Use column radiation mode
 logical, public ::  scm_cambfb_mode        = .false. ! Use extra CAM IOP fields to assure bit for bit match with CAM run
@@ -236,7 +236,7 @@ subroutine scam_readnl(nlfile,single_column_in,scmlat_in,scmlon_in)
        scm_cambfb_mode,scm_crm_mode,scm_zadv_uv,scm_zadv_T,scm_zadv_q,&
        scm_use_obs_T, scm_use_obs_uv, scm_use_obs_qv, &
        scm_relax_linear, scm_relax_tau_top_sec, &
-       scm_relax_tau_bot_sec, scm_force_latlon, scm_relax_fincl
+       scm_relax_tau_bot_sec, scm_force_latlon, scm_relax_fincl, scm_backfill_iop_w_init
 
   single_column=single_column_in
 

--- a/src/control/scamMod.F90
+++ b/src/control/scamMod.F90
@@ -228,6 +228,7 @@ subroutine scam_readnl(nlfile,single_column_in,scmlat_in,scmlon_in)
   integer  :: iatt
   integer  :: ret
   integer  :: latidx, lonidx
+  logical  :: adv
   real(r8) :: ioplat,ioplon
 
 ! this list should include any variable that you might want to include in the namelist
@@ -303,6 +304,45 @@ subroutine scam_readnl(nlfile,single_column_in,scmlat_in,scmlon_in)
         scmlon = ioplon
      end if
      
+     if (masterproc) then
+        write (iulog,*) 'Single Column Model Options: '
+        write (iulog,*) '============================='
+        write (iulog,*) '  iopfile                     = ',trim(iopfile)
+        write (iulog,*) '  scm_backfill_iop_w_init     = ',scm_backfill_iop_w_init
+        write (iulog,*) '  scm_cambfb_mode             = ',scm_cambfb_mode
+        write (iulog,*) '  scm_crm_mode                = ',scm_crm_mode
+        write (iulog,*) '  scm_force_latlon            = ',scm_force_latlon
+        write (iulog,*) '  scm_iop_Tg                  = ',scm_iop_Tg
+        write (iulog,*) '  scm_iop_lhflxshflxTg        = ',scm_iop_lhflxshflxTg
+        write (iulog,*) '  scm_relaxation              = ',scm_relaxation
+        write (iulog,*) '  scm_relax_bot_p             = ',scm_relax_bot_p
+        write (iulog,*) '  scm_relax_linear            = ',scm_relax_linear
+        write (iulog,*) '  scm_relax_tau_bot_sec       = ',scm_relax_tau_bot_sec
+        write (iulog,*) '  scm_relax_tau_sec           = ',scm_relax_tau_sec
+        write (iulog,*) '  scm_relax_tau_top_sec       = ',scm_relax_tau_top_sec
+        write (iulog,*) '  scm_relax_top_p             = ',scm_relax_top_p
+        write (iulog,*) '  scm_use_obs_T               = ',scm_use_obs_T
+        write (iulog,*) '  scm_use_obs_qv              = ',scm_use_obs_qv
+        write (iulog,*) '  scm_use_obs_uv              = ',scm_use_obs_uv
+        write (iulog,*) '  scm_zadv_T                  = ',trim(scm_zadv_T)
+        write (iulog,*) '  scm_zadv_q                  = ',trim(scm_zadv_q)
+        write (iulog,*) '  scm_zadv_uv                 = ',trim(scm_zadv_uv)
+        write (iulog,*) '  scm_relax_finc: '
+        ! output scm_relax_fincl character array
+        do i=1,pcnst
+           if (scm_relax_fincl(i) .ne. '') then
+              adv = mod(i,4)==0
+              if (adv) then
+                 write (iulog, "(A18)") "'"//trim(scm_relax_fincl(i))//"',"
+              else
+                 write (iulog, "(A18)", ADVANCE="NO") "'"//trim(scm_relax_fincl(i))//"',"
+              end if
+           else
+              exit
+           end if
+        end do
+        print *
+     end if
   end if
      
 end subroutine scam_readnl

--- a/src/control/scamMod.F90
+++ b/src/control/scamMod.F90
@@ -1,4 +1,23 @@
 module scamMod
+  !----------------------------------------------------------------------
+  !
+  ! This module provides control variables and namelist functionality
+  ! for SCAM.
+  !
+  ! As with global CAM, SCAM is initialized with state information
+  ! from the initial and boundary files. For each succeeding timestep
+  ! SCAM calculates the physics tendencies and combines these with
+  ! the advective tendencies provided by the IOP file to produce
+  ! a forcast. Generally, the control variables in this module
+  ! determine what data and parameterizations will be used to make
+  ! the forecast. For instance, many of the control variables in
+  ! this module provide flexibility to affect the forecast by overriding
+  ! parameterization prognosed tendencies with observed tendencies
+  ! of a particular field program recorded on the IOP file.
+  ! 
+  ! Public functions/subroutines:
+  !   scam_readnl
+  !-----------------------------------------------------------------------
 
 use shr_kind_mod,   only: r8 => shr_kind_r8
 use pmgrid,         only: plon, plat, plev, plevp
@@ -27,8 +46,6 @@ integer, parameter :: max_path_len = 128
 
 logical, public ::  single_column         ! Using IOP file or not
 logical, public ::  use_iop               ! Using IOP file or not
-logical, public ::  use_analysis
-logical, public ::  use_saveinit
 logical, public ::  use_pert_init         ! perturb initial values
 logical, public ::  use_pert_frc          ! perturb forcing 
 logical, public ::  switch(num_switches)  ! Logical flag settings from GUI
@@ -220,13 +237,9 @@ subroutine scam_readnl(nlfile,single_column_in,scmlat_in,scmlon_in)
 
   ! Local variables
   character(len=*), parameter :: sub = 'scam_readnl'
-  integer :: unitn, ierr
+  integer :: unitn, ierr, i
   integer  :: ncid
-  integer  :: latdimid, londimid
-  integer  :: latsiz, lonsiz
-  integer  :: latid, lonid
   integer  :: iatt
-  integer  :: ret
   integer  :: latidx, lonidx
   logical  :: adv
   real(r8) :: ioplat,ioplon

--- a/src/dynamics/eul/iop.F90
+++ b/src/dynamics/eul/iop.F90
@@ -19,7 +19,7 @@ module iop
   use phys_control,     only: phys_getopts
   use pmgrid,           only: beglat,endlat,plon,plev,plevp
   use prognostics,      only: n3,t3,q3,u3,v3,ps
-  use scamMod,          only: use_camiop, ioptimeidx, have_ps, use_userdata, have_tsair, &
+  use scamMod,          only: use_camiop, ioptimeidx, have_ps, scm_backfill_iop_w_init, have_tsair, &
                               tobs, have_t, tground, have_tg, qobs, have_q, have_cld,    &
                               have_clwp, divq, have_divq, vertdivq, have_vertdivq, divq3d, &
                               have_divq3d, dqfxcam, have_numliq, have_cldliq, have_cldice, &
@@ -27,8 +27,8 @@ module iop
                               have_vertdivt, divt3d, have_divt3d, have_divu3d,  have_divv3d, &
                               have_ptend, ptend, wfld, uobs, have_u, uobs, vobs, have_v, &
                               vobs, have_prec, have_q1, have_q2, have_lhflx, have_shflx, &
-                              use_3dfrc, betacam, fixmascam, alphacam, ioptimeidx,doiopupdate, &
-                              use_userdata, cldiceobs,  cldliqobs, cldobs, clwpobs, divu, &
+                              use_3dfrc, betacam, fixmascam, alphacam, doiopupdate, &
+                              cldiceobs,  cldliqobs, cldobs, clwpobs, divu, &
                               divu3d, divv, divv3d, iopfile, lhflxobs, numiceobs, numliqobs, &
                               precobs, q1obs, scmlat, scmlon, shflxobs, tsair, have_omega, wfldh,qinitobs
   use shr_kind_mod,     only: r8 => shr_kind_r8, max_chars=>shr_kind_cl
@@ -325,7 +325,7 @@ integer, optional, intent(in) :: timelevel
    if ( status .ne. nf90_noerr ) then
       have_ps = .false.
       if (masterproc) write(iulog,*) sub//':Could not find variable Ps'
-      if ( .not. use_userdata ) then
+      if ( .not. scm_backfill_iop_w_init ) then
          status = NF90_CLOSE( ncid )
          return
       else
@@ -398,7 +398,7 @@ integer, optional, intent(in) :: timelevel
    if ( status .ne. nf90_noerr ) then
       have_t = .false.
       if (masterproc) write(iulog,*) sub//':Could not find variable T'
-      if ( .not. use_userdata ) then
+      if ( .not. scm_backfill_iop_w_init ) then
          status = NF90_CLOSE( ncid )
          return
       else
@@ -447,7 +447,7 @@ integer, optional, intent(in) :: timelevel
    if ( status .ne. nf90_noerr ) then
       have_q = .false.
       if (masterproc) write(iulog,*) sub//':Could not find variable q'
-      if ( .not. use_userdata ) then
+      if ( .not. scm_backfill_iop_w_init ) then
          status = nf90_close( ncid )
          return
       else
@@ -794,7 +794,7 @@ integer, optional, intent(in) :: timelevel
    if ( status .ne. nf90_noerr ) then
       have_omega = .false.
       if (masterproc) write(iulog,*) sub//':Could not find variable omega'
-      if ( .not. use_userdata ) then
+      if ( .not. scm_backfill_iop_w_init ) then
          status = nf90_close( ncid )
          return
       else
@@ -1134,7 +1134,7 @@ subroutine setiopupdate
 !
    if ( ncdate > last_date .or. (ncdate == last_date &
       .and. ncsec > last_sec))  then
-      if ( .not. use_userdata ) then
+      if ( .not. scm_backfill_iop_w_init ) then
          call endrun(sub//':ERROR - setiopupdate.c:Reached the end of the time varient dataset')
       else
          doiopupdate = .false.              

--- a/src/physics/cam/physpkg.F90
+++ b/src/physics/cam/physpkg.F90
@@ -1112,6 +1112,7 @@ contains
     use physconst,       only: stebol, latvap
     use carma_intr,      only: carma_accumulate_stats
     use spmd_utils,      only: mpicom
+    use iop_forcing,     only: scam_use_iop_srf
 #if ( defined OFFLINE_DYN )
     use metdata,         only: get_met_srf2
 #endif
@@ -1140,6 +1141,10 @@ contains
     !
 
     if(single_column.and.scm_crm_mode) return
+    !-----------------------------------------------------------------------
+    ! if using IOP values for surface fluxes overwrite here after surface components run
+    !-----------------------------------------------------------------------
+    if (single_column) call scam_use_iop_srf(cam_in)
 
     !-----------------------------------------------------------------------
     ! Tendency physics after coupler


### PR DESCRIPTION
The PR takes closes issue #130 where there were erroneous default values in the namelist definition file.  I also included some minor cleanup to the scam iop variables as well as corrected a bug for the upcoming SAS IOP file. 