### PR TITLE
cam6_2_042: Update clm external to ctsm1.0.dev107; fix input data issue #175

### DIFF
--- a/Externals.cfg
+++ b/Externals.cfg
@@ -24,7 +24,7 @@ externals = Externals_CISM.cfg
 required = True
 
 [clm]
-tag = ctsm1.0.dev105
+tag = ctsm1.0.dev107
 protocol = git
 repo_url = https://github.com/ESCOMP/ctsm
 local_path = components/clm
@@ -35,7 +35,7 @@ required = True
 tag = mosart1_0_36
 protocol = git
 repo_url = https://github.com/ESCOMP/mosart
-local_path = components/mosart 
+local_path = components/mosart
 required = True
 
 [rtm]
@@ -58,4 +58,3 @@ local_path = .
 protocol = externals_only
 externals = Externals_CAM.cfg
 required = True
-

--- a/src/chemistry/utils/input_data_utils.F90
+++ b/src/chemistry/utils/input_data_utils.F90
@@ -13,7 +13,7 @@ module input_data_utils
   use pio,            only : PIO_NOWRITE, PIO_BCAST_ERROR, PIO_INTERNAL_ERROR, PIO_NOERR
   use time_manager,   only : timemgr_get_calendar_cf, set_time_float_from_date, get_curr_date
   use spmd_utils,     only : masterproc
-  
+
   implicit none
 
   private
@@ -134,7 +134,7 @@ contains
        ! check the calendar attribute - must match model calendar
        model_calendar = timemgr_get_calendar_cf()
 
-       if (this%ntimes>2) then 
+       if (this%ntimes>2) then
           ! if only 2 time records then it is assumed that the input has 2 identical time records
           !  -- climatological or solar-cycle avaraged
 
@@ -181,7 +181,7 @@ contains
        ierr =  pio_inq_varid( fileid, 'time_bnds', varid )
 
        use_time_bnds = (ierr==PIO_NOERR .and. .not.force_interp)
-       
+
        if (use_time_bnds) then
           allocate ( this%time_bnds( 2, this%ntimes ) )
           allocate ( time_bnds_file( 2, this%ntimes ) )
@@ -239,13 +239,13 @@ contains
        ! time_bnds_modl - time_bnds_file = times_modl - times_file
        ! time_bnds_modl = time_bnds_file + times_modl - times_file
        this%times(:) = times_modl(:)
-       if (use_time_bnds) then 
+       if (use_time_bnds) then
           this%time_bnds(1,:) = time_bnds_file(1,:) + times_modl(:) - times_file(:)
           this%time_bnds(2,:) = time_bnds_file(2,:) + times_modl(:) - times_file(:)
        endif
     else if (use_time) then
        this%times(:) = times_file(:)
-       if (use_time_bnds) then 
+       if (use_time_bnds) then
           this%time_bnds(1,:) = time_bnds_file(1,:)
           this%time_bnds(2,:) = time_bnds_file(2,:)
        endif
@@ -303,14 +303,14 @@ contains
   !-----------------------------------------------------------------------------
   subroutine destroy( this )
         class(time_coordinate), intent(inout) :: this
-    
+
     if (allocated(this%times)) deallocate(this%times)
     if (allocated(this%time_bnds)) deallocate(this%time_bnds)
     this%ntimes = 0
     this%filename='NONE'
 
   end subroutine destroy
-    
+
   !-----------------------------------------------------------------------------
   ! produce a duplicate time coordinate object
   !-----------------------------------------------------------------------------
@@ -351,7 +351,7 @@ contains
     integer :: index, i
     character(len=cl) :: errmsg
 
-    ! set time indices and time-interpolation weights 
+    ! set time indices and time-interpolation weights
     fixed_time: if (obj%fixed) then
        yr = obj%fixed_ymd/10000
        mon = (obj%fixed_ymd-yr*10000) / 100
@@ -398,7 +398,7 @@ contains
        endif
     endif
 
-    if (.not.(index>0.and.index<obj%ntimes)) then
+    if (.not.(index>0.and.index<=obj%ntimes)) then
        errmsg = 'input_data_utils::set_wghts_indices cannot not find time indices for input file: '&
             // trim(obj%filename)
        write(iulog,*) trim(errmsg)
@@ -410,7 +410,7 @@ contains
        obj%wghts(1) = 1._r8 - obj%wghts(2)
     else
        obj%wghts(1) = 1._r8
-       obj%wghts(2) = 0._r8       
+       obj%wghts(2) = 0._r8
     endif
 
   end subroutine set_wghts_indices
@@ -459,7 +459,7 @@ contains
 
     integer :: year, month, day, sec,n ,i
 
-    n = size( dates ) 
+    n = size( dates )
 
     do i=1,n
        year = dates(i)/10000


### PR DESCRIPTION
        modified:   Externals.cfg
        modified:   src/chemistry/utils/input_data_utils.F90

fixes #182 
fixes #175 

NOTE: The majority of aux_cam baseline tests fail due to changes in clm IC file.

