### PR TITLE
cam6_3_005: Enable "-chem none" configure option with cam6 physics

### DIFF
--- a/bld/build-namelist
+++ b/bld/build-namelist
@@ -2893,7 +2893,9 @@ if ($cfg->get('microphys') =~ /^mg/) {
 
 # Ice nucleation options
 if (!$simple_phys) {
-    add_default($nl, 'use_hetfrz_classnuc');
+    if ($chem =~ /_mam/) {
+        add_default($nl, 'use_hetfrz_classnuc');
+    }
     add_default($nl, 'use_preexisting_ice');
     if ($chem =~ /_mam7/) {
         if ($nl->get_value('use_preexisting_ice') =~ m/$TRUE/io) {

--- a/bld/build-namelist
+++ b/bld/build-namelist
@@ -2895,6 +2895,8 @@ if ($cfg->get('microphys') =~ /^mg/) {
 if (!$simple_phys) {
     if ($chem =~ /_mam/) {
         add_default($nl, 'use_hetfrz_classnuc');
+    } else {
+        add_default($nl, 'use_hetfrz_classnuc', 'val'=>'.false.');
     }
     add_default($nl, 'use_preexisting_ice');
     if ($chem =~ /_mam7/) {

--- a/cime_config/testdefs/testlist_cam.xml
+++ b/cime_config/testdefs/testlist_cam.xml
@@ -785,6 +785,15 @@
       <option name="wallclock">00:30:00</option>
     </options>
   </test>
+  <test compset="QPC6" grid="f10_f10_mg37" name="SMS_D_Ln9" testmods="cam/outfrq3s_ba">
+    <machines>
+      <machine name="izumi" compiler="nag" category="aux_cam"/>
+    </machines>
+    <options>
+      <option name="comment" >cam6 physics with prescribed bulk aerosols</option>
+      <option name="wallclock">00:30:00</option>
+    </options>
+  </test>
 <!--              003                        -->
   <test compset="QPSCAMC5" grid="T42_T42_mg17" name="SMS_D_Ln7" testmods="cam/scmarm">
     <machines>


### PR DESCRIPTION
Do not set use_hetfrz_classnuc if chemistry does not include MAM species.

Added aux_cam test which uses aquaplanet cam6 physics and -chem none.

closes #261
