### PR TITLE
Hotfix for issue closing script

### DIFF
--- a/.github/scripts/branch_pr_issue_closer.py
+++ b/.github/scripts/branch_pr_issue_closer.py
@@ -395,7 +395,7 @@ def _main_prog():
                     card_content = card.get_content()
 
                     #Next, check if card issue number matches any of the "close" issue numbers from the PR:
-                    if card_content.number in close_issues:
+                    if card_content is not None and card_content.number in close_issues:
 
                         #If so, then check if issue number is already in proj_issues_count:
                         if card_content.number in proj_issues_count:

--- a/.github/scripts/branch_pr_issue_closer.py
+++ b/.github/scripts/branch_pr_issue_closer.py
@@ -350,8 +350,8 @@ def _main_prog():
                     #Extract card content:
                     card_content = card.get_content()
 
-                    #Next, check if card number matches merged PR number:
-                    if card_content.number == pr_num:
+                    #Next, check if card number exists and matches merged PR number:
+                    if card_content is not None and card_content.number == pr_num:
                         #If so, and if Project name is None, then set string:
                         if proj_mod_name is None:
                             proj_mod_name = project.name


### PR DESCRIPTION
I forgot that there are some project cards that are neither issues nor PRs, which caused the script to fail (I believe these were brought over when we first transitioned to github).

This quick fix allows the script to keep running even when it runs into those kind of cards.

closes #82 