### PR TITLE
cam6_2_035: add default historical emissions for ne30pg2 and ne30pg3 grids

### DIFF
--- a/bld/namelist_files/namelist_defaults_cam.xml
+++ b/bld/namelist_files/namelist_defaults_cam.xml
@@ -900,101 +900,296 @@
 <NO_bb_srf_file     hgrid="1.9x2.5" ver="cam6">atm/cam/chem/emis/CMIP6_emissions_1750_2015_2deg/emissions-cmip6_NO_bb_surface_1750-2015_1.9x2.5_c20170322.nc</NO_bb_srf_file>
 <NO_ot_srf_file     hgrid="1.9x2.5" ver="cam6">atm/cam/chem/emis/CMIP6_emissions_1750_2015_2deg/emissions-cmip6_NO_other_surface_1750-2015_1.9x2.5_c20170322.nc</NO_ot_srf_file>
 
-<!-- ne30 -->
+<!-- ne30 pg0 -->
 
-<dms_ot_srf_file     hgrid="ne30np4" ver="cam6">atm/cam/chem/emis/historical_ne30np4/emissions-cmip6_DMS_other_surface_1750_2015_ne30np4_c20200605.nc</dms_ot_srf_file>
-<dms_bb_srf_file     hgrid="ne30np4" ver="cam6">atm/cam/chem/emis/historical_ne30np4/emissions-cmip6_DMS_bb_surface_175001-201512_ne30np4_c20200606.nc</dms_bb_srf_file>
-<so2_ag_sh_file      hgrid="ne30np4" ver="cam6">atm/cam/chem/emis/historical_ne30np4/emissions-cmip6_SO2_anthro-ag-ship-res_surface_mol_175001-201412_ne30np4_c20200606.nc</so2_ag_sh_file>
-<so2_an_srf_file     hgrid="ne30np4" ver="cam6">atm/cam/chem/emis/historical_ne30np4/emissions-cmip6_SO2_anthro-ene_surface_mol_175001-201412_ne30np4_c20200606.nc</so2_an_srf_file>
-<so2_bb_srf_file     hgrid="ne30np4" ver="cam6">atm/cam/chem/emis/historical_ne30np4/emissions-cmip6_SO2_bb_surface_175001-201512_ne30np4_c20200606.nc</so2_bb_srf_file>
-<so4_a1_an_srf_file  hgrid="ne30np4" ver="cam6">atm/cam/chem/emis/historical_ne30np4/emissions-cmip6_so4_a1_anthro-ag-ship_surface_mol_175001-201412_ne30np4_c20200606.nc</so4_a1_an_srf_file>
-<so4_a1_bb_srf_file  hgrid="ne30np4" ver="cam6">atm/cam/chem/emis/historical_ne30np4/emissions-cmip6_so4_a1_bb_surface_175001-201512_ne30np4_c20200606.nc</so4_a1_bb_srf_file>
-<so4_a2_an_srf_file  hgrid="ne30np4" ver="cam6">atm/cam/chem/emis/historical_ne30np4/emissions-cmip6_so4_a2_anthro-res_surface_mol_175001-201412_ne30np4_c20200606.nc</so4_a2_an_srf_file>
-<num_a1_sh_srf_file  hgrid="ne30np4" ver="cam6">atm/cam/chem/emis/historical_ne30np4/emissions-cmip6_num_so4_a1_anthro-ag-ship_surface_mol_175001-201412_ne30np4_c20200606.nc</num_a1_sh_srf_file>
-<num_a2_an_srf_file  hgrid="ne30np4" ver="cam6">atm/cam/chem/emis/historical_ne30np4/emissions-cmip6_num_so4_a2_anthro-res_surface_mol_175001-201412_ne30np4_c20200606.nc</num_a2_an_srf_file>
-<bc_a4_an_srf_file   hgrid="ne30np4" ver="cam6">atm/cam/chem/emis/historical_ne30np4/emissions-cmip6_bc_a4_anthro_surface_175001-201412_ne30np4_c20200606.nc</bc_a4_an_srf_file>
-<num_a4_bc_srf_file  hgrid="ne30np4" ver="cam6">atm/cam/chem/emis/historical_ne30np4/emissions-cmip6_num_bc_a4_anthro_surface_175001-201412_ne30np4_c20200606.nc</num_a4_bc_srf_file>
-<pom_a4_an_srf_file  hgrid="ne30np4" ver="cam6">atm/cam/chem/emis/historical_ne30np4/emissions-cmip6_pom_a4_anthro_surface_175001-201412_ne30np4_c20200606.nc</pom_a4_an_srf_file>
-<num_a4_oc_srf_file  hgrid="ne30np4" ver="cam6">atm/cam/chem/emis/historical_ne30np4/emissions-cmip6_num_pom_a4_anthro_surface_175001-201412_ne30np4_c20200606.nc</num_a4_oc_srf_file>
-<num_a1_bb_srf_file  hgrid="ne30np4" ver="cam6">atm/cam/chem/emis/historical_ne30np4/emissions-cmip6_num_so4_a1_bb_surface_175001-201512_ne30np4_c20200606.nc</num_a1_bb_srf_file>
-<bc_a4_bb_srf_file   hgrid="ne30np4" ver="cam6">atm/cam/chem/emis/historical_ne30np4/emissions-cmip6_bc_a4_bb_surface_175001-201512_ne30np4_c20200606.nc</bc_a4_bb_srf_file>
-<num_a4_bb_srf_file  hgrid="ne30np4" ver="cam6">atm/cam/chem/emis/historical_ne30np4/emissions-cmip6_num_bc_a4_bb_surface_175001-201512_ne30np4_c20200606.nc</num_a4_bb_srf_file>
-<pom_a4_bb_srf_file  hgrid="ne30np4" ver="cam6">atm/cam/chem/emis/historical_ne30np4/emissions-cmip6_pom_a4_bb_surface_175001-201512_ne30np4_c20200606.nc</pom_a4_bb_srf_file>
-<num_pom_bb_srf_file hgrid="ne30np4" ver="cam6">atm/cam/chem/emis/historical_ne30np4/emissions-cmip6_num_pom_a4_bb_surface_175001-201512_ne30np4_c20200606.nc</num_pom_bb_srf_file>
-<soag_an_srf_file    hgrid="ne30np4" ver="cam6">atm/cam/chem/emis/historical_ne30np4/emissions-cmip6_SOAGx1.5_anthro_surface_175001-201412_ne30np4_c20200607.nc</soag_an_srf_file>
-<soag_bb_srf_file    hgrid="ne30np4" ver="cam6">atm/cam/chem/emis/historical_ne30np4/emissions-cmip6_SOAGx1.5_bb_surface_175001-201512_ne30np4_c20200607.nc</soag_bb_srf_file>
+<dms_ot_srf_file     hgrid="ne30np4" npg="0" ver="cam6">atm/cam/chem/emis/historical_ne30np4/emissions-cmip6_DMS_other_surface_1750_2015_ne30np4_c20200605.nc</dms_ot_srf_file>
+<dms_bb_srf_file     hgrid="ne30np4" npg="0" ver="cam6">atm/cam/chem/emis/historical_ne30np4/emissions-cmip6_DMS_bb_surface_175001-201512_ne30np4_c20200606.nc</dms_bb_srf_file>
+<so2_ag_sh_file      hgrid="ne30np4" npg="0" ver="cam6">atm/cam/chem/emis/historical_ne30np4/emissions-cmip6_SO2_anthro-ag-ship-res_surface_mol_175001-201412_ne30np4_c20200606.nc</so2_ag_sh_file>
+<so2_an_srf_file     hgrid="ne30np4" npg="0" ver="cam6">atm/cam/chem/emis/historical_ne30np4/emissions-cmip6_SO2_anthro-ene_surface_mol_175001-201412_ne30np4_c20200606.nc</so2_an_srf_file>
+<so2_bb_srf_file     hgrid="ne30np4" npg="0" ver="cam6">atm/cam/chem/emis/historical_ne30np4/emissions-cmip6_SO2_bb_surface_175001-201512_ne30np4_c20200606.nc</so2_bb_srf_file>
+<so4_a1_an_srf_file  hgrid="ne30np4" npg="0" ver="cam6">atm/cam/chem/emis/historical_ne30np4/emissions-cmip6_so4_a1_anthro-ag-ship_surface_mol_175001-201412_ne30np4_c20200606.nc</so4_a1_an_srf_file>
+<so4_a1_bb_srf_file  hgrid="ne30np4" npg="0" ver="cam6">atm/cam/chem/emis/historical_ne30np4/emissions-cmip6_so4_a1_bb_surface_175001-201512_ne30np4_c20200606.nc</so4_a1_bb_srf_file>
+<so4_a2_an_srf_file  hgrid="ne30np4" npg="0" ver="cam6">atm/cam/chem/emis/historical_ne30np4/emissions-cmip6_so4_a2_anthro-res_surface_mol_175001-201412_ne30np4_c20200606.nc</so4_a2_an_srf_file>
+<num_a1_sh_srf_file  hgrid="ne30np4" npg="0" ver="cam6">atm/cam/chem/emis/historical_ne30np4/emissions-cmip6_num_so4_a1_anthro-ag-ship_surface_mol_175001-201412_ne30np4_c20200606.nc</num_a1_sh_srf_file>
+<num_a2_an_srf_file  hgrid="ne30np4" npg="0" ver="cam6">atm/cam/chem/emis/historical_ne30np4/emissions-cmip6_num_so4_a2_anthro-res_surface_mol_175001-201412_ne30np4_c20200606.nc</num_a2_an_srf_file>
+<bc_a4_an_srf_file   hgrid="ne30np4" npg="0" ver="cam6">atm/cam/chem/emis/historical_ne30np4/emissions-cmip6_bc_a4_anthro_surface_175001-201412_ne30np4_c20200606.nc</bc_a4_an_srf_file>
+<num_a4_bc_srf_file  hgrid="ne30np4" npg="0" ver="cam6">atm/cam/chem/emis/historical_ne30np4/emissions-cmip6_num_bc_a4_anthro_surface_175001-201412_ne30np4_c20200606.nc</num_a4_bc_srf_file>
+<pom_a4_an_srf_file  hgrid="ne30np4" npg="0" ver="cam6">atm/cam/chem/emis/historical_ne30np4/emissions-cmip6_pom_a4_anthro_surface_175001-201412_ne30np4_c20200606.nc</pom_a4_an_srf_file>
+<num_a4_oc_srf_file  hgrid="ne30np4" npg="0" ver="cam6">atm/cam/chem/emis/historical_ne30np4/emissions-cmip6_num_pom_a4_anthro_surface_175001-201412_ne30np4_c20200606.nc</num_a4_oc_srf_file>
+<num_a1_bb_srf_file  hgrid="ne30np4" npg="0" ver="cam6">atm/cam/chem/emis/historical_ne30np4/emissions-cmip6_num_so4_a1_bb_surface_175001-201512_ne30np4_c20200606.nc</num_a1_bb_srf_file>
+<bc_a4_bb_srf_file   hgrid="ne30np4" npg="0" ver="cam6">atm/cam/chem/emis/historical_ne30np4/emissions-cmip6_bc_a4_bb_surface_175001-201512_ne30np4_c20200606.nc</bc_a4_bb_srf_file>
+<num_a4_bb_srf_file  hgrid="ne30np4" npg="0" ver="cam6">atm/cam/chem/emis/historical_ne30np4/emissions-cmip6_num_bc_a4_bb_surface_175001-201512_ne30np4_c20200606.nc</num_a4_bb_srf_file>
+<pom_a4_bb_srf_file  hgrid="ne30np4" npg="0" ver="cam6">atm/cam/chem/emis/historical_ne30np4/emissions-cmip6_pom_a4_bb_surface_175001-201512_ne30np4_c20200606.nc</pom_a4_bb_srf_file>
+<num_pom_bb_srf_file hgrid="ne30np4" npg="0" ver="cam6">atm/cam/chem/emis/historical_ne30np4/emissions-cmip6_num_pom_a4_bb_surface_175001-201512_ne30np4_c20200606.nc</num_pom_bb_srf_file>
+<soag_an_srf_file    hgrid="ne30np4" npg="0" ver="cam6">atm/cam/chem/emis/historical_ne30np4/emissions-cmip6_SOAGx1.5_anthro_surface_175001-201412_ne30np4_c20200607.nc</soag_an_srf_file>
+<soag_bg_srf_file    hgrid="ne30np4" npg="0" ver="cam6">atm/cam/chem/emis/historical_ne30np4/emissions-cmip6_SOAGx1.5_biogenic_surface_1750_2015_ne30np4_c20200129.nc</soag_bg_srf_file>
+<soag_bb_srf_file    hgrid="ne30np4" npg="0" ver="cam6">atm/cam/chem/emis/historical_ne30np4/emissions-cmip6_SOAGx1.5_bb_surface_175001-201512_ne30np4_c20200607.nc</soag_bb_srf_file>
 
-<BENZENE_an_srf_file  hgrid="ne30np4" ver="cam6">atm/cam/chem/emis/historical_ne30np4/emissions-cmip6_BENZENE_anthro_surface_175001-201412_ne30np4_c20200606.nc</BENZENE_an_srf_file>
-<BENZENE_bb_srf_file  hgrid="ne30np4" ver="cam6">atm/cam/chem/emis/historical_ne30np4/emissions-cmip6_BENZENE_bb_surface_175001-201512_ne30np4_c20200606.nc</BENZENE_bb_srf_file>
-<BIGALK_an_srf_file   hgrid="ne30np4" ver="cam6">atm/cam/chem/emis/historical_ne30np4/emissions-cmip6_BIGALK_anthro_surface_175001-201412_ne30np4_c20200606.nc</BIGALK_an_srf_file>
-<BIGALK_bb_srf_file   hgrid="ne30np4" ver="cam6">atm/cam/chem/emis/historical_ne30np4/emissions-cmip6_BIGALK_bb_surface_175001-201512_ne30np4_c20200606.nc</BIGALK_bb_srf_file>
-<BIGENE_an_srf_file   hgrid="ne30np4" ver="cam6">atm/cam/chem/emis/historical_ne30np4/emissions-cmip6_BIGENE_anthro_surface_175001-201412_ne30np4_c20200606.nc</BIGENE_an_srf_file>
-<BIGENE_bb_srf_file   hgrid="ne30np4" ver="cam6">atm/cam/chem/emis/historical_ne30np4/emissions-cmip6_BIGENE_bb_surface_175001-201512_ne30np4_c20200606.nc</BIGENE_bb_srf_file>
-<C2H2_an_srf_file     hgrid="ne30np4" ver="cam6">atm/cam/chem/emis/historical_ne30np4/emissions-cmip6_C2H2_anthro_surface_175001-201412_ne30np4_c20200606.nc</C2H2_an_srf_file>
-<C2H2_bb_srf_file     hgrid="ne30np4" ver="cam6">atm/cam/chem/emis/historical_ne30np4/emissions-cmip6_C2H2_bb_surface_175001-201512_ne30np4_c20200606.nc</C2H2_bb_srf_file>
-<C2H4_an_srf_file     hgrid="ne30np4" ver="cam6">atm/cam/chem/emis/historical_ne30np4/emissions-cmip6_C2H4_anthro_surface_175001-201412_ne30np4_c20200606.nc</C2H4_an_srf_file>
-<C2H4_bb_srf_file     hgrid="ne30np4" ver="cam6">atm/cam/chem/emis/historical_ne30np4/emissions-cmip6_C2H4_bb_surface_175001-201512_ne30np4_c20200606.nc</C2H4_bb_srf_file>
-<C2H4_ot_srf_file     hgrid="ne30np4" ver="cam6">atm/cam/chem/emis/historical_ne30np4/emissions-cmip6_C2H4_other_surface_1750_2015_ne30np4_c20200605.nc</C2H4_ot_srf_file>
-<C2H5OH_an_srf_file   hgrid="ne30np4" ver="cam6">atm/cam/chem/emis/historical_ne30np4/emissions-cmip6_C2H5OH_anthro_surface_175001-201412_ne30np4_c20200606.nc</C2H5OH_an_srf_file>
-<C2H5OH_bb_srf_file   hgrid="ne30np4" ver="cam6">atm/cam/chem/emis/historical_ne30np4/emissions-cmip6_C2H5OH_bb_surface_175001-201512_ne30np4_c20200606.nc</C2H5OH_bb_srf_file>
-<C2H6_an_srf_file     hgrid="ne30np4" ver="cam6">atm/cam/chem/emis/historical_ne30np4/emissions-cmip6_C2H6_anthro_surface_175001-201412_ne30np4_c20200606.nc</C2H6_an_srf_file>
-<C2H6_bb_srf_file     hgrid="ne30np4" ver="cam6">atm/cam/chem/emis/historical_ne30np4/emissions-cmip6_C2H6_bb_surface_175001-201512_ne30np4_c20200606.nc</C2H6_bb_srf_file>
-<C2H6_ot_srf_file     hgrid="ne30np4" ver="cam6">atm/cam/chem/emis/historical_ne30np4/emissions-cmip6_C2H6_other_surface_1750_2015_ne30np4_c20200605.nc</C2H6_ot_srf_file>
-<C3H6_an_srf_file     hgrid="ne30np4" ver="cam6">atm/cam/chem/emis/historical_ne30np4/emissions-cmip6_C3H6_anthro_surface_175001-201412_ne30np4_c20200606.nc</C3H6_an_srf_file>
-<C3H6_bb_srf_file     hgrid="ne30np4" ver="cam6">atm/cam/chem/emis/historical_ne30np4/emissions-cmip6_C3H6_bb_surface_175001-201512_ne30np4_c20200606.nc</C3H6_bb_srf_file>
-<C3H6_ot_srf_file     hgrid="ne30np4" ver="cam6">atm/cam/chem/emis/historical_ne30np4/emissions-cmip6_C3H6_other_surface_1750_2015_ne30np4_c20200605.nc</C3H6_ot_srf_file>
-<C3H8_an_srf_file     hgrid="ne30np4" ver="cam6">atm/cam/chem/emis/historical_ne30np4/emissions-cmip6_C3H8_anthro_surface_175001-201412_ne30np4_c20200606.nc</C3H8_an_srf_file>
-<C3H8_bb_srf_file     hgrid="ne30np4" ver="cam6">atm/cam/chem/emis/historical_ne30np4/emissions-cmip6_C3H8_bb_surface_175001-201512_ne30np4_c20200606.nc</C3H8_bb_srf_file>
-<C3H8_ot_srf_file     hgrid="ne30np4" ver="cam6">atm/cam/chem/emis/historical_ne30np4/emissions-cmip6_C3H8_other_surface_1750_2015_ne30np4_c20200605.nc</C3H8_ot_srf_file>
-<CH2O_an_srf_file     hgrid="ne30np4" ver="cam6">atm/cam/chem/emis/historical_ne30np4/emissions-cmip6_CH2O_anthro_surface_175001-201412_ne30np4_c20200606.nc</CH2O_an_srf_file>
-<CH2O_bb_srf_file     hgrid="ne30np4" ver="cam6">atm/cam/chem/emis/historical_ne30np4/emissions-cmip6_CH2O_bb_surface_175001-201512_ne30np4_c20200606.nc</CH2O_bb_srf_file>
-<CH3CHO_an_srf_file   hgrid="ne30np4" ver="cam6">atm/cam/chem/emis/historical_ne30np4/emissions-cmip6_CH3CHO_anthro_surface_175001-201412_ne30np4_c20200606.nc</CH3CHO_an_srf_file>
-<CH3CHO_bb_srf_file   hgrid="ne30np4" ver="cam6">atm/cam/chem/emis/historical_ne30np4/emissions-cmip6_CH3CHO_bb_surface_175001-201512_ne30np4_c20200606.nc</CH3CHO_bb_srf_file>
-<CH3CN_an_srf_file    hgrid="ne30np4" ver="cam6">atm/cam/chem/emis/historical_ne30np4/emissions-cmip6_CH3CN_anthro_surface_175001-201412_ne30np4_c20200606.nc</CH3CN_an_srf_file>
-<CH3CN_bb_srf_file    hgrid="ne30np4" ver="cam6">atm/cam/chem/emis/historical_ne30np4/emissions-cmip6_CH3CN_bb_surface_175001-201512_ne30np4_c20200606.nc</CH3CN_bb_srf_file>
-<CH3COCH3_an_srf_file hgrid="ne30np4" ver="cam6">atm/cam/chem/emis/historical_ne30np4/emissions-cmip6_CH3COCH3_anthro_surface_175001-201412_ne30np4_c20200606.nc</CH3COCH3_an_srf_file>
-<CH3COCH3_bb_srf_file hgrid="ne30np4" ver="cam6">atm/cam/chem/emis/historical_ne30np4/emissions-cmip6_CH3COCH3_bb_surface_175001-201512_ne30np4_c20200606.nc</CH3COCH3_bb_srf_file>
-<CH3COCHO_bb_srf_file hgrid="ne30np4" ver="cam6">atm/cam/chem/emis/historical_ne30np4/emissions-cmip6_CH3COCHO_bb_surface_175001-201512_ne30np4_c20200606.nc</CH3COCHO_bb_srf_file>
-<CH3COOH_an_srf_file  hgrid="ne30np4" ver="cam6">atm/cam/chem/emis/historical_ne30np4/emissions-cmip6_CH3COOH_anthro_surface_175001-201412_ne30np4_c20200606.nc</CH3COOH_an_srf_file>
-<CH3COOH_bb_srf_file  hgrid="ne30np4" ver="cam6">atm/cam/chem/emis/historical_ne30np4/emissions-cmip6_CH3COOH_bb_surface_175001-201512_ne30np4_c20200606.nc</CH3COOH_bb_srf_file>
-<CH3OH_an_srf_file    hgrid="ne30np4" ver="cam6">atm/cam/chem/emis/historical_ne30np4/emissions-cmip6_CH3OH_anthro_surface_175001-201412_ne30np4_c20200606.nc</CH3OH_an_srf_file>
-<CH3OH_bb_srf_file    hgrid="ne30np4" ver="cam6">atm/cam/chem/emis/historical_ne30np4/emissions-cmip6_CH3OH_bb_surface_175001-201512_ne30np4_c20200606.nc</CH3OH_bb_srf_file>
-<CO_an_srf_file       hgrid="ne30np4" ver="cam6">atm/cam/chem/emis/historical_ne30np4/emissions-cmip6_CO_anthro_surface_175001-201412_ne30np4_c20200606.nc</CO_an_srf_file>
-<CO_bb_srf_file       hgrid="ne30np4" ver="cam6">atm/cam/chem/emis/historical_ne30np4/emissions-cmip6_CO_bb_surface_175001-201512_ne30np4_c20200606.nc</CO_bb_srf_file>
-<CO_ot_srf_file       hgrid="ne30np4" ver="cam6">atm/cam/chem/emis/historical_ne30np4/emissions-cmip6_CO_other_surface_1750_2015_ne30np4_c20200605.nc</CO_ot_srf_file>
-<GLYALD_bb_srf_file   hgrid="ne30np4" ver="cam6">atm/cam/chem/emis/historical_ne30np4/emissions-cmip6_GLYALD_bb_surface_175001-201512_ne30np4_c20200606.nc</GLYALD_bb_srf_file>
-<HCN_an_srf_file      hgrid="ne30np4" ver="cam6">atm/cam/chem/emis/historical_ne30np4/emissions-cmip6_HCN_anthro_surface_175001-201412_ne30np4_c20200606.nc</HCN_an_srf_file>
-<HCN_bb_srf_file      hgrid="ne30np4" ver="cam6">atm/cam/chem/emis/historical_ne30np4/emissions-cmip6_HCN_bb_surface_175001-201512_ne30np4_c20200606.nc</HCN_bb_srf_file>
-<HCOOH_an_srf_file    hgrid="ne30np4" ver="cam6">atm/cam/chem/emis/historical_ne30np4/emissions-cmip6_HCOOH_anthro_surface_175001-201412_ne30np4_c20200606.nc</HCOOH_an_srf_file>
-<HCOOH_bb_srf_file    hgrid="ne30np4" ver="cam6">atm/cam/chem/emis/historical_ne30np4/emissions-cmip6_HCOOH_bb_surface_175001-201512_ne30np4_c20200606.nc</HCOOH_bb_srf_file>
-<ISOP_bb_srf_file     hgrid="ne30np4" ver="cam6">atm/cam/chem/emis/historical_ne30np4/emissions-cmip6_ISOP_bb_surface_175001-201512_ne30np4_c20200606.nc</ISOP_bb_srf_file>
-<IVOC_an_srf_file     hgrid="ne30np4" ver="cam6">atm/cam/chem/emis/historical_ne30np4/emissions-cmip6_IVOC_anthro_surface_175001-201412_ne30np4_c20200607.nc</IVOC_an_srf_file>
-<IVOC_bb_srf_file     hgrid="ne30np4" ver="cam6">atm/cam/chem/emis/historical_ne30np4/emissions-cmip6_IVOC_bb_surface_175001-201512_ne30np4_c20200607.nc</IVOC_bb_srf_file>
-<MEK_an_srf_file      hgrid="ne30np4" ver="cam6">atm/cam/chem/emis/historical_ne30np4/emissions-cmip6_MEK_anthro_surface_175001-201412_ne30np4_c20200606.nc</MEK_an_srf_file>
-<MEK_bb_srf_file      hgrid="ne30np4" ver="cam6">atm/cam/chem/emis/historical_ne30np4/emissions-cmip6_MEK_bb_surface_175001-201512_ne30np4_c20200606.nc</MEK_bb_srf_file>
-<MTERP_bb_srf_file    hgrid="ne30np4" ver="cam6">atm/cam/chem/emis/historical_ne30np4/emissions-cmip6_MTERP_bb_surface_175001-201512_ne30np4_c20200606.nc</MTERP_bb_srf_file>
-<NH3_an_srf_file      hgrid="ne30np4" ver="cam6">atm/cam/chem/emis/historical_ne30np4/emissions-cmip6_NH3_anthro_surface_175001-201412_ne30np4_c20200606.nc</NH3_an_srf_file>
-<NH3_bb_srf_file      hgrid="ne30np4" ver="cam6">atm/cam/chem/emis/historical_ne30np4/emissions-cmip6_NH3_bb_surface_175001-201512_ne30np4_c20200606.nc</NH3_bb_srf_file>
-<NH3_ot_srf_file      hgrid="ne30np4" ver="cam6">atm/cam/chem/emis/historical_ne30np4/emissions-cmip6_NH3_other_surface_1750_2015_ne30np4_c20200605.nc</NH3_ot_srf_file>
-<NO_an_srf_file       hgrid="ne30np4" ver="cam6">atm/cam/chem/emis/historical_ne30np4/emissions-cmip6_NOx_anthro_surface_175001-201412_ne30np4_c20200606.nc</NO_an_srf_file>
-<NO_bb_srf_file       hgrid="ne30np4" ver="cam6">atm/cam/chem/emis/historical_ne30np4/emissions-cmip6_NOx_bb_surface_175001-201512_ne30np4_c20200606.nc</NO_bb_srf_file>
-<NO_ot_srf_file       hgrid="ne30np4" ver="cam6">atm/cam/chem/emis/historical_ne30np4/emissions-cmip6_NO_other_surface_1750_2015_ne30np4_c20200605.nc</NO_ot_srf_file>
-<SVOC_an_srf_file     hgrid="ne30np4" ver="cam6">atm/cam/chem/emis/historical_ne30np4/emissions-cmip6_SVOC_anthro_surface_175001-201412_ne30np4_c20200607.nc</SVOC_an_srf_file>
-<SVOC_bb_srf_file     hgrid="ne30np4" ver="cam6">atm/cam/chem/emis/historical_ne30np4/emissions-cmip6_SVOC_bb_surface_175001-201512_ne30np4_c20200607.nc</SVOC_bb_srf_file>
-<TOLUENE_an_srf_file  hgrid="ne30np4" ver="cam6">atm/cam/chem/emis/historical_ne30np4/emissions-cmip6_TOLUENE_anthro_surface_175001-201412_ne30np4_c20200606.nc</TOLUENE_an_srf_file>
-<TOLUENE_bb_srf_file  hgrid="ne30np4" ver="cam6">atm/cam/chem/emis/historical_ne30np4/emissions-cmip6_TOLUENE_bb_surface_175001-201512_ne30np4_c20200606.nc</TOLUENE_bb_srf_file>
-<XYLENES_an_srf_file  hgrid="ne30np4" ver="cam6">atm/cam/chem/emis/historical_ne30np4/emissions-cmip6_XYLENES_anthro_surface_175001-201412_ne30np4_c20200606.nc</XYLENES_an_srf_file>
-<XYLENES_bb_srf_file  hgrid="ne30np4" ver="cam6">atm/cam/chem/emis/historical_ne30np4/emissions-cmip6_XYLENES_bb_surface_175001-201512_ne30np4_c20200606.nc</XYLENES_bb_srf_file>
+<BENZENE_an_srf_file  hgrid="ne30np4" npg="0" ver="cam6">atm/cam/chem/emis/historical_ne30np4/emissions-cmip6_BENZENE_anthro_surface_175001-201412_ne30np4_c20200606.nc</BENZENE_an_srf_file>
+<BENZENE_bb_srf_file  hgrid="ne30np4" npg="0" ver="cam6">atm/cam/chem/emis/historical_ne30np4/emissions-cmip6_BENZENE_bb_surface_175001-201512_ne30np4_c20200606.nc</BENZENE_bb_srf_file>
+<BIGALK_an_srf_file   hgrid="ne30np4" npg="0" ver="cam6">atm/cam/chem/emis/historical_ne30np4/emissions-cmip6_BIGALK_anthro_surface_175001-201412_ne30np4_c20200606.nc</BIGALK_an_srf_file>
+<BIGALK_bb_srf_file   hgrid="ne30np4" npg="0" ver="cam6">atm/cam/chem/emis/historical_ne30np4/emissions-cmip6_BIGALK_bb_surface_175001-201512_ne30np4_c20200606.nc</BIGALK_bb_srf_file>
+<BIGENE_an_srf_file   hgrid="ne30np4" npg="0" ver="cam6">atm/cam/chem/emis/historical_ne30np4/emissions-cmip6_BIGENE_anthro_surface_175001-201412_ne30np4_c20200606.nc</BIGENE_an_srf_file>
+<BIGENE_bb_srf_file   hgrid="ne30np4" npg="0" ver="cam6">atm/cam/chem/emis/historical_ne30np4/emissions-cmip6_BIGENE_bb_surface_175001-201512_ne30np4_c20200606.nc</BIGENE_bb_srf_file>
+<C2H2_an_srf_file     hgrid="ne30np4" npg="0" ver="cam6">atm/cam/chem/emis/historical_ne30np4/emissions-cmip6_C2H2_anthro_surface_175001-201412_ne30np4_c20200606.nc</C2H2_an_srf_file>
+<C2H2_bb_srf_file     hgrid="ne30np4" npg="0" ver="cam6">atm/cam/chem/emis/historical_ne30np4/emissions-cmip6_C2H2_bb_surface_175001-201512_ne30np4_c20200606.nc</C2H2_bb_srf_file>
+<C2H4_an_srf_file     hgrid="ne30np4" npg="0" ver="cam6">atm/cam/chem/emis/historical_ne30np4/emissions-cmip6_C2H4_anthro_surface_175001-201412_ne30np4_c20200606.nc</C2H4_an_srf_file>
+<C2H4_bb_srf_file     hgrid="ne30np4" npg="0" ver="cam6">atm/cam/chem/emis/historical_ne30np4/emissions-cmip6_C2H4_bb_surface_175001-201512_ne30np4_c20200606.nc</C2H4_bb_srf_file>
+<C2H4_ot_srf_file     hgrid="ne30np4" npg="0" ver="cam6">atm/cam/chem/emis/historical_ne30np4/emissions-cmip6_C2H4_other_surface_1750_2015_ne30np4_c20200605.nc</C2H4_ot_srf_file>
+<C2H5OH_an_srf_file   hgrid="ne30np4" npg="0" ver="cam6">atm/cam/chem/emis/historical_ne30np4/emissions-cmip6_C2H5OH_anthro_surface_175001-201412_ne30np4_c20200606.nc</C2H5OH_an_srf_file>
+<C2H5OH_bb_srf_file   hgrid="ne30np4" npg="0" ver="cam6">atm/cam/chem/emis/historical_ne30np4/emissions-cmip6_C2H5OH_bb_surface_175001-201512_ne30np4_c20200606.nc</C2H5OH_bb_srf_file>
+<C2H6_an_srf_file     hgrid="ne30np4" npg="0" ver="cam6">atm/cam/chem/emis/historical_ne30np4/emissions-cmip6_C2H6_anthro_surface_175001-201412_ne30np4_c20200606.nc</C2H6_an_srf_file>
+<C2H6_bb_srf_file     hgrid="ne30np4" npg="0" ver="cam6">atm/cam/chem/emis/historical_ne30np4/emissions-cmip6_C2H6_bb_surface_175001-201512_ne30np4_c20200606.nc</C2H6_bb_srf_file>
+<C2H6_ot_srf_file     hgrid="ne30np4" npg="0" ver="cam6">atm/cam/chem/emis/historical_ne30np4/emissions-cmip6_C2H6_other_surface_1750_2015_ne30np4_c20200605.nc</C2H6_ot_srf_file>
+<C3H6_an_srf_file     hgrid="ne30np4" npg="0" ver="cam6">atm/cam/chem/emis/historical_ne30np4/emissions-cmip6_C3H6_anthro_surface_175001-201412_ne30np4_c20200606.nc</C3H6_an_srf_file>
+<C3H6_bb_srf_file     hgrid="ne30np4" npg="0" ver="cam6">atm/cam/chem/emis/historical_ne30np4/emissions-cmip6_C3H6_bb_surface_175001-201512_ne30np4_c20200606.nc</C3H6_bb_srf_file>
+<C3H6_ot_srf_file     hgrid="ne30np4" npg="0" ver="cam6">atm/cam/chem/emis/historical_ne30np4/emissions-cmip6_C3H6_other_surface_1750_2015_ne30np4_c20200605.nc</C3H6_ot_srf_file>
+<C3H8_an_srf_file     hgrid="ne30np4" npg="0" ver="cam6">atm/cam/chem/emis/historical_ne30np4/emissions-cmip6_C3H8_anthro_surface_175001-201412_ne30np4_c20200606.nc</C3H8_an_srf_file>
+<C3H8_bb_srf_file     hgrid="ne30np4" npg="0" ver="cam6">atm/cam/chem/emis/historical_ne30np4/emissions-cmip6_C3H8_bb_surface_175001-201512_ne30np4_c20200606.nc</C3H8_bb_srf_file>
+<C3H8_ot_srf_file     hgrid="ne30np4" npg="0" ver="cam6">atm/cam/chem/emis/historical_ne30np4/emissions-cmip6_C3H8_other_surface_1750_2015_ne30np4_c20200605.nc</C3H8_ot_srf_file>
+<CH2O_an_srf_file     hgrid="ne30np4" npg="0" ver="cam6">atm/cam/chem/emis/historical_ne30np4/emissions-cmip6_CH2O_anthro_surface_175001-201412_ne30np4_c20200606.nc</CH2O_an_srf_file>
+<CH2O_bb_srf_file     hgrid="ne30np4" npg="0" ver="cam6">atm/cam/chem/emis/historical_ne30np4/emissions-cmip6_CH2O_bb_surface_175001-201512_ne30np4_c20200606.nc</CH2O_bb_srf_file>
+<CH3CHO_an_srf_file   hgrid="ne30np4" npg="0" ver="cam6">atm/cam/chem/emis/historical_ne30np4/emissions-cmip6_CH3CHO_anthro_surface_175001-201412_ne30np4_c20200606.nc</CH3CHO_an_srf_file>
+<CH3CHO_bb_srf_file   hgrid="ne30np4" npg="0" ver="cam6">atm/cam/chem/emis/historical_ne30np4/emissions-cmip6_CH3CHO_bb_surface_175001-201512_ne30np4_c20200606.nc</CH3CHO_bb_srf_file>
+<CH3CN_an_srf_file    hgrid="ne30np4" npg="0" ver="cam6">atm/cam/chem/emis/historical_ne30np4/emissions-cmip6_CH3CN_anthro_surface_175001-201412_ne30np4_c20200606.nc</CH3CN_an_srf_file>
+<CH3CN_bb_srf_file    hgrid="ne30np4" npg="0" ver="cam6">atm/cam/chem/emis/historical_ne30np4/emissions-cmip6_CH3CN_bb_surface_175001-201512_ne30np4_c20200606.nc</CH3CN_bb_srf_file>
+<CH3COCH3_an_srf_file hgrid="ne30np4" npg="0" ver="cam6">atm/cam/chem/emis/historical_ne30np4/emissions-cmip6_CH3COCH3_anthro_surface_175001-201412_ne30np4_c20200606.nc</CH3COCH3_an_srf_file>
+<CH3COCH3_bb_srf_file hgrid="ne30np4" npg="0" ver="cam6">atm/cam/chem/emis/historical_ne30np4/emissions-cmip6_CH3COCH3_bb_surface_175001-201512_ne30np4_c20200606.nc</CH3COCH3_bb_srf_file>
+<CH3COCHO_bb_srf_file hgrid="ne30np4" npg="0" ver="cam6">atm/cam/chem/emis/historical_ne30np4/emissions-cmip6_CH3COCHO_bb_surface_175001-201512_ne30np4_c20200606.nc</CH3COCHO_bb_srf_file>
+<CH3COOH_an_srf_file  hgrid="ne30np4" npg="0" ver="cam6">atm/cam/chem/emis/historical_ne30np4/emissions-cmip6_CH3COOH_anthro_surface_175001-201412_ne30np4_c20200606.nc</CH3COOH_an_srf_file>
+<CH3COOH_bb_srf_file  hgrid="ne30np4" npg="0" ver="cam6">atm/cam/chem/emis/historical_ne30np4/emissions-cmip6_CH3COOH_bb_surface_175001-201512_ne30np4_c20200606.nc</CH3COOH_bb_srf_file>
+<CH3OH_an_srf_file    hgrid="ne30np4" npg="0" ver="cam6">atm/cam/chem/emis/historical_ne30np4/emissions-cmip6_CH3OH_anthro_surface_175001-201412_ne30np4_c20200606.nc</CH3OH_an_srf_file>
+<CH3OH_bb_srf_file    hgrid="ne30np4" npg="0" ver="cam6">atm/cam/chem/emis/historical_ne30np4/emissions-cmip6_CH3OH_bb_surface_175001-201512_ne30np4_c20200606.nc</CH3OH_bb_srf_file>
+<CO_an_srf_file       hgrid="ne30np4" npg="0" ver="cam6">atm/cam/chem/emis/historical_ne30np4/emissions-cmip6_CO_anthro_surface_175001-201412_ne30np4_c20200606.nc</CO_an_srf_file>
+<CO_bb_srf_file       hgrid="ne30np4" npg="0" ver="cam6">atm/cam/chem/emis/historical_ne30np4/emissions-cmip6_CO_bb_surface_175001-201512_ne30np4_c20200606.nc</CO_bb_srf_file>
+<CO_ot_srf_file       hgrid="ne30np4" npg="0" ver="cam6">atm/cam/chem/emis/historical_ne30np4/emissions-cmip6_CO_other_surface_1750_2015_ne30np4_c20200605.nc</CO_ot_srf_file>
+<GLYALD_bb_srf_file   hgrid="ne30np4" npg="0" ver="cam6">atm/cam/chem/emis/historical_ne30np4/emissions-cmip6_GLYALD_bb_surface_175001-201512_ne30np4_c20200606.nc</GLYALD_bb_srf_file>
+<HCN_an_srf_file      hgrid="ne30np4" npg="0" ver="cam6">atm/cam/chem/emis/historical_ne30np4/emissions-cmip6_HCN_anthro_surface_175001-201412_ne30np4_c20200606.nc</HCN_an_srf_file>
+<HCN_bb_srf_file      hgrid="ne30np4" npg="0" ver="cam6">atm/cam/chem/emis/historical_ne30np4/emissions-cmip6_HCN_bb_surface_175001-201512_ne30np4_c20200606.nc</HCN_bb_srf_file>
+<HCOOH_an_srf_file    hgrid="ne30np4" npg="0" ver="cam6">atm/cam/chem/emis/historical_ne30np4/emissions-cmip6_HCOOH_anthro_surface_175001-201412_ne30np4_c20200606.nc</HCOOH_an_srf_file>
+<HCOOH_bb_srf_file    hgrid="ne30np4" npg="0" ver="cam6">atm/cam/chem/emis/historical_ne30np4/emissions-cmip6_HCOOH_bb_surface_175001-201512_ne30np4_c20200606.nc</HCOOH_bb_srf_file>
+<ISOP_bb_srf_file     hgrid="ne30np4" npg="0" ver="cam6">atm/cam/chem/emis/historical_ne30np4/emissions-cmip6_ISOP_bb_surface_175001-201512_ne30np4_c20200606.nc</ISOP_bb_srf_file>
+<IVOC_an_srf_file     hgrid="ne30np4" npg="0" ver="cam6">atm/cam/chem/emis/historical_ne30np4/emissions-cmip6_IVOC_anthro_surface_175001-201412_ne30np4_c20200607.nc</IVOC_an_srf_file>
+<IVOC_bb_srf_file     hgrid="ne30np4" npg="0" ver="cam6">atm/cam/chem/emis/historical_ne30np4/emissions-cmip6_IVOC_bb_surface_175001-201512_ne30np4_c20200607.nc</IVOC_bb_srf_file>
+<MEK_an_srf_file      hgrid="ne30np4" npg="0" ver="cam6">atm/cam/chem/emis/historical_ne30np4/emissions-cmip6_MEK_anthro_surface_175001-201412_ne30np4_c20200606.nc</MEK_an_srf_file>
+<MEK_bb_srf_file      hgrid="ne30np4" npg="0" ver="cam6">atm/cam/chem/emis/historical_ne30np4/emissions-cmip6_MEK_bb_surface_175001-201512_ne30np4_c20200606.nc</MEK_bb_srf_file>
+<MTERP_bb_srf_file    hgrid="ne30np4" npg="0" ver="cam6">atm/cam/chem/emis/historical_ne30np4/emissions-cmip6_MTERP_bb_surface_175001-201512_ne30np4_c20200606.nc</MTERP_bb_srf_file>
+<NH3_an_srf_file      hgrid="ne30np4" npg="0" ver="cam6">atm/cam/chem/emis/historical_ne30np4/emissions-cmip6_NH3_anthro_surface_175001-201412_ne30np4_c20200606.nc</NH3_an_srf_file>
+<NH3_bb_srf_file      hgrid="ne30np4" npg="0" ver="cam6">atm/cam/chem/emis/historical_ne30np4/emissions-cmip6_NH3_bb_surface_175001-201512_ne30np4_c20200606.nc</NH3_bb_srf_file>
+<NH3_ot_srf_file      hgrid="ne30np4" npg="0" ver="cam6">atm/cam/chem/emis/historical_ne30np4/emissions-cmip6_NH3_other_surface_1750_2015_ne30np4_c20200605.nc</NH3_ot_srf_file>
+<NO_an_srf_file       hgrid="ne30np4" npg="0" ver="cam6">atm/cam/chem/emis/historical_ne30np4/emissions-cmip6_NOx_anthro_surface_175001-201412_ne30np4_c20200606.nc</NO_an_srf_file>
+<NO_bb_srf_file       hgrid="ne30np4" npg="0" ver="cam6">atm/cam/chem/emis/historical_ne30np4/emissions-cmip6_NOx_bb_surface_175001-201512_ne30np4_c20200606.nc</NO_bb_srf_file>
+<NO_ot_srf_file       hgrid="ne30np4" npg="0" ver="cam6">atm/cam/chem/emis/historical_ne30np4/emissions-cmip6_NO_other_surface_1750_2015_ne30np4_c20200605.nc</NO_ot_srf_file>
+<SVOC_an_srf_file     hgrid="ne30np4" npg="0" ver="cam6">atm/cam/chem/emis/historical_ne30np4/emissions-cmip6_SVOC_anthro_surface_175001-201412_ne30np4_c20200607.nc</SVOC_an_srf_file>
+<SVOC_bb_srf_file     hgrid="ne30np4" npg="0" ver="cam6">atm/cam/chem/emis/historical_ne30np4/emissions-cmip6_SVOC_bb_surface_175001-201512_ne30np4_c20200607.nc</SVOC_bb_srf_file>
+<TOLUENE_an_srf_file  hgrid="ne30np4" npg="0" ver="cam6">atm/cam/chem/emis/historical_ne30np4/emissions-cmip6_TOLUENE_anthro_surface_175001-201412_ne30np4_c20200606.nc</TOLUENE_an_srf_file>
+<TOLUENE_bb_srf_file  hgrid="ne30np4" npg="0" ver="cam6">atm/cam/chem/emis/historical_ne30np4/emissions-cmip6_TOLUENE_bb_surface_175001-201512_ne30np4_c20200606.nc</TOLUENE_bb_srf_file>
+<XYLENES_an_srf_file  hgrid="ne30np4" npg="0" ver="cam6">atm/cam/chem/emis/historical_ne30np4/emissions-cmip6_XYLENES_anthro_surface_175001-201412_ne30np4_c20200606.nc</XYLENES_an_srf_file>
+<XYLENES_bb_srf_file  hgrid="ne30np4" npg="0" ver="cam6">atm/cam/chem/emis/historical_ne30np4/emissions-cmip6_XYLENES_bb_surface_175001-201512_ne30np4_c20200606.nc</XYLENES_bb_srf_file>
 
-<E90_srf_file         hgrid="ne30np4" ver="cam6">atm/cam/chem/emis/historical_ne30np4/emissions_E90global_surface_1750_2015_ne30np4_c20200606.nc</E90_srf_file>
+<E90_srf_file         hgrid="ne30np4" npg="0" ver="cam6">atm/cam/chem/emis/historical_ne30np4/emissions_E90global_surface_1750_2015_ne30np4_c20200606.nc</E90_srf_file>
 
-<so2_cv_ext_file      hgrid="ne30np4" ver="cam6">atm/cam/chem/emis/historical_ne30np4/emissions-cmip6_SO2_contvolcano_vertical_850-5000_ne30np4_c20200606.nc</so2_cv_ext_file>
-<so4_a1_cv_ext_file   hgrid="ne30np4" ver="cam6">atm/cam/chem/emis/historical_ne30np4/emissions-cmip6_so4_a1_contvolcano_vertical_850-5000_ne30np4_c20200606.nc</so4_a1_cv_ext_file>
-<num_a1_cv_ext_file   hgrid="ne30np4" ver="cam6">atm/cam/chem/emis/historical_ne30np4/emissions-cmip6_num_a1_so4_contvolcano_vertical_850-5000_ne30np4_c20200606.nc</num_a1_cv_ext_file>
-<so4_a2_cv_ext_file   hgrid="ne30np4" ver="cam6">atm/cam/chem/emis/historical_ne30np4/emissions-cmip6_so4_a2_contvolcano_vertical_850-5000_ne30np4_c20200606.nc</so4_a2_cv_ext_file>
-<num_a2_cv_ext_file   hgrid="ne30np4" ver="cam6">atm/cam/chem/emis/historical_ne30np4/emissions-cmip6_num_a2_so4_contvolcano_vertical_850-5000_ne30np4_c20200606.nc</num_a2_cv_ext_file>
-<so4_a1_an_ext_file   hgrid="ne30np4" ver="cam6">atm/cam/chem/emis/historical_ne30np4/emissions-cmip6_so4_a1_anthro-ene_vertical_mol_175001-201412_ne30np4_c20200606.nc</so4_a1_an_ext_file>
-<num_a1_an_ext_file   hgrid="ne30np4" ver="cam6">atm/cam/chem/emis/historical_ne30np4/emissions-cmip6_num_so4_a1_anthro-ene_vertical_mol_175001-201412_ne30np4_c20200606.nc</num_a1_an_ext_file>
+<so2_cv_ext_file      hgrid="ne30np4" npg="0" ver="cam6">atm/cam/chem/emis/historical_ne30np4/emissions-cmip6_SO2_contvolcano_vertical_850-5000_ne30np4_c20200606.nc</so2_cv_ext_file>
+<so4_a1_cv_ext_file   hgrid="ne30np4" npg="0" ver="cam6">atm/cam/chem/emis/historical_ne30np4/emissions-cmip6_so4_a1_contvolcano_vertical_850-5000_ne30np4_c20200606.nc</so4_a1_cv_ext_file>
+<num_a1_cv_ext_file   hgrid="ne30np4" npg="0" ver="cam6">atm/cam/chem/emis/historical_ne30np4/emissions-cmip6_num_a1_so4_contvolcano_vertical_850-5000_ne30np4_c20200606.nc</num_a1_cv_ext_file>
+<so4_a2_cv_ext_file   hgrid="ne30np4" npg="0" ver="cam6">atm/cam/chem/emis/historical_ne30np4/emissions-cmip6_so4_a2_contvolcano_vertical_850-5000_ne30np4_c20200606.nc</so4_a2_cv_ext_file>
+<num_a2_cv_ext_file   hgrid="ne30np4" npg="0" ver="cam6">atm/cam/chem/emis/historical_ne30np4/emissions-cmip6_num_a2_so4_contvolcano_vertical_850-5000_ne30np4_c20200606.nc</num_a2_cv_ext_file>
+<so4_a1_an_ext_file   hgrid="ne30np4" npg="0" ver="cam6">atm/cam/chem/emis/historical_ne30np4/emissions-cmip6_so4_a1_anthro-ene_vertical_mol_175001-201412_ne30np4_c20200606.nc</so4_a1_an_ext_file>
+<num_a1_an_ext_file   hgrid="ne30np4" npg="0" ver="cam6">atm/cam/chem/emis/historical_ne30np4/emissions-cmip6_num_so4_a1_anthro-ene_vertical_mol_175001-201412_ne30np4_c20200606.nc</num_a1_an_ext_file>
+
+<!-- ne30 pg3 -->
+
+<dms_ot_srf_file     hgrid="ne30np4" npg="3" ver="cam6">atm/cam/chem/emis/historical_ne30pg3/emissions-cmip6_DMS_other_surface_1750_2015_ne30pg3_c20200630.nc</dms_ot_srf_file>
+<dms_bb_srf_file     hgrid="ne30np4" npg="3" ver="cam6">atm/cam/chem/emis/historical_ne30pg3/emissions-cmip6_DMS_bb_surface_175001-201512_ne30pg3_c20191118.nc</dms_bb_srf_file>
+<so2_ag_sh_file      hgrid="ne30np4" npg="3" ver="cam6">atm/cam/chem/emis/historical_ne30pg3/emissions-cmip6_SO2_anthro-ag-ship-res_surface_mol_175001-201412_ne30pg3_c20200103.nc</so2_ag_sh_file>
+<so2_an_srf_file     hgrid="ne30np4" npg="3" ver="cam6">atm/cam/chem/emis/historical_ne30pg3/emissions-cmip6_SO2_anthro-ene_surface_mol_175001-201412_ne30pg3_c20200103.nc</so2_an_srf_file>
+<so2_bb_srf_file     hgrid="ne30np4" npg="3" ver="cam6">atm/cam/chem/emis/historical_ne30pg3/emissions-cmip6_SO2_bb_surface_175001-201512_ne30pg3_c20191118.nc</so2_bb_srf_file>
+<so4_a1_an_srf_file  hgrid="ne30np4" npg="3" ver="cam6">atm/cam/chem/emis/historical_ne30pg3/emissions-cmip6_so4_a1_anthro-ag-ship_surface_mol_175001-201412_ne30pg3_c20200103.nc</so4_a1_an_srf_file>
+<so4_a1_bb_srf_file  hgrid="ne30np4" npg="3" ver="cam6">atm/cam/chem/emis/historical_ne30pg3/emissions-cmip6_so4_a1_bb_surface_175001-201512_ne30pg3_c20191118.nc</so4_a1_bb_srf_file>
+<so4_a2_an_srf_file  hgrid="ne30np4" npg="3" ver="cam6">atm/cam/chem/emis/historical_ne30pg3/emissions-cmip6_so4_a2_anthro-res_surface_mol_175001-201412_ne30pg3_c20200103.nc</so4_a2_an_srf_file>
+<num_a1_sh_srf_file  hgrid="ne30np4" npg="3" ver="cam6">atm/cam/chem/emis/historical_ne30pg3/emissions-cmip6_num_so4_a1_anthro-ag-ship_surface_mol_175001-201412_ne30pg3_c20200103.nc</num_a1_sh_srf_file>
+<num_a2_an_srf_file  hgrid="ne30np4" npg="3" ver="cam6">atm/cam/chem/emis/historical_ne30pg3/emissions-cmip6_num_so4_a2_anthro-res_surface_mol_175001-201412_ne30pg3_c20200103.nc</num_a2_an_srf_file>
+<bc_a4_an_srf_file   hgrid="ne30np4" npg="3" ver="cam6">atm/cam/chem/emis/historical_ne30pg3/emissions-cmip6_bc_a4_anthro_surface_175001-201412_ne30pg3_c20191118.nc</bc_a4_an_srf_file>
+<num_a4_bc_srf_file  hgrid="ne30np4" npg="3" ver="cam6">atm/cam/chem/emis/historical_ne30pg3/emissions-cmip6_num_bc_a4_anthro_surface_175001-201412_ne30pg3_c20191118.nc</num_a4_bc_srf_file>
+<pom_a4_an_srf_file  hgrid="ne30np4" npg="3" ver="cam6">atm/cam/chem/emis/historical_ne30pg3/emissions-cmip6_pom_a4_anthro_surface_175001-201412_ne30pg3_c20191118.nc</pom_a4_an_srf_file>
+<num_a4_oc_srf_file  hgrid="ne30np4" npg="3" ver="cam6">atm/cam/chem/emis/historical_ne30pg3/emissions-cmip6_num_pom_a4_anthro_surface_175001-201412_ne30pg3_c20191118.nc</num_a4_oc_srf_file>
+<num_a1_bb_srf_file  hgrid="ne30np4" npg="3" ver="cam6">atm/cam/chem/emis/historical_ne30pg3/emissions-cmip6_num_so4_a1_bb_surface_175001-201512_ne30pg3_c20191118.nc</num_a1_bb_srf_file>
+<bc_a4_bb_srf_file   hgrid="ne30np4" npg="3" ver="cam6">atm/cam/chem/emis/historical_ne30pg3/emissions-cmip6_bc_a4_bb_surface_175001-201512_ne30pg3_c20191118.nc</bc_a4_bb_srf_file>
+<num_a4_bb_srf_file  hgrid="ne30np4" npg="3" ver="cam6">atm/cam/chem/emis/historical_ne30pg3/emissions-cmip6_num_bc_a4_bb_surface_175001-201512_ne30pg3_c20191118.nc</num_a4_bb_srf_file>
+<pom_a4_bb_srf_file  hgrid="ne30np4" npg="3" ver="cam6">atm/cam/chem/emis/historical_ne30pg3/emissions-cmip6_pom_a4_bb_surface_175001-201512_ne30pg3_c20191118.nc</pom_a4_bb_srf_file>
+<num_pom_bb_srf_file hgrid="ne30np4" npg="3" ver="cam6">atm/cam/chem/emis/historical_ne30pg3/emissions-cmip6_num_pom_a4_bb_surface_175001-201512_ne30pg3_c20191118.nc</num_pom_bb_srf_file>
+<soag_an_srf_file    hgrid="ne30np4" npg="3" ver="cam6">atm/cam/chem/emis/historical_ne30pg3/emissions-cmip6_SOAGx1.5_anthro_surface_175001-201412_ne30pg3_c20200103.nc</soag_an_srf_file>
+<soag_bg_srf_file    hgrid="ne30np4" npg="3" ver="cam6">atm/cam/chem/emis/historical_ne30pg3/emissions-cmip6_SOAGx1.5_biogenic_surface_1750_2015_ne30pg3_c20200629.nc</soag_bg_srf_file>
+<soag_bb_srf_file    hgrid="ne30np4" npg="3" ver="cam6">atm/cam/chem/emis/historical_ne30pg3/emissions-cmip6_SOAGx1.5_bb_surface_175001-201512_ne30pg3_c20191119.nc</soag_bb_srf_file>
+
+<BENZENE_an_srf_file  hgrid="ne30np4" npg="3" ver="cam6">atm/cam/chem/emis/historical_ne30pg3/emissions-cmip6_BENZENE_anthro_surface_175001-201412_ne30pg3_c20191118.nc</BENZENE_an_srf_file>
+<BENZENE_bb_srf_file  hgrid="ne30np4" npg="3" ver="cam6">atm/cam/chem/emis/historical_ne30pg3/emissions-cmip6_BENZENE_bb_surface_175001-201512_ne30pg3_c20191118.nc</BENZENE_bb_srf_file>
+<BIGALK_an_srf_file   hgrid="ne30np4" npg="3" ver="cam6">atm/cam/chem/emis/historical_ne30pg3/emissions-cmip6_BIGALK_anthro_surface_175001-201412_ne30pg3_c20191118.nc</BIGALK_an_srf_file>
+<BIGALK_bb_srf_file   hgrid="ne30np4" npg="3" ver="cam6">atm/cam/chem/emis/historical_ne30pg3/emissions-cmip6_BIGALK_bb_surface_175001-201512_ne30pg3_c20191118.nc</BIGALK_bb_srf_file>
+<BIGENE_an_srf_file   hgrid="ne30np4" npg="3" ver="cam6">atm/cam/chem/emis/historical_ne30pg3/emissions-cmip6_BIGENE_anthro_surface_175001-201412_ne30pg3_c20191118.nc</BIGENE_an_srf_file>
+<BIGENE_bb_srf_file   hgrid="ne30np4" npg="3" ver="cam6">atm/cam/chem/emis/historical_ne30pg3/emissions-cmip6_BIGENE_bb_surface_175001-201512_ne30pg3_c20191118.nc</BIGENE_bb_srf_file>
+<C2H2_an_srf_file     hgrid="ne30np4" npg="3" ver="cam6">atm/cam/chem/emis/historical_ne30pg3/emissions-cmip6_C2H2_anthro_surface_175001-201412_ne30pg3_c20191118.nc</C2H2_an_srf_file>
+<C2H2_bb_srf_file     hgrid="ne30np4" npg="3" ver="cam6">atm/cam/chem/emis/historical_ne30pg3/emissions-cmip6_C2H2_bb_surface_175001-201512_ne30pg3_c20191118.nc</C2H2_bb_srf_file>
+<C2H4_an_srf_file     hgrid="ne30np4" npg="3" ver="cam6">atm/cam/chem/emis/historical_ne30pg3/emissions-cmip6_C2H4_anthro_surface_175001-201412_ne30pg3_c20191118.nc</C2H4_an_srf_file>
+<C2H4_bb_srf_file     hgrid="ne30np4" npg="3" ver="cam6">atm/cam/chem/emis/historical_ne30pg3/emissions-cmip6_C2H4_bb_surface_175001-201512_ne30pg3_c20191118.nc</C2H4_bb_srf_file>
+<C2H4_ot_srf_file     hgrid="ne30np4" npg="3" ver="cam6">atm/cam/chem/emis/historical_ne30pg3/emissions-cmip6_C2H4_other_surface_1750_2015_ne30pg3_c20200630.nc</C2H4_ot_srf_file>
+<C2H5OH_an_srf_file   hgrid="ne30np4" npg="3" ver="cam6">atm/cam/chem/emis/historical_ne30pg3/emissions-cmip6_C2H5OH_anthro_surface_175001-201412_ne30pg3_c20191118.nc</C2H5OH_an_srf_file>
+<C2H5OH_bb_srf_file   hgrid="ne30np4" npg="3" ver="cam6">atm/cam/chem/emis/historical_ne30pg3/emissions-cmip6_C2H5OH_bb_surface_175001-201512_ne30pg3_c20191118.nc</C2H5OH_bb_srf_file>
+<C2H6_an_srf_file     hgrid="ne30np4" npg="3" ver="cam6">atm/cam/chem/emis/historical_ne30pg3/emissions-cmip6_C2H6_anthro_surface_175001-201412_ne30pg3_c20191118.nc</C2H6_an_srf_file>
+<C2H6_bb_srf_file     hgrid="ne30np4" npg="3" ver="cam6">atm/cam/chem/emis/historical_ne30pg3/emissions-cmip6_C2H6_bb_surface_175001-201512_ne30pg3_c20191118.nc</C2H6_bb_srf_file>
+<C2H6_ot_srf_file     hgrid="ne30np4" npg="3" ver="cam6">atm/cam/chem/emis/historical_ne30pg3/emissions-cmip6_C2H6_other_surface_1750_2015_ne30pg3_c20200630.nc</C2H6_ot_srf_file>
+<C3H6_an_srf_file     hgrid="ne30np4" npg="3" ver="cam6">atm/cam/chem/emis/historical_ne30pg3/emissions-cmip6_C3H6_anthro_surface_175001-201412_ne30pg3_c20191118.nc</C3H6_an_srf_file>
+<C3H6_bb_srf_file     hgrid="ne30np4" npg="3" ver="cam6">atm/cam/chem/emis/historical_ne30pg3/emissions-cmip6_C3H6_bb_surface_175001-201512_ne30pg3_c20191118.nc</C3H6_bb_srf_file>
+<C3H6_ot_srf_file     hgrid="ne30np4" npg="3" ver="cam6">atm/cam/chem/emis/historical_ne30pg3/emissions-cmip6_C3H6_other_surface_1750_2015_ne30pg3_c20200630.nc</C3H6_ot_srf_file>
+<C3H8_an_srf_file     hgrid="ne30np4" npg="3" ver="cam6">atm/cam/chem/emis/historical_ne30pg3/emissions-cmip6_C3H8_anthro_surface_175001-201412_ne30pg3_c20191118.nc</C3H8_an_srf_file>
+<C3H8_bb_srf_file     hgrid="ne30np4" npg="3" ver="cam6">atm/cam/chem/emis/historical_ne30pg3/emissions-cmip6_C3H8_bb_surface_175001-201512_ne30pg3_c20191118.nc</C3H8_bb_srf_file>
+<C3H8_ot_srf_file     hgrid="ne30np4" npg="3" ver="cam6">atm/cam/chem/emis/historical_ne30pg3/emissions-cmip6_C3H8_other_surface_1750_2015_ne30pg3_c20200630.nc</C3H8_ot_srf_file>
+<CH2O_an_srf_file     hgrid="ne30np4" npg="3" ver="cam6">atm/cam/chem/emis/historical_ne30pg3/emissions-cmip6_CH2O_anthro_surface_175001-201412_ne30pg3_c20191118.nc</CH2O_an_srf_file>
+<CH2O_bb_srf_file     hgrid="ne30np4" npg="3" ver="cam6">atm/cam/chem/emis/historical_ne30pg3/emissions-cmip6_CH2O_bb_surface_175001-201512_ne30pg3_c20191118.nc</CH2O_bb_srf_file>
+<CH3CHO_an_srf_file   hgrid="ne30np4" npg="3" ver="cam6">atm/cam/chem/emis/historical_ne30pg3/emissions-cmip6_CH3CHO_anthro_surface_175001-201412_ne30pg3_c20191118.nc</CH3CHO_an_srf_file>
+<CH3CHO_bb_srf_file   hgrid="ne30np4" npg="3" ver="cam6">atm/cam/chem/emis/historical_ne30pg3/emissions-cmip6_CH3CHO_bb_surface_175001-201512_ne30pg3_c20191118.nc</CH3CHO_bb_srf_file>
+<CH3CN_an_srf_file    hgrid="ne30np4" npg="3" ver="cam6">atm/cam/chem/emis/historical_ne30pg3/emissions-cmip6_CH3CN_anthro_surface_175001-201412_ne30pg3_c20191119.nc</CH3CN_an_srf_file>
+<CH3CN_bb_srf_file    hgrid="ne30np4" npg="3" ver="cam6">atm/cam/chem/emis/historical_ne30pg3/emissions-cmip6_CH3CN_bb_surface_175001-201512_ne30pg3_c20191119.nc</CH3CN_bb_srf_file>
+<CH3COCH3_an_srf_file hgrid="ne30np4" npg="3" ver="cam6">atm/cam/chem/emis/historical_ne30pg3/emissions-cmip6_CH3COCH3_anthro_surface_175001-201412_ne30pg3_c20191118.nc</CH3COCH3_an_srf_file>
+<CH3COCH3_bb_srf_file hgrid="ne30np4" npg="3" ver="cam6">atm/cam/chem/emis/historical_ne30pg3/emissions-cmip6_CH3COCH3_bb_surface_175001-201512_ne30pg3_c20191118.nc</CH3COCH3_bb_srf_file>
+<CH3COCHO_bb_srf_file hgrid="ne30np4" npg="3" ver="cam6">atm/cam/chem/emis/historical_ne30pg3/emissions-cmip6_CH3COCHO_bb_surface_175001-201512_ne30pg3_c20191118.nc</CH3COCHO_bb_srf_file>
+<CH3COOH_an_srf_file  hgrid="ne30np4" npg="3" ver="cam6">atm/cam/chem/emis/historical_ne30pg3/emissions-cmip6_CH3COOH_anthro_surface_175001-201412_ne30pg3_c20191118.nc</CH3COOH_an_srf_file>
+<CH3COOH_bb_srf_file  hgrid="ne30np4" npg="3" ver="cam6">atm/cam/chem/emis/historical_ne30pg3/emissions-cmip6_CH3COOH_bb_surface_175001-201512_ne30pg3_c20191118.nc</CH3COOH_bb_srf_file>
+<CH3OH_an_srf_file    hgrid="ne30np4" npg="3" ver="cam6">atm/cam/chem/emis/historical_ne30pg3/emissions-cmip6_CH3OH_anthro_surface_175001-201412_ne30pg3_c20191118.nc</CH3OH_an_srf_file>
+<CH3OH_bb_srf_file    hgrid="ne30np4" npg="3" ver="cam6">atm/cam/chem/emis/historical_ne30pg3/emissions-cmip6_CH3OH_bb_surface_175001-201512_ne30pg3_c20191118.nc</CH3OH_bb_srf_file>
+<CO_an_srf_file       hgrid="ne30np4" npg="3" ver="cam6">atm/cam/chem/emis/historical_ne30pg3/emissions-cmip6_CO_anthro_surface_175001-201412_ne30pg3_c20191118.nc</CO_an_srf_file>
+<CO_bb_srf_file       hgrid="ne30np4" npg="3" ver="cam6">atm/cam/chem/emis/historical_ne30pg3/emissions-cmip6_CO_bb_surface_175001-201512_ne30pg3_c20191118.nc</CO_bb_srf_file>
+<CO_ot_srf_file       hgrid="ne30np4" npg="3" ver="cam6">atm/cam/chem/emis/historical_ne30pg3/emissions-cmip6_CO_other_surface_1750_2015_ne30pg3_c20200630.nc</CO_ot_srf_file>
+<GLYALD_bb_srf_file   hgrid="ne30np4" npg="3" ver="cam6">atm/cam/chem/emis/historical_ne30pg3/emissions-cmip6_GLYALD_bb_surface_175001-201512_ne30pg3_c20191118.nc</GLYALD_bb_srf_file>
+<HCN_an_srf_file      hgrid="ne30np4" npg="3" ver="cam6">atm/cam/chem/emis/historical_ne30pg3/emissions-cmip6_HCN_anthro_surface_175001-201412_ne30pg3_c20191119.nc</HCN_an_srf_file>
+<HCN_bb_srf_file      hgrid="ne30np4" npg="3" ver="cam6">atm/cam/chem/emis/historical_ne30pg3/emissions-cmip6_HCN_bb_surface_175001-201512_ne30pg3_c20191119.nc</HCN_bb_srf_file>
+<HCOOH_an_srf_file    hgrid="ne30np4" npg="3" ver="cam6">atm/cam/chem/emis/historical_ne30pg3/emissions-cmip6_HCOOH_anthro_surface_175001-201412_ne30pg3_c20191118.nc</HCOOH_an_srf_file>
+<HCOOH_bb_srf_file    hgrid="ne30np4" npg="3" ver="cam6">atm/cam/chem/emis/historical_ne30pg3/emissions-cmip6_HCOOH_bb_surface_175001-201512_ne30pg3_c20191118.nc</HCOOH_bb_srf_file>
+<ISOP_bb_srf_file     hgrid="ne30np4" npg="3" ver="cam6">atm/cam/chem/emis/historical_ne30pg3/emissions-cmip6_ISOP_bb_surface_175001-201512_ne30pg3_c20191118.nc</ISOP_bb_srf_file>
+<IVOC_an_srf_file     hgrid="ne30np4" npg="3" ver="cam6">atm/cam/chem/emis/historical_ne30pg3/emissions-cmip6_IVOC_anthro_surface_175001-201412_ne30pg3_c20200103.nc</IVOC_an_srf_file>
+<IVOC_bb_srf_file     hgrid="ne30np4" npg="3" ver="cam6">atm/cam/chem/emis/historical_ne30pg3/emissions-cmip6_IVOC_bb_surface_175001-201512_ne30pg3_c20191119.nc</IVOC_bb_srf_file>
+<MEK_an_srf_file      hgrid="ne30np4" npg="3" ver="cam6">atm/cam/chem/emis/historical_ne30pg3/emissions-cmip6_MEK_anthro_surface_175001-201412_ne30pg3_c20191118.nc</MEK_an_srf_file>
+<MEK_bb_srf_file      hgrid="ne30np4" npg="3" ver="cam6">atm/cam/chem/emis/historical_ne30pg3/emissions-cmip6_MEK_bb_surface_175001-201512_ne30pg3_c20191118.nc</MEK_bb_srf_file>
+<MTERP_bb_srf_file    hgrid="ne30np4" npg="3" ver="cam6">atm/cam/chem/emis/historical_ne30pg3/emissions-cmip6_MTERP_bb_surface_175001-201512_ne30pg3_c20191118.nc</MTERP_bb_srf_file>
+<NH3_an_srf_file      hgrid="ne30np4" npg="3" ver="cam6">atm/cam/chem/emis/historical_ne30pg3/emissions-cmip6_NH3_anthro_surface_175001-201412_ne30pg3_c20191118.nc</NH3_an_srf_file>
+<NH3_bb_srf_file      hgrid="ne30np4" npg="3" ver="cam6">atm/cam/chem/emis/historical_ne30pg3/emissions-cmip6_NH3_bb_surface_175001-201512_ne30pg3_c20191118.nc</NH3_bb_srf_file>
+<NH3_ot_srf_file      hgrid="ne30np4" npg="3" ver="cam6">atm/cam/chem/emis/historical_ne30pg3/emissions-cmip6_NH3_other_surface_1750_2015_ne30pg3_c20200531.nc</NH3_ot_srf_file>
+<NO_an_srf_file       hgrid="ne30np4" npg="3" ver="cam6">atm/cam/chem/emis/historical_ne30pg3/emissions-cmip6_NOx_anthro_surface_175001-201412_ne30pg3_c20191118.nc</NO_an_srf_file>
+<NO_bb_srf_file       hgrid="ne30np4" npg="3" ver="cam6">atm/cam/chem/emis/historical_ne30pg3/emissions-cmip6_NOx_bb_surface_175001-201512_ne30pg3_c20191118.nc</NO_bb_srf_file>
+<NO_ot_srf_file       hgrid="ne30np4" npg="3" ver="cam6">atm/cam/chem/emis/historical_ne30pg3/emissions-cmip6_NO_other_surface_1750_2015_ne30pg3_c20200523.nc</NO_ot_srf_file>
+<SVOC_an_srf_file     hgrid="ne30np4" npg="3" ver="cam6">atm/cam/chem/emis/historical_ne30pg3/emissions-cmip6_SVOC_anthro_surface_175001-201412_ne30pg3_c20200103.nc</SVOC_an_srf_file>
+<SVOC_bb_srf_file     hgrid="ne30np4" npg="3" ver="cam6">atm/cam/chem/emis/historical_ne30pg3/emissions-cmip6_SVOC_bb_surface_175001-201512_ne30pg3_c20191119.nc</SVOC_bb_srf_file>
+<TOLUENE_an_srf_file  hgrid="ne30np4" npg="3" ver="cam6">atm/cam/chem/emis/historical_ne30pg3/emissions-cmip6_TOLUENE_anthro_surface_175001-201412_ne30pg3_c20191118.nc</TOLUENE_an_srf_file>
+<TOLUENE_bb_srf_file  hgrid="ne30np4" npg="3" ver="cam6">atm/cam/chem/emis/historical_ne30pg3/emissions-cmip6_TOLUENE_bb_surface_175001-201512_ne30pg3_c20191118.nc</TOLUENE_bb_srf_file>
+<XYLENES_an_srf_file  hgrid="ne30np4" npg="3" ver="cam6">atm/cam/chem/emis/historical_ne30pg3/emissions-cmip6_XYLENES_anthro_surface_175001-201412_ne30pg3_c20191118.nc</XYLENES_an_srf_file>
+<XYLENES_bb_srf_file  hgrid="ne30np4" npg="3" ver="cam6">atm/cam/chem/emis/historical_ne30pg3/emissions-cmip6_XYLENES_bb_surface_175001-201512_ne30pg3_c20191118.nc</XYLENES_bb_srf_file>
+
+<E90_srf_file         hgrid="ne30np4" npg="3" ver="cam6">atm/cam/chem/emis/historical_ne30pg3/emissions_E90global_surface_1750_2015_ne30pg3_c20200630.nc</E90_srf_file>
+
+<so2_cv_ext_file      hgrid="ne30np4" npg="3" ver="cam6">atm/cam/chem/emis/historical_ne30pg3/emissions-cmip6_SO2_contvolcano_vertical_850-5000_ne30pg3_c20200125.nc</so2_cv_ext_file>
+<so4_a1_cv_ext_file   hgrid="ne30np4" npg="3" ver="cam6">atm/cam/chem/emis/historical_ne30pg3/emissions-cmip6_so4_a1_contvolcano_vertical_850-5000_ne30pg3_c20200125.nc</so4_a1_cv_ext_file>
+<num_a1_cv_ext_file   hgrid="ne30np4" npg="3" ver="cam6">atm/cam/chem/emis/historical_ne30pg3/emissions-cmip6_num_a1_so4_contvolcano_vertical_850-5000_ne30pg3_c20200125.nc</num_a1_cv_ext_file>
+<so4_a2_cv_ext_file   hgrid="ne30np4" npg="3" ver="cam6">atm/cam/chem/emis/historical_ne30pg3/emissions-cmip6_so4_a2_contvolcano_vertical_850-5000_ne30pg3_c20200125.nc</so4_a2_cv_ext_file>
+<num_a2_cv_ext_file   hgrid="ne30np4" npg="3" ver="cam6">atm/cam/chem/emis/historical_ne30pg3/emissions-cmip6_num_a2_so4_contvolcano_vertical_850-5000_ne30pg3_c20200125.nc</num_a2_cv_ext_file>
+<so4_a1_an_ext_file   hgrid="ne30np4" npg="3" ver="cam6">atm/cam/chem/emis/historical_ne30pg3/emissions-cmip6_so4_a1_anthro-ene_vertical_mol_175001-201412_ne30pg3_c20200103.nc</so4_a1_an_ext_file>
+<num_a1_an_ext_file   hgrid="ne30np4" npg="3" ver="cam6">atm/cam/chem/emis/historical_ne30pg3/emissions-cmip6_num_so4_a1_anthro-ene_vertical_mol_175001-201412_ne30pg3_c20200103.nc</num_a1_an_ext_file>
+
+<!-- ne30 pg2 -->
+
+<dms_ot_srf_file     hgrid="ne30np4" npg="2" ver="cam6">atm/cam/chem/emis/historical_ne30pg2/emissions-cmip6_DMS_other_surface_1750_2015_ne30pg2_c20200630.nc</dms_ot_srf_file>
+<dms_bb_srf_file     hgrid="ne30np4" npg="2" ver="cam6">atm/cam/chem/emis/historical_ne30pg2/emissions-cmip6_DMS_bb_surface_175001-201512_ne30pg2_c20200630.nc</dms_bb_srf_file>
+<so2_ag_sh_file      hgrid="ne30np4" npg="2" ver="cam6">atm/cam/chem/emis/historical_ne30pg2/emissions-cmip6_SO2_anthro-ag-ship-res_surface_mol_175001-201412_ne30pg2_c20200630.nc</so2_ag_sh_file>
+<so2_an_srf_file     hgrid="ne30np4" npg="2" ver="cam6">atm/cam/chem/emis/historical_ne30pg2/emissions-cmip6_SO2_anthro-ene_surface_mol_175001-201412_ne30pg2_c20200630.nc</so2_an_srf_file>
+<so2_bb_srf_file     hgrid="ne30np4" npg="2" ver="cam6">atm/cam/chem/emis/historical_ne30pg2/emissions-cmip6_SO2_bb_surface_175001-201512_ne30pg2_c20200630.nc</so2_bb_srf_file>
+<so4_a1_an_srf_file  hgrid="ne30np4" npg="2" ver="cam6">atm/cam/chem/emis/historical_ne30pg2/emissions-cmip6_so4_a1_anthro-ag-ship_surface_mol_175001-201412_ne30pg2_c20200630.nc</so4_a1_an_srf_file>
+<so4_a1_bb_srf_file  hgrid="ne30np4" npg="2" ver="cam6">atm/cam/chem/emis/historical_ne30pg2/emissions-cmip6_so4_a1_bb_surface_175001-201512_ne30pg2_c20200630.nc</so4_a1_bb_srf_file>
+<so4_a2_an_srf_file  hgrid="ne30np4" npg="2" ver="cam6">atm/cam/chem/emis/historical_ne30pg2/emissions-cmip6_so4_a2_anthro-res_surface_mol_175001-201412_ne30pg2_c20200630.nc</so4_a2_an_srf_file>
+<num_a1_sh_srf_file  hgrid="ne30np4" npg="2" ver="cam6">atm/cam/chem/emis/historical_ne30pg2/emissions-cmip6_num_so4_a1_anthro-ag-ship_surface_mol_175001-201412_ne30pg2_c20200630.nc</num_a1_sh_srf_file>
+<num_a2_an_srf_file  hgrid="ne30np4" npg="2" ver="cam6">atm/cam/chem/emis/historical_ne30pg2/emissions-cmip6_num_so4_a2_anthro-res_surface_mol_175001-201412_ne30pg2_c20200630.nc</num_a2_an_srf_file>
+<bc_a4_an_srf_file   hgrid="ne30np4" npg="2" ver="cam6">atm/cam/chem/emis/historical_ne30pg2/emissions-cmip6_bc_a4_anthro_surface_175001-201412_ne30pg2_c20200630.nc</bc_a4_an_srf_file>
+<num_a4_bc_srf_file  hgrid="ne30np4" npg="2" ver="cam6">atm/cam/chem/emis/historical_ne30pg2/emissions-cmip6_num_bc_a4_anthro_surface_175001-201412_ne30pg2_c20200630.nc</num_a4_bc_srf_file>
+<pom_a4_an_srf_file  hgrid="ne30np4" npg="2" ver="cam6">atm/cam/chem/emis/historical_ne30pg2/emissions-cmip6_pom_a4_anthro_surface_175001-201412_ne30pg2_c20200630.nc</pom_a4_an_srf_file>
+<num_a4_oc_srf_file  hgrid="ne30np4" npg="2" ver="cam6">atm/cam/chem/emis/historical_ne30pg2/emissions-cmip6_num_pom_a4_anthro_surface_175001-201412_ne30pg2_c20200630.nc</num_a4_oc_srf_file>
+<num_a1_bb_srf_file  hgrid="ne30np4" npg="2" ver="cam6">atm/cam/chem/emis/historical_ne30pg2/emissions-cmip6_num_so4_a1_bb_surface_175001-201512_ne30pg2_c20200630.nc</num_a1_bb_srf_file>
+<bc_a4_bb_srf_file   hgrid="ne30np4" npg="2" ver="cam6">atm/cam/chem/emis/historical_ne30pg2/emissions-cmip6_bc_a4_bb_surface_175001-201512_ne30pg2_c20200630.nc</bc_a4_bb_srf_file>
+<num_a4_bb_srf_file  hgrid="ne30np4" npg="2" ver="cam6">atm/cam/chem/emis/historical_ne30pg2/emissions-cmip6_num_bc_a4_bb_surface_175001-201512_ne30pg2_c20200630.nc</num_a4_bb_srf_file>
+<pom_a4_bb_srf_file  hgrid="ne30np4" npg="2" ver="cam6">atm/cam/chem/emis/historical_ne30pg2/emissions-cmip6_pom_a4_bb_surface_175001-201512_ne30pg2_c20200630.nc</pom_a4_bb_srf_file>
+<num_pom_bb_srf_file hgrid="ne30np4" npg="2" ver="cam6">atm/cam/chem/emis/historical_ne30pg2/emissions-cmip6_num_pom_a4_bb_surface_175001-201512_ne30pg2_c20200630.nc</num_pom_bb_srf_file>
+<soag_an_srf_file    hgrid="ne30np4" npg="2" ver="cam6">atm/cam/chem/emis/historical_ne30pg2/emissions-cmip6_SOAGx1.5_anthro_surface_175001-201412_ne30pg2_c20200701.nc</soag_an_srf_file>
+<soag_bg_srf_file    hgrid="ne30np4" npg="2" ver="cam6">atm/cam/chem/emis/historical_ne30pg2/emissions-cmip6_SOAGx1.5_biogenic_surface_1750_2015_ne30pg2_c20200629.nc</soag_bg_srf_file>
+<soag_bb_srf_file    hgrid="ne30np4" npg="2" ver="cam6">atm/cam/chem/emis/historical_ne30pg2/emissions-cmip6_SOAGx1.5_bb_surface_175001-201512_ne30pg2_c20200630.nc</soag_bb_srf_file>
+
+<BENZENE_an_srf_file  hgrid="ne30np4" npg="2" ver="cam6">atm/cam/chem/emis/historical_ne30pg2/emissions-cmip6_BENZENE_anthro_surface_175001-201412_ne30pg2_c20200701.nc</BENZENE_an_srf_file>
+<BENZENE_bb_srf_file  hgrid="ne30np4" npg="2" ver="cam6">atm/cam/chem/emis/historical_ne30pg2/emissions-cmip6_BENZENE_bb_surface_175001-201512_ne30pg2_c20200630.nc</BENZENE_bb_srf_file>
+<BIGALK_an_srf_file   hgrid="ne30np4" npg="2" ver="cam6">atm/cam/chem/emis/historical_ne30pg2/emissions-cmip6_BIGALK_anthro_surface_175001-201412_ne30pg2_c20200701.nc</BIGALK_an_srf_file>
+<BIGALK_bb_srf_file   hgrid="ne30np4" npg="2" ver="cam6">atm/cam/chem/emis/historical_ne30pg2/emissions-cmip6_BIGALK_bb_surface_175001-201512_ne30pg2_c20200630.nc</BIGALK_bb_srf_file>
+<BIGENE_an_srf_file   hgrid="ne30np4" npg="2" ver="cam6">atm/cam/chem/emis/historical_ne30pg2/emissions-cmip6_BIGENE_anthro_surface_175001-201412_ne30pg2_c20200701.nc</BIGENE_an_srf_file>
+<BIGENE_bb_srf_file   hgrid="ne30np4" npg="2" ver="cam6">atm/cam/chem/emis/historical_ne30pg2/emissions-cmip6_BIGENE_bb_surface_175001-201512_ne30pg2_c20200630.nc</BIGENE_bb_srf_file>
+<C2H2_an_srf_file     hgrid="ne30np4" npg="2" ver="cam6">atm/cam/chem/emis/historical_ne30pg2/emissions-cmip6_C2H2_anthro_surface_175001-201412_ne30pg2_c20200701.nc</C2H2_an_srf_file>
+<C2H2_bb_srf_file     hgrid="ne30np4" npg="2" ver="cam6">atm/cam/chem/emis/historical_ne30pg2/emissions-cmip6_C2H2_bb_surface_175001-201512_ne30pg2_c20200630.nc</C2H2_bb_srf_file>
+<C2H4_an_srf_file     hgrid="ne30np4" npg="2" ver="cam6">atm/cam/chem/emis/historical_ne30pg2/emissions-cmip6_C2H4_anthro_surface_175001-201412_ne30pg2_c20200701.nc</C2H4_an_srf_file>
+<C2H4_bb_srf_file     hgrid="ne30np4" npg="2" ver="cam6">atm/cam/chem/emis/historical_ne30pg2/emissions-cmip6_C2H4_bb_surface_175001-201512_ne30pg2_c20200630.nc</C2H4_bb_srf_file>
+<C2H4_ot_srf_file     hgrid="ne30np4" npg="2" ver="cam6">atm/cam/chem/emis/historical_ne30pg2/emissions-cmip6_C2H4_other_surface_1750_2015_ne30pg2_c20200630.nc</C2H4_ot_srf_file>
+<C2H5OH_an_srf_file   hgrid="ne30np4" npg="2" ver="cam6">atm/cam/chem/emis/historical_ne30pg2/emissions-cmip6_C2H5OH_anthro_surface_175001-201412_ne30pg2_c20200701.nc</C2H5OH_an_srf_file>
+<C2H5OH_bb_srf_file   hgrid="ne30np4" npg="2" ver="cam6">atm/cam/chem/emis/historical_ne30pg2/emissions-cmip6_C2H5OH_bb_surface_175001-201512_ne30pg2_c20200630.nc</C2H5OH_bb_srf_file>
+<C2H6_an_srf_file     hgrid="ne30np4" npg="2" ver="cam6">atm/cam/chem/emis/historical_ne30pg2/emissions-cmip6_C2H6_anthro_surface_175001-201412_ne30pg2_c20200701.nc</C2H6_an_srf_file>
+<C2H6_bb_srf_file     hgrid="ne30np4" npg="2" ver="cam6">atm/cam/chem/emis/historical_ne30pg2/emissions-cmip6_C2H6_bb_surface_175001-201512_ne30pg2_c20200630.nc</C2H6_bb_srf_file>
+<C2H6_ot_srf_file     hgrid="ne30np4" npg="2" ver="cam6">atm/cam/chem/emis/historical_ne30pg2/emissions-cmip6_C2H6_other_surface_1750_2015_ne30pg2_c20200630.nc</C2H6_ot_srf_file>
+<C3H6_an_srf_file     hgrid="ne30np4" npg="2" ver="cam6">atm/cam/chem/emis/historical_ne30pg2/emissions-cmip6_C3H6_anthro_surface_175001-201412_ne30pg2_c20200701.nc</C3H6_an_srf_file>
+<C3H6_bb_srf_file     hgrid="ne30np4" npg="2" ver="cam6">atm/cam/chem/emis/historical_ne30pg2/emissions-cmip6_C3H6_bb_surface_175001-201512_ne30pg2_c20200630.nc</C3H6_bb_srf_file>
+<C3H6_ot_srf_file     hgrid="ne30np4" npg="2" ver="cam6">atm/cam/chem/emis/historical_ne30pg2/emissions-cmip6_C3H6_other_surface_1750_2015_ne30pg2_c20200630.nc</C3H6_ot_srf_file>
+<C3H8_an_srf_file     hgrid="ne30np4" npg="2" ver="cam6">atm/cam/chem/emis/historical_ne30pg2/emissions-cmip6_C3H8_anthro_surface_175001-201412_ne30pg2_c20200701.nc</C3H8_an_srf_file>
+<C3H8_bb_srf_file     hgrid="ne30np4" npg="2" ver="cam6">atm/cam/chem/emis/historical_ne30pg2/emissions-cmip6_C3H8_bb_surface_175001-201512_ne30pg2_c20200630.nc</C3H8_bb_srf_file>
+<C3H8_ot_srf_file     hgrid="ne30np4" npg="2" ver="cam6">atm/cam/chem/emis/historical_ne30pg2/emissions-cmip6_C3H8_other_surface_1750_2015_ne30pg2_c20200630.nc</C3H8_ot_srf_file>
+<CH2O_an_srf_file     hgrid="ne30np4" npg="2" ver="cam6">atm/cam/chem/emis/historical_ne30pg2/emissions-cmip6_CH2O_anthro_surface_175001-201412_ne30pg2_c20200701.nc</CH2O_an_srf_file>
+<CH2O_bb_srf_file     hgrid="ne30np4" npg="2" ver="cam6">atm/cam/chem/emis/historical_ne30pg2/emissions-cmip6_CH2O_bb_surface_175001-201512_ne30pg2_c20200630.nc</CH2O_bb_srf_file>
+<CH3CHO_an_srf_file   hgrid="ne30np4" npg="2" ver="cam6">atm/cam/chem/emis/historical_ne30pg2/emissions-cmip6_CH3CHO_anthro_surface_175001-201412_ne30pg2_c20200701.nc</CH3CHO_an_srf_file>
+<CH3CHO_bb_srf_file   hgrid="ne30np4" npg="2" ver="cam6">atm/cam/chem/emis/historical_ne30pg2/emissions-cmip6_CH3CHO_bb_surface_175001-201512_ne30pg2_c20200630.nc</CH3CHO_bb_srf_file>
+<CH3CN_an_srf_file    hgrid="ne30np4" npg="2" ver="cam6">atm/cam/chem/emis/historical_ne30pg2/emissions-cmip6_CH3CN_anthro_surface_175001-201412_ne30pg2_c20200701.nc</CH3CN_an_srf_file>
+<CH3CN_bb_srf_file    hgrid="ne30np4" npg="2" ver="cam6">atm/cam/chem/emis/historical_ne30pg2/emissions-cmip6_CH3CN_bb_surface_175001-201512_ne30pg2_c20200630.nc</CH3CN_bb_srf_file>
+<CH3COCH3_an_srf_file hgrid="ne30np4" npg="2" ver="cam6">atm/cam/chem/emis/historical_ne30pg2/emissions-cmip6_CH3COCH3_anthro_surface_175001-201412_ne30pg2_c20200701.nc</CH3COCH3_an_srf_file>
+<CH3COCH3_bb_srf_file hgrid="ne30np4" npg="2" ver="cam6">atm/cam/chem/emis/historical_ne30pg2/emissions-cmip6_CH3COCH3_bb_surface_175001-201512_ne30pg2_c20200630.nc</CH3COCH3_bb_srf_file>
+<CH3COCHO_bb_srf_file hgrid="ne30np4" npg="2" ver="cam6">atm/cam/chem/emis/historical_ne30pg2/emissions-cmip6_CH3COCHO_bb_surface_175001-201512_ne30pg2_c20200630.nc</CH3COCHO_bb_srf_file>
+<CH3COOH_an_srf_file  hgrid="ne30np4" npg="2" ver="cam6">atm/cam/chem/emis/historical_ne30pg2/emissions-cmip6_CH3COOH_anthro_surface_175001-201412_ne30pg2_c20200701.nc</CH3COOH_an_srf_file>
+<CH3COOH_bb_srf_file  hgrid="ne30np4" npg="2" ver="cam6">atm/cam/chem/emis/historical_ne30pg2/emissions-cmip6_CH3COOH_bb_surface_175001-201512_ne30pg2_c20200630.nc</CH3COOH_bb_srf_file>
+<CH3OH_an_srf_file    hgrid="ne30np4" npg="2" ver="cam6">atm/cam/chem/emis/historical_ne30pg2/emissions-cmip6_CH3OH_anthro_surface_175001-201412_ne30pg2_c20200701.nc</CH3OH_an_srf_file>
+<CH3OH_bb_srf_file    hgrid="ne30np4" npg="2" ver="cam6">atm/cam/chem/emis/historical_ne30pg2/emissions-cmip6_CH3OH_bb_surface_175001-201512_ne30pg2_c20200630.nc</CH3OH_bb_srf_file>
+<CO_an_srf_file       hgrid="ne30np4" npg="2" ver="cam6">atm/cam/chem/emis/historical_ne30pg2/emissions-cmip6_CO_anthro_surface_175001-201412_ne30pg2_c20200630.nc</CO_an_srf_file>
+<CO_bb_srf_file       hgrid="ne30np4" npg="2" ver="cam6">atm/cam/chem/emis/historical_ne30pg2/emissions-cmip6_CO_bb_surface_175001-201512_ne30pg2_c20200630.nc</CO_bb_srf_file>
+<CO_ot_srf_file       hgrid="ne30np4" npg="2" ver="cam6">atm/cam/chem/emis/historical_ne30pg2/emissions-cmip6_CO_other_surface_1750_2015_ne30pg2_c20200630.nc</CO_ot_srf_file>
+<GLYALD_bb_srf_file   hgrid="ne30np4" npg="2" ver="cam6">atm/cam/chem/emis/historical_ne30pg2/emissions-cmip6_GLYALD_bb_surface_175001-201512_ne30pg2_c20200630.nc</GLYALD_bb_srf_file>
+<HCN_an_srf_file      hgrid="ne30np4" npg="2" ver="cam6">atm/cam/chem/emis/historical_ne30pg2/emissions-cmip6_HCN_anthro_surface_175001-201412_ne30pg2_c20200701.nc</HCN_an_srf_file>
+<HCN_bb_srf_file      hgrid="ne30np4" npg="2" ver="cam6">atm/cam/chem/emis/historical_ne30pg2/emissions-cmip6_HCN_bb_surface_175001-201512_ne30pg2_c20200630.nc</HCN_bb_srf_file>
+<HCOOH_an_srf_file    hgrid="ne30np4" npg="2" ver="cam6">atm/cam/chem/emis/historical_ne30pg2/emissions-cmip6_HCOOH_anthro_surface_175001-201412_ne30pg2_c20200701.nc</HCOOH_an_srf_file>
+<HCOOH_bb_srf_file    hgrid="ne30np4" npg="2" ver="cam6">atm/cam/chem/emis/historical_ne30pg2/emissions-cmip6_HCOOH_bb_surface_175001-201512_ne30pg2_c20200630.nc</HCOOH_bb_srf_file>
+<ISOP_bb_srf_file     hgrid="ne30np4" npg="2" ver="cam6">atm/cam/chem/emis/historical_ne30pg2/emissions-cmip6_ISOP_bb_surface_175001-201512_ne30pg2_c20200630.nc</ISOP_bb_srf_file>
+<IVOC_an_srf_file     hgrid="ne30np4" npg="2" ver="cam6">atm/cam/chem/emis/historical_ne30pg2/emissions-cmip6_IVOC_anthro_surface_175001-201412_ne30pg2_c20200701.nc</IVOC_an_srf_file>
+<IVOC_bb_srf_file     hgrid="ne30np4" npg="2" ver="cam6">atm/cam/chem/emis/historical_ne30pg2/emissions-cmip6_IVOC_bb_surface_175001-201512_ne30pg2_c20200630.nc</IVOC_bb_srf_file>
+<MEK_an_srf_file      hgrid="ne30np4" npg="2" ver="cam6">atm/cam/chem/emis/historical_ne30pg2/emissions-cmip6_MEK_anthro_surface_175001-201412_ne30pg2_c20200701.nc</MEK_an_srf_file>
+<MEK_bb_srf_file      hgrid="ne30np4" npg="2" ver="cam6">atm/cam/chem/emis/historical_ne30pg2/emissions-cmip6_MEK_bb_surface_175001-201512_ne30pg2_c20200630.nc</MEK_bb_srf_file>
+<MTERP_bb_srf_file    hgrid="ne30np4" npg="2" ver="cam6">atm/cam/chem/emis/historical_ne30pg2/emissions-cmip6_MTERP_bb_surface_175001-201512_ne30pg2_c20200630.nc</MTERP_bb_srf_file>
+<NH3_an_srf_file      hgrid="ne30np4" npg="2" ver="cam6">atm/cam/chem/emis/historical_ne30pg2/emissions-cmip6_NH3_anthro_surface_175001-201412_ne30pg2_c20200630.nc</NH3_an_srf_file>
+<NH3_bb_srf_file      hgrid="ne30np4" npg="2" ver="cam6">atm/cam/chem/emis/historical_ne30pg2/emissions-cmip6_NH3_bb_surface_175001-201512_ne30pg2_c20200630.nc</NH3_bb_srf_file>
+<NH3_ot_srf_file      hgrid="ne30np4" npg="2" ver="cam6">atm/cam/chem/emis/historical_ne30pg2/emissions-cmip6_NH3_other_surface_1750_2015_ne30pg2_c20200630.nc</NH3_ot_srf_file>
+<NO_an_srf_file       hgrid="ne30np4" npg="2" ver="cam6">atm/cam/chem/emis/historical_ne30pg2/emissions-cmip6_NOx_anthro_surface_175001-201412_ne30pg2_c20200630.nc</NO_an_srf_file>
+<NO_bb_srf_file       hgrid="ne30np4" npg="2" ver="cam6">atm/cam/chem/emis/historical_ne30pg2/emissions-cmip6_NOx_bb_surface_175001-201512_ne30pg2_c20200701.nc</NO_bb_srf_file>
+<NO_ot_srf_file       hgrid="ne30np4" npg="2" ver="cam6">atm/cam/chem/emis/historical_ne30pg2/emissions-cmip6_NO_other_surface_1750_2015_ne30pg2_c20200630.nc</NO_ot_srf_file>
+<SVOC_an_srf_file     hgrid="ne30np4" npg="2" ver="cam6">atm/cam/chem/emis/historical_ne30pg2/emissions-cmip6_SVOC_anthro_surface_175001-201412_ne30pg2_c20200701.nc</SVOC_an_srf_file>
+<SVOC_bb_srf_file     hgrid="ne30np4" npg="2" ver="cam6">atm/cam/chem/emis/historical_ne30pg2/emissions-cmip6_SVOC_bb_surface_175001-201512_ne30pg2_c20200630.nc</SVOC_bb_srf_file>
+<TOLUENE_an_srf_file  hgrid="ne30np4" npg="2" ver="cam6">atm/cam/chem/emis/historical_ne30pg2/emissions-cmip6_TOLUENE_anthro_surface_175001-201412_ne30pg2_c20200701.nc</TOLUENE_an_srf_file>
+<TOLUENE_bb_srf_file  hgrid="ne30np4" npg="2" ver="cam6">atm/cam/chem/emis/historical_ne30pg2/emissions-cmip6_TOLUENE_bb_surface_175001-201512_ne30pg2_c20200630.nc</TOLUENE_bb_srf_file>
+<XYLENES_an_srf_file  hgrid="ne30np4" npg="2" ver="cam6">atm/cam/chem/emis/historical_ne30pg2/emissions-cmip6_XYLENES_anthro_surface_175001-201412_ne30pg2_c20200701.nc</XYLENES_an_srf_file>
+<XYLENES_bb_srf_file  hgrid="ne30np4" npg="2" ver="cam6">atm/cam/chem/emis/historical_ne30pg2/emissions-cmip6_XYLENES_bb_surface_175001-201512_ne30pg2_c20200630.nc</XYLENES_bb_srf_file>
+
+<E90_srf_file         hgrid="ne30np4" npg="2" ver="cam6">atm/cam/chem/emis/historical_ne30pg2/emissions_E90global_surface_1750_2015_ne30pg2_c20200630.nc</E90_srf_file>
+
+<so2_cv_ext_file      hgrid="ne30np4" npg="2" ver="cam6">atm/cam/chem/emis/historical_ne30pg2/emissions-cmip6_SO2_contvolcano_vertical_850-5000_ne30pg2_c20200701.nc</so2_cv_ext_file>
+<so4_a1_cv_ext_file   hgrid="ne30np4" npg="2" ver="cam6">atm/cam/chem/emis/historical_ne30pg2/emissions-cmip6_so4_a1_contvolcano_vertical_850-5000_ne30pg2_c20200701.nc</so4_a1_cv_ext_file>
+<num_a1_cv_ext_file   hgrid="ne30np4" npg="2" ver="cam6">atm/cam/chem/emis/historical_ne30pg2/emissions-cmip6_num_a1_so4_contvolcano_vertical_850-5000_ne30pg2_c20200701.nc</num_a1_cv_ext_file>
+<so4_a2_cv_ext_file   hgrid="ne30np4" npg="2" ver="cam6">atm/cam/chem/emis/historical_ne30pg2/emissions-cmip6_so4_a2_contvolcano_vertical_850-5000_ne30pg2_c20200701.nc</so4_a2_cv_ext_file>
+<num_a2_cv_ext_file   hgrid="ne30np4" npg="2" ver="cam6">atm/cam/chem/emis/historical_ne30pg2/emissions-cmip6_num_a2_so4_contvolcano_vertical_850-5000_ne30pg2_c20200701.nc</num_a2_cv_ext_file>
+<so4_a1_an_ext_file   hgrid="ne30np4" npg="2" ver="cam6">atm/cam/chem/emis/historical_ne30pg2/emissions-cmip6_so4_a1_anthro-ene_vertical_mol_175001-201412_ne30pg2_c20200630.nc</so4_a1_an_ext_file>
+<num_a1_an_ext_file   hgrid="ne30np4" npg="2" ver="cam6">atm/cam/chem/emis/historical_ne30pg2/emissions-cmip6_num_so4_a1_anthro-ene_vertical_mol_175001-201412_ne30pg2_c20200630.nc</num_a1_an_ext_file>
 
 <!-- CONUS -->
 


### PR DESCRIPTION
        modified:   bld/namelist_files/namelist_defaults_cam.xml

closes #161 