### PR TITLE
cam6_2_030: Fix for floating point issue in GW drag.

### DIFF
--- a/src/physics/cam/gw_common.F90
+++ b/src/physics/cam/gw_common.F90
@@ -619,6 +619,14 @@ subroutine gw_drag_prof(ncol, band, p, src_level, tend_level, dt, &
         ! new stress will be smaller than the old stress, causing stress
         ! divergence in the next layer down. This smoothes large stress
         ! divergences downward while conserving total stress.
+
+        ! Protection on SMALL gwut to prevent floating point
+        ! issues.
+        !--------------------------------------------------
+        where( abs(gwut(:,k,l)) < 1.e-15_r8 )
+           gwut(:,k,l) = 0._r8
+        endwhere   
+
         where (k <= tend_level)
            tau(:,l,k+1) = tau(:,l,k) + & 
                 abs(gwut(:,k,l)) * p%del(:,k) / gravit 


### PR DESCRIPTION
fixes #147

Note: This fix is a workaround, the underlying source of the cascading error caused by small values still should be tracked down and fixed.