### PR TITLE
cam6_2_045: Cleanup on config_pes.xml and change to testlist_cam.xml

### DIFF
--- a/cime_config/config_pes.xml
+++ b/cime_config/config_pes.xml
@@ -110,7 +110,7 @@
     </mach>
   </grid>
   <grid name="a%ne30" >
-    <mach name="hobart">
+    <mach name="hobart|izumi">
       <pes pesize="any" compset="any">
 	<comment>none</comment>
 	<ntasks>
@@ -360,116 +360,7 @@
       </pes>
     </mach>
   </grid>
-  <grid name="a%ne16" >
-    <mach name="yellowstone|pronghorn">
-      <pes pesize="any" compset="any">
-        <MAX_MPITASKS_PER_NODE>16</MAX_MPITASKS_PER_NODE>
-        <MAX_TASKS_PER_NODE>32</MAX_TASKS_PER_NODE>
-	<comment>none</comment>
-	<ntasks>
-	  <ntasks_atm>630</ntasks_atm> 
-	  <ntasks_lnd>630</ntasks_lnd>           
-	  <ntasks_rof>630</ntasks_rof> 
-	  <ntasks_ice>630</ntasks_ice> 
-	  <ntasks_ocn>630</ntasks_ocn> 
-	  <ntasks_glc>630</ntasks_glc> 
-	  <ntasks_wav>630</ntasks_wav> 
-	  <ntasks_cpl>630</ntasks_cpl> 
-	</ntasks>
-	<nthrds>
-	  <nthrds_atm>2</nthrds_atm>   
-	  <nthrds_lnd>2</nthrds_lnd> 
-	  <nthrds_rof>2</nthrds_rof> 
-	  <nthrds_ice>2</nthrds_ice> 
-	  <nthrds_ocn>2</nthrds_ocn> 
-	  <nthrds_glc>2</nthrds_glc> 
-	  <nthrds_wav>2</nthrds_wav> 
-	  <nthrds_cpl>2</nthrds_cpl> 
-	</nthrds>
-	<rootpe>
-	  <rootpe_atm>0</rootpe_atm> 
-	  <rootpe_lnd>0</rootpe_lnd> 
-	  <rootpe_rof>0</rootpe_rof> 
-	  <rootpe_ice>0</rootpe_ice>    
-	  <rootpe_ocn>0</rootpe_ocn>   
-	  <rootpe_glc>0</rootpe_glc> 
-	  <rootpe_wav>0</rootpe_wav> 
-	  <rootpe_cpl>0</rootpe_cpl>                         
-	</rootpe>
-      </pes>
-    </mach>
-  </grid>
   <grid name="a%ne30" >
-    <mach name="yellowstone|pronghorn">
-      <pes pesize="any" compset="any">
-        <MAX_MPITASKS_PER_NODE>16</MAX_MPITASKS_PER_NODE>
-        <MAX_TASKS_PER_NODE>32</MAX_TASKS_PER_NODE>
-	<comment>none</comment>
-	<ntasks>
-	  <ntasks_atm>900</ntasks_atm> 
-	  <ntasks_lnd>900</ntasks_lnd>           
-	  <ntasks_rof>900</ntasks_rof> 
-	  <ntasks_ice>900</ntasks_ice> 
-	  <ntasks_ocn>900</ntasks_ocn> 
-	  <ntasks_glc>900</ntasks_glc> 
-	  <ntasks_wav>900</ntasks_wav> 
-	  <ntasks_cpl>900</ntasks_cpl> 
-	</ntasks>
-	<nthrds>
-	  <nthrds_atm>2</nthrds_atm>   
-	  <nthrds_lnd>2</nthrds_lnd> 
-	  <nthrds_rof>2</nthrds_rof> 
-	  <nthrds_ice>2</nthrds_ice> 
-	  <nthrds_ocn>2</nthrds_ocn> 
-	  <nthrds_glc>2</nthrds_glc> 
-	  <nthrds_wav>2</nthrds_wav> 
-	  <nthrds_cpl>2</nthrds_cpl> 
-	</nthrds>
-	<rootpe>
-	  <rootpe_atm>0</rootpe_atm> 
-	  <rootpe_lnd>0</rootpe_lnd> 
-	  <rootpe_rof>0</rootpe_rof> 
-	  <rootpe_ice>0</rootpe_ice>    
-	  <rootpe_ocn>0</rootpe_ocn>   
-	  <rootpe_glc>0</rootpe_glc> 
-	  <rootpe_wav>0</rootpe_wav> 
-	  <rootpe_cpl>0</rootpe_cpl>                         
-	</rootpe>
-      </pes>
-      <pes pesize="any" compset="CAM\d+%W">
-	<comment>none</comment>
-	<ntasks>
-	  <ntasks_atm>1800</ntasks_atm> 
-	  <ntasks_lnd>1800</ntasks_lnd>           
-	  <ntasks_rof>1800</ntasks_rof> 
-	  <ntasks_ice>1800</ntasks_ice> 
-	  <ntasks_ocn>1800</ntasks_ocn> 
-	  <ntasks_glc>1800</ntasks_glc> 
-	  <ntasks_wav>1800</ntasks_wav> 
-	  <ntasks_cpl>1800</ntasks_cpl> 
-	</ntasks>
-	<nthrds>
-	  <nthrds_atm>2</nthrds_atm>   
-	  <nthrds_lnd>2</nthrds_lnd> 
-	  <nthrds_rof>2</nthrds_rof> 
-	  <nthrds_ice>2</nthrds_ice> 
-	  <nthrds_ocn>2</nthrds_ocn> 
-	  <nthrds_glc>2</nthrds_glc> 
-	  <nthrds_wav>2</nthrds_wav> 
-	  <nthrds_cpl>2</nthrds_cpl> 
-	</nthrds>
-	<rootpe>
-	  <rootpe_atm>0</rootpe_atm> 
-	  <rootpe_lnd>0</rootpe_lnd> 
-	  <rootpe_rof>0</rootpe_rof> 
-	  <rootpe_ice>0</rootpe_ice>    
-	  <rootpe_ocn>0</rootpe_ocn>   
-	  <rootpe_glc>0</rootpe_glc> 
-	  <rootpe_wav>0</rootpe_wav> 
-	  <rootpe_cpl>0</rootpe_cpl>                         
-	</rootpe>
-      </pes>
-    </mach>
     <mach name="cheyenne">
       <pes pesize="any" compset="_(CAM50|CAM60)%(CC|WC|CV|CF)">
         <comment>none</comment>
@@ -691,45 +582,6 @@
       </pes>
     </mach>
   </grid>
-  <grid name="a%ne120">
-    <mach name="yellowstone|pronghorn">
-      <pes pesize="any" compset="any">
-        <MAX_MPITASKS_PER_NODE>16</MAX_MPITASKS_PER_NODE>
-        <MAX_TASKS_PER_NODE>32</MAX_TASKS_PER_NODE>
-	<comment>none</comment>
-	<ntasks>
-	  <ntasks_atm>7680</ntasks_atm> 
-	  <ntasks_lnd>3040</ntasks_lnd>           
-	  <ntasks_rof>3040</ntasks_rof> 
-	  <ntasks_ice>3840</ntasks_ice> 
-	  <ntasks_ocn>7680</ntasks_ocn> 
-	  <ntasks_glc>7680</ntasks_glc> 
-	  <ntasks_wav>7680</ntasks_wav> 
-	  <ntasks_cpl>7680</ntasks_cpl> 
-	</ntasks>
-	<nthrds>
-	  <nthrds_atm>2</nthrds_atm> 
-	  <nthrds_lnd>2</nthrds_lnd> 
-	  <nthrds_rof>2</nthrds_rof> 
-	  <nthrds_ice>2</nthrds_ice> 
-	  <nthrds_ocn>2</nthrds_ocn> 
-	  <nthrds_glc>2</nthrds_glc> 
-	  <nthrds_wav>2</nthrds_wav> 
-	  <nthrds_cpl>2</nthrds_cpl> 
-	</nthrds>
-	<rootpe>
-	  <rootpe_atm>0</rootpe_atm> 
-	  <rootpe_lnd>0</rootpe_lnd> 
-	  <rootpe_rof>0</rootpe_rof> 
-	  <rootpe_ice>3040</rootpe_ice>    
-	  <rootpe_ocn>0</rootpe_ocn>   
-	  <rootpe_glc>0</rootpe_glc> 
-	  <rootpe_wav>0</rootpe_wav> 
-	  <rootpe_cpl>0</rootpe_cpl>                         
-	</rootpe>
-      </pes>
-    </mach>
-  </grid>
   <grid name="a%ne240">
     <mach name="any">
       <pes pesize="any" compset="any">
@@ -747,45 +599,6 @@
 	<nthrds>
 	  <nthrds_atm>1</nthrds_atm>                   
 	  <nthrds_lnd>1</nthrds_lnd> 
-	  <nthrds_rof>1</nthrds_rof> 
-	  <nthrds_ice>1</nthrds_ice> 
-	  <nthrds_ocn>1</nthrds_ocn> 
-	  <nthrds_glc>1</nthrds_glc> 
-	  <nthrds_wav>1</nthrds_wav> 
-	  <nthrds_cpl>1</nthrds_cpl> 
-	</nthrds>
-	<rootpe>
-	  <rootpe_atm>0</rootpe_atm> 
-	  <rootpe_lnd>0</rootpe_lnd> 
-	  <rootpe_rof>0</rootpe_rof> 
-	  <rootpe_ice>0</rootpe_ice>    
-	  <rootpe_ocn>0</rootpe_ocn>   
-	  <rootpe_glc>0</rootpe_glc> 
-	  <rootpe_wav>0</rootpe_wav> 
-	  <rootpe_cpl>0</rootpe_cpl>                         
-	</rootpe>
-      </pes>
-    </mach>
-  </grid>
-  <grid name="a%T31">
-    <mach name="yellowstone|pronghorn">
-      <pes pesize="any" compset="any">
-        <MAX_MPITASKS_PER_NODE>32</MAX_MPITASKS_PER_NODE>
-        <MAX_TASKS_PER_NODE>32</MAX_TASKS_PER_NODE>
-	<comment>none</comment>
-	<ntasks>
-	  <ntasks_atm>-1</ntasks_atm> 
-	  <ntasks_lnd>-1</ntasks_lnd>           
-	  <ntasks_rof>-1</ntasks_rof> 
-	  <ntasks_ice>-1</ntasks_ice> 
-	  <ntasks_ocn>-1</ntasks_ocn> 
-	  <ntasks_glc>-1</ntasks_glc> 
-	  <ntasks_wav>-1</ntasks_wav> 
-	  <ntasks_cpl>-1</ntasks_cpl> 
-	</ntasks>
-	<nthrds>
-	  <nthrds_atm>1</nthrds_atm>
-  	  <nthrds_lnd>1</nthrds_lnd> 
 	  <nthrds_rof>1</nthrds_rof> 
 	  <nthrds_ice>1</nthrds_ice> 
 	  <nthrds_ocn>1</nthrds_ocn> 
@@ -1209,7 +1022,7 @@
 	</rootpe>
       </pes>
     </mach>
-    <mach name="hobart">
+    <mach name="hobart|izumi">
       <pes pesize="any" compset="CAM\d+%W">
 	<comment>none</comment>
 	<ntasks>
@@ -1283,115 +1096,6 @@
     </mach>
   </grid>
 
-  <grid name="a%1.9x2.5">
-    <mach name="yellowstone|pronghorn">
-      <pes pesize="any" compset="any">
-        <MAX_MPITASKS_PER_NODE>16</MAX_MPITASKS_PER_NODE>
-        <MAX_TASKS_PER_NODE>32</MAX_TASKS_PER_NODE>
-	<comment>none</comment>
-	<ntasks>
-	  <ntasks_atm>192</ntasks_atm> 
-	  <ntasks_lnd>192</ntasks_lnd>           
-	  <ntasks_rof>192</ntasks_rof> 
-	  <ntasks_ice>192</ntasks_ice> 
-	  <ntasks_ocn>192</ntasks_ocn> 
-	  <ntasks_glc>192</ntasks_glc> 
-	  <ntasks_wav>192</ntasks_wav> 
-	  <ntasks_cpl>192</ntasks_cpl> 
-	</ntasks>
-	<nthrds>
-	  <nthrds_atm>2</nthrds_atm> 
-	  <nthrds_lnd>2</nthrds_lnd> 
-	  <nthrds_rof>2</nthrds_rof> 
-	  <nthrds_ice>2</nthrds_ice> 
-	  <nthrds_ocn>2</nthrds_ocn> 
-	  <nthrds_glc>2</nthrds_glc> 
-	  <nthrds_wav>2</nthrds_wav> 
-	  <nthrds_cpl>2</nthrds_cpl> 
-	</nthrds>
-	<rootpe>
-	  <rootpe_atm>0</rootpe_atm> 
-	  <rootpe_lnd>0</rootpe_lnd> 
-	  <rootpe_rof>0</rootpe_rof> 
-	  <rootpe_ice>0</rootpe_ice>    
-	  <rootpe_ocn>0</rootpe_ocn>   
-	  <rootpe_glc>0</rootpe_glc> 
-	  <rootpe_wav>0</rootpe_wav> 
-	  <rootpe_cpl>0</rootpe_cpl>                         
-	</rootpe>
-      </pes>
-      <pes pesize="any" compset="_CAM\d+%WC(S|T|C|M)">
-        <MAX_MPITASKS_PER_NODE>16</MAX_MPITASKS_PER_NODE>
-        <MAX_TASKS_PER_NODE>32</MAX_TASKS_PER_NODE>
-	<comment>none</comment>
-	<ntasks>
-	  <ntasks_atm>256</ntasks_atm>
-	  <ntasks_lnd>256</ntasks_lnd>
-	  <ntasks_rof>256</ntasks_rof>
-	  <ntasks_ice>256</ntasks_ice>
-	  <ntasks_ocn>256</ntasks_ocn>
-	  <ntasks_glc>256</ntasks_glc>
-	  <ntasks_wav>256</ntasks_wav>
-	  <ntasks_cpl>256</ntasks_cpl>
-	</ntasks>
-	<nthrds>
-	  <nthrds_atm>2</nthrds_atm>
-	  <nthrds_lnd>2</nthrds_lnd>
-	  <nthrds_rof>2</nthrds_rof>
-	  <nthrds_ice>2</nthrds_ice>
-	  <nthrds_ocn>2</nthrds_ocn>
-	  <nthrds_glc>2</nthrds_glc>
-	  <nthrds_wav>2</nthrds_wav>
-	  <nthrds_cpl>2</nthrds_cpl>
-	</nthrds>
-	<rootpe>
-	  <rootpe_atm>0</rootpe_atm>
-	  <rootpe_lnd>0</rootpe_lnd>
-	  <rootpe_rof>0</rootpe_rof>
-	  <rootpe_ice>0</rootpe_ice>
-	  <rootpe_ocn>0</rootpe_ocn>
-	  <rootpe_glc>0</rootpe_glc>
-	  <rootpe_wav>0</rootpe_wav>
-	  <rootpe_cpl>0</rootpe_cpl>
-	</rootpe>
-      </pes>
-      <pes pesize="any" compset="_CAM40%WX">
-        <MAX_MPITASKS_PER_NODE>16</MAX_MPITASKS_PER_NODE>
-        <MAX_TASKS_PER_NODE>32</MAX_TASKS_PER_NODE>
-	<comment>none</comment>
-	<ntasks>
-	  <ntasks_atm>128</ntasks_atm>
-	  <ntasks_lnd>128</ntasks_lnd>
-	  <ntasks_rof>128</ntasks_rof>
-	  <ntasks_ice>128</ntasks_ice>
-	  <ntasks_ocn>128</ntasks_ocn>
-	  <ntasks_glc>128</ntasks_glc>
-	  <ntasks_wav>128</ntasks_wav>
-	  <ntasks_cpl>128</ntasks_cpl>
-	</ntasks>
-	<nthrds>
-	  <nthrds_atm>2</nthrds_atm>
-	  <nthrds_lnd>2</nthrds_lnd>
-	  <nthrds_rof>2</nthrds_rof>
-	  <nthrds_ice>2</nthrds_ice>
-	  <nthrds_ocn>2</nthrds_ocn>
-	  <nthrds_glc>2</nthrds_glc>
-	  <nthrds_wav>2</nthrds_wav>
-	  <nthrds_cpl>2</nthrds_cpl>
-	</nthrds>
-	<rootpe>
-	  <rootpe_atm>0</rootpe_atm>
-	  <rootpe_lnd>0</rootpe_lnd>
-	  <rootpe_rof>0</rootpe_rof>
-	  <rootpe_ice>0</rootpe_ice>
-	  <rootpe_ocn>0</rootpe_ocn>
-	  <rootpe_glc>0</rootpe_glc>
-	  <rootpe_wav>0</rootpe_wav>
-	  <rootpe_cpl>0</rootpe_cpl>
-	</rootpe>
-      </pes>
-    </mach>
-  </grid>
   <grid name="a%0.9x1.25">
     <mach name="any">
       <pes pesize="any" compset="any">
@@ -1489,43 +1193,6 @@
 	  <nthrds_glc>8</nthrds_glc> 
 	  <nthrds_wav>8</nthrds_wav> 
 	  <nthrds_cpl>8</nthrds_cpl> 
-	</nthrds>
-	<rootpe>
-	  <rootpe_atm>0</rootpe_atm> 
-	  <rootpe_lnd>0</rootpe_lnd> 
-	  <rootpe_rof>0</rootpe_rof> 
-	  <rootpe_ice>0</rootpe_ice>    
-	  <rootpe_ocn>0</rootpe_ocn>   
-	  <rootpe_glc>0</rootpe_glc> 
-	  <rootpe_wav>0</rootpe_wav> 
-	  <rootpe_cpl>0</rootpe_cpl>                         
-	</rootpe>
-      </pes>
-    </mach>
-  </grid>
-  <grid name="a%0.9x1.25">
-    <mach name="yellowstone">
-      <pes pesize="any" compset="any">
-	<comment>none</comment>
-	<ntasks>
-	  <ntasks_atm>-64</ntasks_atm> 
-	  <ntasks_lnd>-64</ntasks_lnd>           
-	  <ntasks_rof>-64</ntasks_rof> 
-	  <ntasks_ice>-64</ntasks_ice> 
-	  <ntasks_ocn>-64</ntasks_ocn> 
-	  <ntasks_glc>-64</ntasks_glc> 
-	  <ntasks_wav>-64</ntasks_wav> 
-	  <ntasks_cpl>-64</ntasks_cpl> 
-	</ntasks>
-	<nthrds>
-	  <nthrds_atm>2</nthrds_atm> 
-	  <nthrds_lnd>2</nthrds_lnd> 
-	  <nthrds_rof>2</nthrds_rof> 
-	  <nthrds_ice>2</nthrds_ice> 
-	  <nthrds_ocn>2</nthrds_ocn> 
-	  <nthrds_glc>2</nthrds_glc> 
-	  <nthrds_wav>2</nthrds_wav> 
-	  <nthrds_cpl>2</nthrds_cpl> 
 	</nthrds>
 	<rootpe>
 	  <rootpe_atm>0</rootpe_atm> 

--- a/cime_config/config_pes.xml
+++ b/cime_config/config_pes.xml
@@ -184,43 +184,6 @@
     </mach>
   </grid>
   <grid name="a%ne30" >
-    <mach name="edison|eos">
-      <pes pesize="any" compset="any">
-	<comment>none</comment>
-	<ntasks>
-	  <ntasks_atm>-40</ntasks_atm> 
-	  <ntasks_lnd>-40</ntasks_lnd>           
-	  <ntasks_rof>-40</ntasks_rof> 
-	  <ntasks_ice>-40</ntasks_ice> 
-	  <ntasks_ocn>-40</ntasks_ocn> 
-	  <ntasks_glc>-40</ntasks_glc> 
-	  <ntasks_wav>-40</ntasks_wav> 
-	  <ntasks_cpl>-40</ntasks_cpl> 
-	</ntasks>
-	<nthrds>
-	  <nthrds_atm>4</nthrds_atm>   
-	  <nthrds_lnd>4</nthrds_lnd> 
-	  <nthrds_rof>4</nthrds_rof> 
-	  <nthrds_ice>4</nthrds_ice> 
-	  <nthrds_ocn>4</nthrds_ocn> 
-	  <nthrds_glc>4</nthrds_glc> 
-	  <nthrds_wav>4</nthrds_wav> 
-	  <nthrds_cpl>4</nthrds_cpl> 
-	</nthrds>
-	<rootpe>
-	  <rootpe_atm>0</rootpe_atm> 
-	  <rootpe_lnd>0</rootpe_lnd> 
-	  <rootpe_rof>0</rootpe_rof> 
-	  <rootpe_ice>0</rootpe_ice>    
-	  <rootpe_ocn>0</rootpe_ocn>   
-	  <rootpe_glc>0</rootpe_glc> 
-	  <rootpe_wav>0</rootpe_wav> 
-	  <rootpe_cpl>0</rootpe_cpl>                         
-	</rootpe>
-      </pes>
-    </mach>
-  </grid>
-  <grid name="a%ne30" >
     <mach name="mira">
       <pes pesize="any" compset="any">
 	<comment>none</comment>
@@ -369,43 +332,6 @@
     </mach>
   </grid>
   <grid name="a%ne120">
-    <mach name="edison|eos">
-      <pes pesize="any" compset="any">
-	<comment>none</comment>
-	<ntasks>
-	  <ntasks_atm>4800</ntasks_atm> 
-	  <ntasks_lnd>4800</ntasks_lnd>           
-	  <ntasks_rof>4800</ntasks_rof> 
-	  <ntasks_ice>4800</ntasks_ice> 
-	  <ntasks_ocn>4800</ntasks_ocn> 
-	  <ntasks_glc>4800</ntasks_glc> 
-	  <ntasks_wav>4800</ntasks_wav> 
-	  <ntasks_cpl>4800</ntasks_cpl> 
-	</ntasks>
-	<nthrds>
-	  <nthrds_atm>4</nthrds_atm>   
-	  <nthrds_lnd>4</nthrds_lnd> 
-	  <nthrds_rof>4</nthrds_rof> 
-	  <nthrds_ice>4</nthrds_ice> 
-	  <nthrds_ocn>4</nthrds_ocn> 
-	  <nthrds_glc>4</nthrds_glc> 
-	  <nthrds_wav>4</nthrds_wav> 
-	  <nthrds_cpl>4</nthrds_cpl> 
-	</nthrds>
-	<rootpe>
-	  <rootpe_atm>0</rootpe_atm> 
-	  <rootpe_lnd>0</rootpe_lnd> 
-	  <rootpe_rof>0</rootpe_rof> 
-	  <rootpe_ice>0</rootpe_ice>    
-	  <rootpe_ocn>0</rootpe_ocn>   
-	  <rootpe_glc>0</rootpe_glc> 
-	  <rootpe_wav>0</rootpe_wav> 
-	  <rootpe_cpl>0</rootpe_cpl>                         
-	</rootpe>
-      </pes>
-    </mach>
-  </grid>
-  <grid name="a%ne120">
     <mach name="mira">
       <pes pesize="any" compset="any">
 	<comment>none</comment>
@@ -517,43 +443,6 @@
     </mach>
   </grid>
   <grid name="a%T31">
-    <mach name="edison|eos">
-      <pes pesize="any" compset="any">
-	<comment>none</comment>
-	<ntasks>
-	  <ntasks_atm>12</ntasks_atm> 
-	  <ntasks_lnd>12</ntasks_lnd>           
-	  <ntasks_rof>12</ntasks_rof> 
-	  <ntasks_ice>12</ntasks_ice> 
-	  <ntasks_ocn>12</ntasks_ocn> 
-	  <ntasks_glc>12</ntasks_glc> 
-	  <ntasks_wav>12</ntasks_wav> 
-	  <ntasks_cpl>12</ntasks_cpl> 
-	</ntasks>
-	<nthrds>
-	  <nthrds_atm>4</nthrds_atm>
-  	  <nthrds_lnd>4</nthrds_lnd> 
-	  <nthrds_rof>4</nthrds_rof> 
-	  <nthrds_ice>4</nthrds_ice> 
-	  <nthrds_ocn>4</nthrds_ocn> 
-	  <nthrds_glc>4</nthrds_glc> 
-	  <nthrds_wav>4</nthrds_wav> 
-	  <nthrds_cpl>4</nthrds_cpl> 
-	</nthrds>
-	<rootpe>
-	  <rootpe_atm>0</rootpe_atm> 
-	  <rootpe_lnd>0</rootpe_lnd> 
-	  <rootpe_rof>0</rootpe_rof> 
-	  <rootpe_ice>0</rootpe_ice>    
-	  <rootpe_ocn>0</rootpe_ocn>   
-	  <rootpe_glc>0</rootpe_glc> 
-	  <rootpe_wav>0</rootpe_wav> 
-	  <rootpe_cpl>0</rootpe_cpl>                         
-	</rootpe>
-      </pes>
-    </mach>
-  </grid>
-  <grid name="a%T31">
     <mach name="hera|sierra" >
       <pes pesize="any" compset="any">
 	<comment>none</comment>
@@ -613,43 +502,6 @@
 	  <nthrds_glc>1</nthrds_glc> 
 	  <nthrds_wav>1</nthrds_wav> 
 	  <nthrds_cpl>1</nthrds_cpl> 
-	</nthrds>
-	<rootpe>
-	  <rootpe_atm>0</rootpe_atm> 
-	  <rootpe_lnd>0</rootpe_lnd> 
-	  <rootpe_rof>0</rootpe_rof> 
-	  <rootpe_ice>0</rootpe_ice>    
-	  <rootpe_ocn>0</rootpe_ocn>   
-	  <rootpe_glc>0</rootpe_glc> 
-	  <rootpe_wav>0</rootpe_wav> 
-	  <rootpe_cpl>0</rootpe_cpl>                         
-	</rootpe>
-      </pes>
-    </mach>
-  </grid>
-  <grid name="a%1.9x2.5">
-    <mach name="edison|eos">
-      <pes pesize="any" compset="any">
-	<comment>none</comment>
-	<ntasks>
-	  <ntasks_atm>96</ntasks_atm> 
-	  <ntasks_lnd>96</ntasks_lnd>           
-	  <ntasks_rof>96</ntasks_rof> 
-	  <ntasks_ice>96</ntasks_ice> 
-	  <ntasks_ocn>96</ntasks_ocn> 
-	  <ntasks_glc>96</ntasks_glc> 
-	  <ntasks_wav>96</ntasks_wav> 
-	  <ntasks_cpl>96</ntasks_cpl> 
-	</ntasks>
-	<nthrds>
-	  <nthrds_atm>4</nthrds_atm> 
-	  <nthrds_lnd>4</nthrds_lnd> 
-	  <nthrds_rof>4</nthrds_rof> 
-	  <nthrds_ice>4</nthrds_ice> 
-	  <nthrds_ocn>4</nthrds_ocn> 
-	  <nthrds_glc>4</nthrds_glc> 
-	  <nthrds_wav>4</nthrds_wav> 
-	  <nthrds_cpl>4</nthrds_cpl> 
 	</nthrds>
 	<rootpe>
 	  <rootpe_atm>0</rootpe_atm> 
@@ -1016,43 +868,6 @@
 	  <nthrds_glc>1</nthrds_glc> 
 	  <nthrds_wav>1</nthrds_wav> 
 	  <nthrds_cpl>1</nthrds_cpl> 
-	</nthrds>
-	<rootpe>
-	  <rootpe_atm>0</rootpe_atm> 
-	  <rootpe_lnd>0</rootpe_lnd> 
-	  <rootpe_rof>0</rootpe_rof> 
-	  <rootpe_ice>0</rootpe_ice>    
-	  <rootpe_ocn>0</rootpe_ocn>   
-	  <rootpe_glc>0</rootpe_glc> 
-	  <rootpe_wav>0</rootpe_wav> 
-	  <rootpe_cpl>0</rootpe_cpl>                         
-	</rootpe>
-      </pes>
-    </mach>
-  </grid>
-  <grid name="a%0.9x1.25">
-    <mach name="edison|eos">
-      <pes pesize="any" compset="any">
-	<comment>none</comment>
-	<ntasks>
-	  <ntasks_atm>192</ntasks_atm> 
-	  <ntasks_lnd>192</ntasks_lnd>           
-	  <ntasks_rof>192</ntasks_rof> 
-	  <ntasks_ice>192</ntasks_ice> 
-	  <ntasks_ocn>192</ntasks_ocn> 
-	  <ntasks_glc>192</ntasks_glc> 
-	  <ntasks_wav>192</ntasks_wav> 
-	  <ntasks_cpl>192</ntasks_cpl> 
-	</ntasks>
-	<nthrds>
-	  <nthrds_atm>4</nthrds_atm>
-	  <nthrds_lnd>4</nthrds_lnd> 
-	  <nthrds_rof>4</nthrds_rof> 
-	  <nthrds_ice>4</nthrds_ice> 
-	  <nthrds_ocn>4</nthrds_ocn> 
-	  <nthrds_glc>4</nthrds_glc> 
-	  <nthrds_wav>4</nthrds_wav> 
-	  <nthrds_cpl>4</nthrds_cpl> 
 	</nthrds>
 	<rootpe>
 	  <rootpe_atm>0</rootpe_atm> 

--- a/cime_config/config_pes.xml
+++ b/cime_config/config_pes.xml
@@ -1388,14 +1388,14 @@
       <pes pesize="any" compset="any">
         <comment>none</comment>
 	      <ntasks>
-	        <ntasks_atm>-204</ntasks_atm> 
-	        <ntasks_lnd>-204</ntasks_lnd>           
-	        <ntasks_rof>-204</ntasks_rof> 
-	        <ntasks_ice>-204</ntasks_ice> 
-	        <ntasks_ocn>-204</ntasks_ocn> 
-	        <ntasks_glc>-204</ntasks_glc> 
-	        <ntasks_wav>-204</ntasks_wav> 
-	        <ntasks_cpl>-204</ntasks_cpl> 
+	        <ntasks_atm>-91</ntasks_atm> 
+	        <ntasks_lnd>-91</ntasks_lnd>           
+	        <ntasks_rof>-91</ntasks_rof> 
+	        <ntasks_ice>-91</ntasks_ice> 
+	        <ntasks_ocn>-91</ntasks_ocn> 
+	        <ntasks_glc>-91</ntasks_glc> 
+	        <ntasks_wav>-91</ntasks_wav> 
+	        <ntasks_cpl>-91</ntasks_cpl> 
 	      </ntasks>
 	      <nthrds>
 	        <nthrds_atm>1</nthrds_atm>
@@ -1426,14 +1426,14 @@
       <pes pesize="any" compset="any">
         <comment>none</comment>
 	      <ntasks>
-	        <ntasks_atm>-265</ntasks_atm> 
-	        <ntasks_lnd>-265</ntasks_lnd>           
-	        <ntasks_rof>-265</ntasks_rof> 
-	        <ntasks_ice>-265</ntasks_ice> 
-	        <ntasks_ocn>-265</ntasks_ocn> 
-	        <ntasks_glc>-265</ntasks_glc> 
-	        <ntasks_wav>-265</ntasks_wav> 
-	        <ntasks_cpl>-265</ntasks_cpl> 
+	        <ntasks_atm>-118</ntasks_atm> 
+	        <ntasks_lnd>-118</ntasks_lnd>           
+	        <ntasks_rof>-118</ntasks_rof> 
+	        <ntasks_ice>-118</ntasks_ice> 
+	        <ntasks_ocn>-118</ntasks_ocn> 
+	        <ntasks_glc>-118</ntasks_glc> 
+	        <ntasks_wav>-118</ntasks_wav> 
+	        <ntasks_cpl>-118</ntasks_cpl> 
 	      </ntasks>
 	      <nthrds>
 	        <nthrds_atm>1</nthrds_atm>
@@ -1464,14 +1464,14 @@
       <pes pesize="any" compset="any">
         <comment>none</comment>
 	      <ntasks>
-	        <ntasks_atm>-303</ntasks_atm> 
-	        <ntasks_lnd>-303</ntasks_lnd>           
-	        <ntasks_rof>-303</ntasks_rof> 
-	        <ntasks_ice>-303</ntasks_ice> 
-	        <ntasks_ocn>-303</ntasks_ocn> 
-	        <ntasks_glc>-303</ntasks_glc> 
-	        <ntasks_wav>-303</ntasks_wav> 
-	        <ntasks_cpl>-303</ntasks_cpl> 
+	        <ntasks_atm>-135</ntasks_atm> 
+	        <ntasks_lnd>-135</ntasks_lnd>           
+	        <ntasks_rof>-135</ntasks_rof> 
+	        <ntasks_ice>-135</ntasks_ice> 
+	        <ntasks_ocn>-135</ntasks_ocn> 
+	        <ntasks_glc>-135</ntasks_glc> 
+	        <ntasks_wav>-135</ntasks_wav> 
+	        <ntasks_cpl>-135</ntasks_cpl> 
 	      </ntasks>
 	      <nthrds>
 	        <nthrds_atm>1</nthrds_atm>

--- a/cime_config/config_pes.xml
+++ b/cime_config/config_pes.xml
@@ -1644,7 +1644,7 @@
     </mach>
   </grid>
 
-  <grid name="a%ne0np4.CONUS" >
+  <grid name="a%ne0np4CONUS" >
     <mach name="any" >
       <pes pesize="any" compset="any">
         <comment>none</comment>

--- a/cime_config/config_pes.xml
+++ b/cime_config/config_pes.xml
@@ -257,109 +257,6 @@
       </pes>
     </mach>
   </grid>
-  <grid name="a%ne0np4CONUS" >
-    <mach name="cheyenne">
-      <pes pesize="any" compset="any">
-	<comment>none</comment>
-	<ntasks>
-	  <ntasks_atm>-8</ntasks_atm> 
-	  <ntasks_lnd>-8</ntasks_lnd>           
-	  <ntasks_rof>-8</ntasks_rof> 
-	  <ntasks_ice>-8</ntasks_ice> 
-	  <ntasks_ocn>-8</ntasks_ocn> 
-	  <ntasks_glc>-8</ntasks_glc> 
-	  <ntasks_wav>-8</ntasks_wav> 
-	  <ntasks_cpl>-8</ntasks_cpl> 
-	</ntasks>
-	<nthrds>
-	  <nthrds_atm>1</nthrds_atm>                   
-	  <nthrds_lnd>1</nthrds_lnd> 
-	  <nthrds_rof>1</nthrds_rof> 
-	  <nthrds_ice>1</nthrds_ice> 
-	  <nthrds_ocn>1</nthrds_ocn> 
-	  <nthrds_glc>1</nthrds_glc> 
-	  <nthrds_wav>1</nthrds_wav> 
-	  <nthrds_cpl>1</nthrds_cpl> 
-	</nthrds>
-	<rootpe>
-	  <rootpe_atm>0</rootpe_atm> 
-	  <rootpe_lnd>0</rootpe_lnd> 
-	  <rootpe_rof>0</rootpe_rof> 
-	  <rootpe_ice>0</rootpe_ice>    
-	  <rootpe_ocn>0</rootpe_ocn>   
-	  <rootpe_glc>0</rootpe_glc> 
-	  <rootpe_wav>0</rootpe_wav> 
-	  <rootpe_cpl>0</rootpe_cpl>                         
-	</rootpe>
-      </pes>
-      <pes pesize="any" compset="CAM\d+%W">
-	<comment>none</comment>
-	<ntasks>
-	  <ntasks_atm>-16</ntasks_atm> 
-	  <ntasks_lnd>-16</ntasks_lnd>           
-	  <ntasks_rof>-16</ntasks_rof> 
-	  <ntasks_ice>-16</ntasks_ice> 
-	  <ntasks_ocn>-16</ntasks_ocn> 
-	  <ntasks_glc>-16</ntasks_glc> 
-	  <ntasks_wav>-16</ntasks_wav> 
-	  <ntasks_cpl>-16</ntasks_cpl> 
-	</ntasks>
-	<nthrds>
-	  <nthrds_atm>1</nthrds_atm>                   
-	  <nthrds_lnd>1</nthrds_lnd> 
-	  <nthrds_rof>1</nthrds_rof> 
-	  <nthrds_ice>1</nthrds_ice> 
-	  <nthrds_ocn>1</nthrds_ocn> 
-	  <nthrds_glc>1</nthrds_glc> 
-	  <nthrds_wav>1</nthrds_wav> 
-	  <nthrds_cpl>1</nthrds_cpl> 
-	</nthrds>
-	<rootpe>
-	  <rootpe_atm>0</rootpe_atm> 
-	  <rootpe_lnd>0</rootpe_lnd> 
-	  <rootpe_rof>0</rootpe_rof> 
-	  <rootpe_ice>0</rootpe_ice>    
-	  <rootpe_ocn>0</rootpe_ocn>   
-	  <rootpe_glc>0</rootpe_glc> 
-	  <rootpe_wav>0</rootpe_wav> 
-	  <rootpe_cpl>0</rootpe_cpl>                         
-	</rootpe>
-      </pes>
-      <pes pesize="any" compset="_CAM60%CC">
-        <comment>none</comment>
-        <ntasks>
-          <ntasks_atm>-50</ntasks_atm>
-          <ntasks_lnd>-50</ntasks_lnd>
-          <ntasks_rof>-50</ntasks_rof>
-          <ntasks_ice>-50</ntasks_ice>
-          <ntasks_ocn>-50</ntasks_ocn>
-          <ntasks_glc>-50</ntasks_glc>
-          <ntasks_wav>-50</ntasks_wav>
-          <ntasks_cpl>-50</ntasks_cpl>
-        </ntasks>
-        <nthrds>
-          <nthrds_atm>1</nthrds_atm>
-          <nthrds_lnd>1</nthrds_lnd>
-          <nthrds_rof>1</nthrds_rof>
-          <nthrds_ice>1</nthrds_ice>
-          <nthrds_ocn>1</nthrds_ocn>
-          <nthrds_glc>1</nthrds_glc>
-          <nthrds_wav>1</nthrds_wav>
-          <nthrds_cpl>1</nthrds_cpl>
-        </nthrds>
-        <rootpe>
-          <rootpe_atm>0</rootpe_atm>
-          <rootpe_lnd>0</rootpe_lnd>
-          <rootpe_rof>0</rootpe_rof>
-          <rootpe_ice>0</rootpe_ice>
-          <rootpe_ocn>0</rootpe_ocn>
-          <rootpe_glc>0</rootpe_glc>
-          <rootpe_wav>0</rootpe_wav>
-          <rootpe_cpl>0</rootpe_cpl>
-        </rootpe>
-      </pes>
-    </mach>
-  </grid>
   <grid name="a%ne30" >
     <mach name="cheyenne">
       <pes pesize="any" compset="_(CAM50|CAM60)%(CC|WC|CV|CF)">
@@ -1477,6 +1374,314 @@
       </pes>
     </mach>
   </grid>
+
+  <!-- CAM/FV3 grids -->
+  <grid name="a%C24" >
+    <mach name="any" >
+      <pes pesize="any" compset="any">
+        <comment>none</comment>
+	      <ntasks>
+	        <ntasks_atm>-1</ntasks_atm> 
+	        <ntasks_lnd>-1</ntasks_lnd>           
+	        <ntasks_rof>-1</ntasks_rof> 
+	        <ntasks_ice>-1</ntasks_ice> 
+	        <ntasks_ocn>-1</ntasks_ocn> 
+	        <ntasks_glc>-1</ntasks_glc> 
+	        <ntasks_wav>-1</ntasks_wav> 
+	        <ntasks_cpl>-1</ntasks_cpl> 
+	      </ntasks>
+	      <nthrds>
+	        <nthrds_atm>1</nthrds_atm>
+	        <nthrds_lnd>1</nthrds_lnd> 
+	        <nthrds_rof>1</nthrds_rof> 
+	        <nthrds_ice>1</nthrds_ice> 
+	        <nthrds_ocn>1</nthrds_ocn> 
+	        <nthrds_glc>1</nthrds_glc> 
+	        <nthrds_wav>1</nthrds_wav> 
+	        <nthrds_cpl>1</nthrds_cpl> 
+	      </nthrds>
+	      <rootpe>
+	        <rootpe_atm>0</rootpe_atm> 
+	        <rootpe_lnd>0</rootpe_lnd> 
+	        <rootpe_rof>0</rootpe_rof> 
+	        <rootpe_ice>0</rootpe_ice>    
+	        <rootpe_ocn>0</rootpe_ocn>   
+	        <rootpe_glc>0</rootpe_glc> 
+	        <rootpe_wav>0</rootpe_wav> 
+	        <rootpe_cpl>0</rootpe_cpl>                         
+        </rootpe>
+      </pes>
+    </mach>
+  </grid>
+
+  <grid name="a%C48" >
+    <mach name="any" >
+      <pes pesize="any" compset="any">
+        <comment>none</comment>
+	      <ntasks>
+	        <ntasks_atm>-4</ntasks_atm> 
+	        <ntasks_lnd>-4</ntasks_lnd>           
+	        <ntasks_rof>-4</ntasks_rof> 
+	        <ntasks_ice>-4</ntasks_ice> 
+	        <ntasks_ocn>-4</ntasks_ocn> 
+	        <ntasks_glc>-4</ntasks_glc> 
+	        <ntasks_wav>-4</ntasks_wav> 
+	        <ntasks_cpl>-4</ntasks_cpl> 
+	      </ntasks>
+	      <nthrds>
+	        <nthrds_atm>1</nthrds_atm>
+	        <nthrds_lnd>1</nthrds_lnd> 
+	        <nthrds_rof>1</nthrds_rof> 
+	        <nthrds_ice>1</nthrds_ice> 
+	        <nthrds_ocn>1</nthrds_ocn> 
+	        <nthrds_glc>1</nthrds_glc> 
+	        <nthrds_wav>1</nthrds_wav> 
+	        <nthrds_cpl>1</nthrds_cpl> 
+	      </nthrds>
+	      <rootpe>
+	        <rootpe_atm>0</rootpe_atm> 
+	        <rootpe_lnd>0</rootpe_lnd> 
+	        <rootpe_rof>0</rootpe_rof> 
+	        <rootpe_ice>0</rootpe_ice>    
+	        <rootpe_ocn>0</rootpe_ocn>   
+	        <rootpe_glc>0</rootpe_glc> 
+	        <rootpe_wav>0</rootpe_wav> 
+	        <rootpe_cpl>0</rootpe_cpl>                         
+        </rootpe>
+      </pes>
+    </mach>
+  </grid>
+
+  <grid name="a%C96" >
+    <mach name="any" >
+      <pes pesize="any" compset="any">
+        <comment>none</comment>
+	      <ntasks>
+	        <ntasks_atm>-16</ntasks_atm> 
+	        <ntasks_lnd>-16</ntasks_lnd>           
+	        <ntasks_rof>-16</ntasks_rof> 
+	        <ntasks_ice>-16</ntasks_ice> 
+	        <ntasks_ocn>-16</ntasks_ocn> 
+	        <ntasks_glc>-16</ntasks_glc> 
+	        <ntasks_wav>-16</ntasks_wav> 
+	        <ntasks_cpl>-16</ntasks_cpl> 
+	      </ntasks>
+	      <nthrds>
+	        <nthrds_atm>1</nthrds_atm>
+	        <nthrds_lnd>1</nthrds_lnd> 
+	        <nthrds_rof>1</nthrds_rof> 
+	        <nthrds_ice>1</nthrds_ice> 
+	        <nthrds_ocn>1</nthrds_ocn> 
+	        <nthrds_glc>1</nthrds_glc> 
+	        <nthrds_wav>1</nthrds_wav> 
+	        <nthrds_cpl>1</nthrds_cpl> 
+	      </nthrds>
+	      <rootpe>
+	        <rootpe_atm>0</rootpe_atm> 
+	        <rootpe_lnd>0</rootpe_lnd> 
+	        <rootpe_rof>0</rootpe_rof> 
+	        <rootpe_ice>0</rootpe_ice>    
+	        <rootpe_ocn>0</rootpe_ocn>   
+	        <rootpe_glc>0</rootpe_glc> 
+	        <rootpe_wav>0</rootpe_wav> 
+	        <rootpe_cpl>0</rootpe_cpl>                         
+        </rootpe>
+      </pes>
+    </mach>
+  </grid>
+
+  <grid name="a%C192" >
+    <mach name="any" >
+      <pes pesize="any" compset="any">
+        <comment>none</comment>
+	      <ntasks>
+	        <ntasks_atm>-32</ntasks_atm> 
+	        <ntasks_lnd>-32</ntasks_lnd>           
+	        <ntasks_rof>-32</ntasks_rof> 
+	        <ntasks_ice>-32</ntasks_ice> 
+	        <ntasks_ocn>-32</ntasks_ocn> 
+	        <ntasks_glc>-32</ntasks_glc> 
+	        <ntasks_wav>-32</ntasks_wav> 
+	        <ntasks_cpl>-32</ntasks_cpl> 
+	      </ntasks>
+	      <nthrds>
+	        <nthrds_atm>1</nthrds_atm>
+	        <nthrds_lnd>1</nthrds_lnd> 
+	        <nthrds_rof>1</nthrds_rof> 
+	        <nthrds_ice>1</nthrds_ice> 
+	        <nthrds_ocn>1</nthrds_ocn> 
+	        <nthrds_glc>1</nthrds_glc> 
+	        <nthrds_wav>1</nthrds_wav> 
+	        <nthrds_cpl>1</nthrds_cpl> 
+	      </nthrds>
+	      <rootpe>
+	        <rootpe_atm>0</rootpe_atm> 
+	        <rootpe_lnd>0</rootpe_lnd> 
+	        <rootpe_rof>0</rootpe_rof> 
+	        <rootpe_ice>0</rootpe_ice>    
+	        <rootpe_ocn>0</rootpe_ocn>   
+	        <rootpe_glc>0</rootpe_glc> 
+	        <rootpe_wav>0</rootpe_wav> 
+	        <rootpe_cpl>0</rootpe_cpl>                         
+        </rootpe>
+      </pes>
+    </mach>
+  </grid>
+
+  <grid name="a%C384" >
+    <mach name="any" >
+      <pes pesize="any" compset="any">
+        <comment>none</comment>
+	      <ntasks>
+	        <ntasks_atm>-32</ntasks_atm> 
+	        <ntasks_lnd>-32</ntasks_lnd>           
+	        <ntasks_rof>-32</ntasks_rof> 
+	        <ntasks_ice>-32</ntasks_ice> 
+	        <ntasks_ocn>-32</ntasks_ocn> 
+	        <ntasks_glc>-32</ntasks_glc> 
+	        <ntasks_wav>-32</ntasks_wav> 
+	        <ntasks_cpl>-32</ntasks_cpl> 
+	      </ntasks>
+	      <nthrds>
+	        <nthrds_atm>1</nthrds_atm>
+	        <nthrds_lnd>1</nthrds_lnd> 
+	        <nthrds_rof>1</nthrds_rof> 
+	        <nthrds_ice>1</nthrds_ice> 
+	        <nthrds_ocn>1</nthrds_ocn> 
+	        <nthrds_glc>1</nthrds_glc> 
+	        <nthrds_wav>1</nthrds_wav> 
+	        <nthrds_cpl>1</nthrds_cpl> 
+	      </nthrds>
+	      <rootpe>
+	        <rootpe_atm>0</rootpe_atm> 
+	        <rootpe_lnd>0</rootpe_lnd> 
+	        <rootpe_rof>0</rootpe_rof> 
+	        <rootpe_ice>0</rootpe_ice>    
+	        <rootpe_ocn>0</rootpe_ocn>   
+	        <rootpe_glc>0</rootpe_glc> 
+	        <rootpe_wav>0</rootpe_wav> 
+	        <rootpe_cpl>0</rootpe_cpl>                         
+        </rootpe>
+      </pes>
+    </mach>
+  </grid>
+
+
+  <!-- SE RR grids -->
+  <grid name="a%ne0np4.ARCTIC.ne30x4" >
+    <mach name="any" >
+      <pes pesize="any" compset="any">
+        <comment>none</comment>
+	      <ntasks>
+	        <ntasks_atm>-204</ntasks_atm> 
+	        <ntasks_lnd>-204</ntasks_lnd>           
+	        <ntasks_rof>-204</ntasks_rof> 
+	        <ntasks_ice>-204</ntasks_ice> 
+	        <ntasks_ocn>-204</ntasks_ocn> 
+	        <ntasks_glc>-204</ntasks_glc> 
+	        <ntasks_wav>-204</ntasks_wav> 
+	        <ntasks_cpl>-204</ntasks_cpl> 
+	      </ntasks>
+	      <nthrds>
+	        <nthrds_atm>1</nthrds_atm>
+	        <nthrds_lnd>1</nthrds_lnd> 
+	        <nthrds_rof>1</nthrds_rof> 
+	        <nthrds_ice>1</nthrds_ice> 
+	        <nthrds_ocn>1</nthrds_ocn> 
+	        <nthrds_glc>1</nthrds_glc> 
+	        <nthrds_wav>1</nthrds_wav> 
+	        <nthrds_cpl>1</nthrds_cpl> 
+	      </nthrds>
+	      <rootpe>
+	        <rootpe_atm>0</rootpe_atm> 
+	        <rootpe_lnd>0</rootpe_lnd> 
+	        <rootpe_rof>0</rootpe_rof> 
+	        <rootpe_ice>0</rootpe_ice>    
+	        <rootpe_ocn>0</rootpe_ocn>   
+	        <rootpe_glc>0</rootpe_glc> 
+	        <rootpe_wav>0</rootpe_wav> 
+	        <rootpe_cpl>0</rootpe_cpl>                         
+        </rootpe>
+      </pes>
+    </mach>
+  </grid>
+
+  <grid name="a%ne0np4.ARCTICGRIS.ne30x8" >
+    <mach name="any" >
+      <pes pesize="any" compset="any">
+        <comment>none</comment>
+	      <ntasks>
+	        <ntasks_atm>-265</ntasks_atm> 
+	        <ntasks_lnd>-265</ntasks_lnd>           
+	        <ntasks_rof>-265</ntasks_rof> 
+	        <ntasks_ice>-265</ntasks_ice> 
+	        <ntasks_ocn>-265</ntasks_ocn> 
+	        <ntasks_glc>-265</ntasks_glc> 
+	        <ntasks_wav>-265</ntasks_wav> 
+	        <ntasks_cpl>-265</ntasks_cpl> 
+	      </ntasks>
+	      <nthrds>
+	        <nthrds_atm>1</nthrds_atm>
+	        <nthrds_lnd>1</nthrds_lnd> 
+	        <nthrds_rof>1</nthrds_rof> 
+	        <nthrds_ice>1</nthrds_ice> 
+	        <nthrds_ocn>1</nthrds_ocn> 
+	        <nthrds_glc>1</nthrds_glc> 
+	        <nthrds_wav>1</nthrds_wav> 
+	        <nthrds_cpl>1</nthrds_cpl> 
+	      </nthrds>
+	      <rootpe>
+	        <rootpe_atm>0</rootpe_atm> 
+	        <rootpe_lnd>0</rootpe_lnd> 
+	        <rootpe_rof>0</rootpe_rof> 
+	        <rootpe_ice>0</rootpe_ice>    
+	        <rootpe_ocn>0</rootpe_ocn>   
+	        <rootpe_glc>0</rootpe_glc> 
+	        <rootpe_wav>0</rootpe_wav> 
+	        <rootpe_cpl>0</rootpe_cpl>                         
+        </rootpe>
+      </pes>
+    </mach>
+  </grid>
+
+  <grid name="a%ne0np4.CONUS" >
+    <mach name="any" >
+      <pes pesize="any" compset="any">
+        <comment>none</comment>
+	      <ntasks>
+	        <ntasks_atm>-303</ntasks_atm> 
+	        <ntasks_lnd>-303</ntasks_lnd>           
+	        <ntasks_rof>-303</ntasks_rof> 
+	        <ntasks_ice>-303</ntasks_ice> 
+	        <ntasks_ocn>-303</ntasks_ocn> 
+	        <ntasks_glc>-303</ntasks_glc> 
+	        <ntasks_wav>-303</ntasks_wav> 
+	        <ntasks_cpl>-303</ntasks_cpl> 
+	      </ntasks>
+	      <nthrds>
+	        <nthrds_atm>1</nthrds_atm>
+	        <nthrds_lnd>1</nthrds_lnd> 
+	        <nthrds_rof>1</nthrds_rof> 
+	        <nthrds_ice>1</nthrds_ice> 
+	        <nthrds_ocn>1</nthrds_ocn> 
+	        <nthrds_glc>1</nthrds_glc> 
+	        <nthrds_wav>1</nthrds_wav> 
+	        <nthrds_cpl>1</nthrds_cpl> 
+	      </nthrds>
+	      <rootpe>
+	        <rootpe_atm>0</rootpe_atm> 
+	        <rootpe_lnd>0</rootpe_lnd> 
+	        <rootpe_rof>0</rootpe_rof> 
+	        <rootpe_ice>0</rootpe_ice>    
+	        <rootpe_ocn>0</rootpe_ocn>   
+	        <rootpe_glc>0</rootpe_glc> 
+	        <rootpe_wav>0</rootpe_wav> 
+	        <rootpe_cpl>0</rootpe_cpl>                         
+        </rootpe>
+      </pes>
+    </mach>
+  </grid>
+
 
   <overrides>
     <grid name="any" >

--- a/cime_config/testdefs/testlist_cam.xml
+++ b/cime_config/testdefs/testlist_cam.xml
@@ -223,7 +223,7 @@
       <option name="wallclock">00:10:00</option>
     </options>
   </test>
-  <test compset="QSC6" grid="ne30_ne30_mg17" name="ERP_Ln9" testmods="cam/outfrq9s">
+  <test compset="QPC6" grid="ne30_ne30_mg17" name="ERP_Ln9" testmods="cam/outfrq9s">
     <machines>
       <machine name="cheyenne" compiler="intel" category="prebeta"/>
     </machines>

--- a/cime_config/testdefs/testmods_dirs/cam/outfrq1d_refined_camchem/shell_commands
+++ b/cime_config/testdefs/testmods_dirs/cam/outfrq1d_refined_camchem/shell_commands
@@ -1,2 +1,2 @@
 ./xmlchange RUN_STARTDATE=2013-10-01
-./xmlchange NTASKS=-8
+./xmlchange NTASKS=-16

--- a/cime_config/testdefs/testmods_dirs/cam/outfrq1d_refined_camchem/shell_commands
+++ b/cime_config/testdefs/testmods_dirs/cam/outfrq1d_refined_camchem/shell_commands
@@ -1,1 +1,2 @@
 ./xmlchange RUN_STARTDATE=2013-10-01
+./xmlchange NTASKS=-8

--- a/cime_config/testdefs/testmods_dirs/cam/outfrq1d_refined_camchem/shell_commands
+++ b/cime_config/testdefs/testmods_dirs/cam/outfrq1d_refined_camchem/shell_commands
@@ -1,2 +1,2 @@
 ./xmlchange RUN_STARTDATE=2013-10-01
-./xmlchange NTASKS=-16
+./xmlchange NTASKS=-50

--- a/cime_config/testdefs/testmods_dirs/cam/outfrq9s_mg3/shell_commands
+++ b/cime_config/testdefs/testmods_dirs/cam/outfrq9s_mg3/shell_commands
@@ -1,3 +1,6 @@
 ./xmlchange ROF_NCPL=\$ATM_NCPL
 ./xmlchange GLC_NCPL=\$ATM_NCPL
 ./xmlchange CAM_CONFIG_OPTS=' -microphys mg3' --append
+if [ "`./xmlquery ATM_GRID --value`" == "C96" ]; then
+  ./xmlchange NTASKS=-1
+fi

--- a/cime_config/testdefs/testmods_dirs/cam/outfrq9s_refined_camchem/shell_commands
+++ b/cime_config/testdefs/testmods_dirs/cam/outfrq9s_refined_camchem/shell_commands
@@ -1,0 +1,1 @@
+./xmlchange NTASKS=-8

--- a/cime_config/testdefs/testmods_dirs/cam/outfrq9s_refined_camchem/shell_commands
+++ b/cime_config/testdefs/testmods_dirs/cam/outfrq9s_refined_camchem/shell_commands
@@ -1,1 +1,1 @@
-./xmlchange NTASKS=-8
+./xmlchange NTASKS=-16

--- a/cime_config/testdefs/testmods_dirs/cam/outfrq9s_refined_camchem/shell_commands
+++ b/cime_config/testdefs/testmods_dirs/cam/outfrq9s_refined_camchem/shell_commands
@@ -1,1 +1,1 @@
-./xmlchange NTASKS=-16
+./xmlchange NTASKS=-50


### PR DESCRIPTION
Hi all,

  There are several small, non-code changes in this PR - it's my first, so bear with me, and provide any and all feedback that might help in the future:

 1) Switched the ne30 QSC6 prebeta test to QPC6:
Fixed #195 
 2a) Removed Yellowstone/Casper entries from config_pes.xml
 2b) Removed Edison/Eos entries (decommissioned systems) from config_pes.xml
Fixed #185 
 3a) Added entries for FV3 grids:

  C24 - 1 node, ~9.1 SYPD
  C48 - 4 nodes, ~9.7 SYPD
  C96 - 16 nodes, ~8.5 SYPD
  C192 - 32 nodes, ~2.9 SYPD
  C384 - 32 nodes, ??? SYPD

  These last two had slowdown during initialization due to non-scalable sections of code, so further tests were not yet done.  We can retest and alter these with new code that addresses those.

  3b) Added entries for SE RR grids:

  ne0np4.ARCTIC.ne30x4 - 91 nodes, ??? SYPD
  ne0np4.ARCTICGRIS.ne30x8 - 118 nodes, ??? SYPD
  ne0np4CONUS - 135 nodes, ??? SYPD

  These tests were not getting through the queue, so I don't have numbers yet.  Adam H is running a the ARCTIC case on 214 nodes, so despite the large increase (from 8!) for CONUS, these all seem reasonable.  They were chosen to give each rank ~4 elements. (Based on corrected numbers by Adam H.)  

 Fixed #183 

 4) NOT CHANGED, but maybe should be - the above have 'ne0np4' as a prefix, but the CONUS grid doesn't have a period ('.') after the prefix, whereas both ARCTIC grids do.  The ARCTIC grids were newly added to the file, whereas CONUS was not, so I didn't change it.  But I wanted feedback on that from reviewers. 