### PR TITLE
Prevent Github action from running on forks

### DIFF
--- a/.github/scripts/branch_pr_issue_closer.py
+++ b/.github/scripts/branch_pr_issue_closer.py
@@ -309,7 +309,7 @@ def _main_prog():
 
     #If no issue numbers are present after any of the keywords, then exit script:
     if not close_issues and not close_pulls:
-        endmsg = "No issue or PR numbers were found in the merged PR message.  Thus there is nothing to close."
+        endmsg = "No open issue or PR numbers were found in the merged PR message.  Thus there is nothing to close."
         end_script(endmsg)
 
     #Print list of referenced issues to screen:

--- a/.github/workflows/branch_push_workflow.yml
+++ b/.github/workflows/branch_push_workflow.yml
@@ -22,16 +22,19 @@ jobs:
     - uses: actions/checkout@v2
     # acquire specific version of python
     - name: Set up Python 3.6
+      if: github.repository == 'ESCOMP/CAM' #Only run on main repo
       uses: actions/setup-python@v1
       with:
         python-version: '3.6' # Semantic version range syntax or exact version of a Python version
     # install required python packages
     - name: Install dependencies
+      if: github.repository == 'ESCOMP/CAM' #Only run on main repo
       run: |
         python -m pip install --upgrade pip  # Install latest version of PIP
         pip install PyGithub                 # Install PyGithub python package
     # run CAM issue-closing script
     - name: python action scripts
+      if: github.repository == 'ESCOMP/CAM' #Only run on main repo
       env:
         ACCESS_TOKEN: ${{ secrets.WRITE_ACCESS_TOKEN }}
         TRIGGER_SHA: ${{ github.sha }}


### PR DESCRIPTION
This PR was created to add conditionals to the Github action workflow for push events so that the issue-closing script only triggers when the push is to the main ESCOMP/CAM repo, and not to anyone's fork.

Fixes #136 