### PR TITLE
cam6_2_038: Use cesm2 2 alph06c externals

### DIFF
--- a/Externals.cfg
+++ b/Externals.cfg
@@ -24,7 +24,6 @@ externals = Externals_CISM.cfg
 required = True
 
 [clm]
-#     Need to use a branch tag for ctsm to support experimental CAM-SE grids.
 tag = ctsm1.0.dev105
 protocol = git
 repo_url = https://github.com/ESCOMP/ctsm

--- a/Externals.cfg
+++ b/Externals.cfg
@@ -9,7 +9,7 @@ local_path = components/cice
 required = True
 
 [cime]
-tag = cime5.8.26
+tag = cime5.8.28
 protocol = git
 repo_url = https://github.com/ESMCI/cime
 local_path = cime
@@ -25,9 +25,9 @@ required = True
 
 [clm]
 #     Need to use a branch tag for ctsm to support experimental CAM-SE grids.
-tag = ctsm1.0.dev086.se_grids.n02
+tag = ctsm1.0.dev105
 protocol = git
-repo_url = https://github.com/fischer-ncar/ctsm
+repo_url = https://github.com/ESCOMP/ctsm
 local_path = components/clm
 externals = Externals_CLM.cfg
 required = True

--- a/Externals.cfg
+++ b/Externals.cfg
@@ -2,7 +2,7 @@
 schema_version = 1.0.0
 
 [cice]
-tag = cice5_20191223
+tag = cice5_20200430
 protocol = git
 repo_url = https://github.com/ESCOMP/CESM_CICE5
 local_path = components/cice


### PR DESCRIPTION
This update is to bring in the answer changes for CTSM dev 105 in a non-code changing tag.  Note that FXHIST will be broken until dev106 is brought in.

Closes #173 