### PR TITLE
Remove support for CISM1

### DIFF
--- a/cime_config/config_compsets.xml
+++ b/cime_config/config_compsets.xml
@@ -18,7 +18,7 @@
     ICE  = [CICE, DICE, SICE]
     OCN  = [DOCN, ,AQUAP, SOCN]
     ROF  = [RTM, SROF]
-    GLC  = [CISM1, CISM2, SGLC]
+    GLC  = [CISM2, SGLC]
     WAV  = [SWAV]
     BGC  = optional BGC scenario
 

--- a/cime_config/config_pes.xml
+++ b/cime_config/config_pes.xml
@@ -1550,14 +1550,6 @@
             <nthrds_cpl>1</nthrds_cpl>
           </nthrds>
         </pes>
-        <pes pesize="any" compset="CISM1">
-          <ntasks>
-            <ntasks_glc>1</ntasks_glc>
-          </ntasks>
-          <nthrds>
-            <nthrds_glc>1</nthrds_glc>
-          </nthrds>
-        </pes>
       </mach>
     </grid>
   </overrides>


### PR DESCRIPTION
As of cism2_1_74, CISM1 is no longer supported, so we don't need to have a PE layout section for it.

I haven't done any testing of this simple change. I am assuming you'll want to just combine it with some other changes at some point.