### PR TITLE
cam6_3_008: Fixes for PIO2 plus nudging I/O update

### DIFF
--- a/src/chemistry/mozart/mo_drydep.F90
+++ b/src/chemistry/mozart/mo_drydep.F90
@@ -1,7 +1,7 @@
 module mo_drydep
 
   !---------------------------------------------------------------------
-  !       ... Dry deposition 
+  !       ... Dry deposition
   !---------------------------------------------------------------------
 
   use shr_kind_mod,     only : r8 => shr_kind_r8, shr_kind_cl
@@ -80,7 +80,7 @@ module mo_drydep
   integer, parameter :: n_land_type = 11
 
   integer, allocatable :: spc_ndx(:) ! nddvels
-  real(r8), public :: crb 
+  real(r8), public :: crb
 
   type lnd_dvel_type
      real(r8), pointer :: dvel(:,:)   ! deposition velocity over land (cm/s)
@@ -93,7 +93,7 @@ contains
 
   !---------------------------------------------------------------------------
   !---------------------------------------------------------------------------
-  subroutine dvel_inti_fromlnd 
+  subroutine dvel_inti_fromlnd
     use mo_chem_utls,         only : get_spc_ndx
     use cam_abortutils,       only : endrun
 
@@ -120,10 +120,10 @@ contains
   !-------------------------------------------------------------------------------------
   subroutine drydep_update( state, cam_in )
     use physics_types,   only : physics_state
-    use camsrfexch,      only : cam_in_t     
+    use camsrfexch,      only : cam_in_t
 
     type(physics_state), intent(in) :: state           ! Physics state variables
-    type(cam_in_t),  intent(in) :: cam_in 
+    type(cam_in_t),  intent(in) :: cam_in
 
     if (nddvels<1) return
 
@@ -137,15 +137,15 @@ contains
                              wind_speed, spec_hum, air_temp, pressure_10m, rain, &
                              snow, solar_flux, dvelocity, dflx, mmr, &
                              tv, ncol, lchnk )
-                          
+
     !-------------------------------------------------------------------------------------
-    ! combines the deposition velocities provided by the land model with deposition 
-    ! velocities over ocean and sea ice 
+    ! combines the deposition velocities provided by the land model with deposition
+    ! velocities over ocean and sea ice
     !-------------------------------------------------------------------------------------
 
     use ppgrid,         only : pcols
     use chem_mods,      only : gas_pcnst
-      
+
 #if (defined OFFLINE_DYN)
     use metdata, only: get_met_fields
 #endif
@@ -154,8 +154,8 @@ contains
     ! 	... dummy arguments
     !-------------------------------------------------------------------------------------
 
-    real(r8), intent(in)      :: icefrac(pcols)            
-    real(r8), intent(in)      :: ocnfrac(pcols)            
+    real(r8), intent(in)      :: icefrac(pcols)
+    real(r8), intent(in)      :: ocnfrac(pcols)
     integer,  intent(in)      :: ncol
     integer,  intent(in)      :: lchnk                    ! chunk number
     real(r8), intent(in)      :: sfc_temp(pcols)          ! surface temperature (K)
@@ -164,7 +164,7 @@ contains
     real(r8), intent(in)      :: spec_hum(pcols)          ! specific humidity (kg/kg)
     real(r8), intent(in)      :: air_temp(pcols)          ! surface air temperature (K)
     real(r8), intent(in)      :: pressure_10m(pcols)      ! 10 meter pressure (Pa)
-    real(r8), intent(in)      :: rain(pcols)              
+    real(r8), intent(in)      :: rain(pcols)
     real(r8), intent(in)      :: snow(pcols)              ! snow height (m)
     real(r8), intent(in)      :: solar_flux(pcols)        ! direct shortwave radiation at surface (W/m^2)
     real(r8), intent(in)      :: tv(pcols)                ! potential temperature
@@ -180,17 +180,17 @@ contains
 
     real(r8), dimension(ncol) :: term    ! work array
     integer  :: ispec
-    real(r8)  :: lndfrac(pcols)            
+    real(r8)  :: lndfrac(pcols)
 #if (defined OFFLINE_DYN)
     real(r8)  :: met_ocnfrac(pcols)
-    real(r8)  :: met_icefrac(pcols)            
+    real(r8)  :: met_icefrac(pcols)
 #endif
     integer :: i
 
     lndfrac(:ncol) = 1._r8 - ocnfrac(:ncol) - icefrac(:ncol)
 
-    where( lndfrac(:ncol) < 0._r8 ) 
-       lndfrac(:ncol) = 0._r8 
+    where( lndfrac(:ncol) < 0._r8 )
+       lndfrac(:ncol) = 0._r8
     endwhere
 
 #if (defined OFFLINE_DYN)
@@ -201,7 +201,7 @@ contains
     !   ... initialize
     !-------------------------------------------------------------------------------------
     dvelocity(:,:) = 0._r8
-    
+
     !-------------------------------------------------------------------------------------
     !   ... compute the dep velocities over ocean and sea ice
     !       land type 7 is used for ocean
@@ -226,7 +226,7 @@ contains
        dvelocity(:ncol,spc_ndx(ispec)) = lnd(lchnk)%dvel(:ncol,ispec)*lndfrac(:ncol) &
                                        + ocnice_dvel(:ncol,spc_ndx(ispec))
     enddo
-    
+
     !-------------------------------------------------------------------------------------
     !        ... special adjustments
     !-------------------------------------------------------------------------------------
@@ -249,10 +249,10 @@ contains
           dvelocity(:ncol,hcooh_ndx) = dvelocity(:ncol,ch3cooh_ndx)
        end if
     end if
-    
+
     !-------------------------------------------------------------------------------------
     !        ... assign CO tags to CO
-    ! put this kludge in for now ...  
+    ! put this kludge in for now ...
     !  -- should be able to set all these via the table mapping in seq_drydep_mod
     !-------------------------------------------------------------------------------------
     if( cohc_ndx>0 .and. co_ndx>0 ) then
@@ -533,11 +533,11 @@ contains
     use ncdio_atm, only : infld
 
     logical :: readvar
-    
+
     type(file_desc_t) :: piofile
     character(len=shr_kind_cl) :: locfn
     logical :: lexist
-    
+
     call getfil (drydep_srf_file, locfn, 1, lexist)
     if(lexist) then
        call cam_pio_openfile(piofile, locfn, PIO_NOWRITE)
@@ -630,10 +630,10 @@ contains
     if (single_column) then
        if (scm_cambfb_mode) then
           piofile => initial_file_get_id()
-          call shr_scam_getCloseLatLon(piofile%fh,scmlat,scmlon,closelat,closelon,latidx,lonidx)
+          call shr_scam_getCloseLatLon(piofile,scmlat,scmlon,closelat,closelon,latidx,lonidx)
           ploniop=size(loniop)
           platiop=size(latiop)
-       else 
+       else
           latidx=1
           lonidx=1
           ploniop=1
@@ -697,7 +697,7 @@ contains
     write(iulog,*) 'interp_map : mapping_ext ',mapping_ext
 #endif
     do j = 1,plon+1
-       lon1 = lon_edge(j) 
+       lon1 = lon_edge(j)
        do i = -veg_ext,nlon_veg+veg_ext
           dx = lon_veg_edge_ext(i  ) - lon1
           dy = lon_veg_edge_ext(i+1) - lon1
@@ -729,17 +729,17 @@ contains
           fraction         = 0._r8
           do jj = ind_lat(j),ind_lat(j+1)
              y1 = max( lat_edge(j),lat_veg_edge(jj) )
-             y2 = min( lat_edge(j+1),lat_veg_edge(jj+1) ) 
+             y2 = min( lat_edge(j+1),lat_veg_edge(jj+1) )
              dy = (y2 - y1)/(lat_veg_edge(jj+1) - lat_veg_edge(jj))
              do ii =ind_lon(i),ind_lon(i+1)
                 i_ndx = mapping_ext(ii)
                 x1 = max( lon_edge(i),lon_veg_edge_ext(ii) )
-                x2 = min( lon_edge(i+1),lon_veg_edge_ext(ii+1) ) 
+                x2 = min( lon_edge(i+1),lon_veg_edge_ext(ii+1) )
                 dx = (x2 - x1)/(lon_veg_edge_ext(ii+1) - lon_veg_edge_ext(ii))
                 area = dx * dy
                 total_area = total_area + area
                 !-----------------------------------------------------------------
-                ! 	... special case for ocean grid point 
+                ! 	... special case for ocean grid point
                 !-----------------------------------------------------------------
                 if( nint(landmask(i_ndx,jj)) == 0 ) then
                    fraction(npft_veg+1) = fraction(npft_veg+1) + area
@@ -790,7 +790,7 @@ contains
           tmp_frac_lu(i,11, j) = sum(fraction(10:12))
        end do lon_loop
     end do lat_loop
-    
+
     do lchnk = begchunk, endchunk
        ncol = get_ncols_p(lchnk)
        call get_rlat_all_p(lchnk, ncol, rlats(:ncol))
@@ -819,7 +819,7 @@ contains
     end do
 
   end subroutine interp_map
-  
+
   !-------------------------------------------------------------------------------------
   !-------------------------------------------------------------------------------------
   subroutine drydep_xactive( sfc_temp, pressure_sfc,  &
@@ -860,7 +860,7 @@ contains
     real(r8), intent(in)      :: spec_hum(pcols)          ! specific humidity (kg/kg)
     real(r8), intent(in)      :: air_temp(pcols)          ! surface air temperature (K)
     real(r8), intent(in)      :: pressure_10m(pcols)      ! 10 meter pressure (Pa)
-    real(r8), intent(in)      :: rain(pcols)              
+    real(r8), intent(in)      :: rain(pcols)
     real(r8), intent(in)      :: snow(pcols)              ! snow height (m)
 
     real(r8), intent(in)      :: solar_flux(pcols)        ! direct shortwave radiation at surface (W/m^2)
@@ -874,8 +874,8 @@ contains
     integer, intent(in), optional     ::  beglandtype
     integer, intent(in), optional     ::  endlandtype
 
-    real(r8), intent(in), optional      :: ocnfrc(pcols) 
-    real(r8), intent(in), optional      :: icefrc(pcols) 
+    real(r8), intent(in), optional      :: ocnfrc(pcols)
+    real(r8), intent(in), optional      :: icefrc(pcols)
 
     !-------------------------------------------------------------------------------------
     ! 	... local variables
@@ -952,7 +952,7 @@ contains
     logical  :: fr_lnduse(ncol,n_land_type)           ! wrking array
     real(r8) :: dewm                                  ! multiplier for rs when dew occurs
 
-    real(r8) :: lcl_frc_landuse(ncol,n_land_type) 
+    real(r8) :: lcl_frc_landuse(ncol,n_land_type)
 
     integer :: beglt, endlt
 
@@ -966,16 +966,16 @@ contains
                                 0.005_r8, 0.000_r8, 0.000_r8, 0.000_r8, 0.075_r8, 0.002_r8 /)
 
     if (present( beglandtype)) then
-      beglt = beglandtype 
+      beglt = beglandtype
     else
       beglt = 1
     endif
     if (present( endlandtype)) then
-      endlt = endlandtype 
+      endlt = endlandtype
     else
       endlt = n_land_type
     endif
-  
+
     !-------------------------------------------------------------------------------------
     ! initialize
     !-------------------------------------------------------------------------------------
@@ -1001,7 +1001,7 @@ contains
     !-------------------------------------------------------------------------------------
     ! season index only for ocn and sea ice
     !-------------------------------------------------------------------------------------
-    index_season = 4 
+    index_season = 4
     !-------------------------------------------------------------------------------------
     ! special case for snow covered terrain
     !-------------------------------------------------------------------------------------
@@ -1141,7 +1141,7 @@ contains
     !-------------------------------------------------------------------------------------
     ! revise calculation of friction velocity and z0 over water
     !-------------------------------------------------------------------------------------
-    lt = 7    
+    lt = 7
     do i = 1,ncol
        if( fr_lnduse(i,lt) ) then
           if( unstable(i) ) then
@@ -1386,7 +1386,7 @@ contains
                 if( lt == 7 ) then
                    where( fr_lnduse(:ncol,lt) )
                       ! assume no surface resistance for SO2 over water`
-                      wrk(:) = wrk(:) + lnd_frc(:)/(dep_ra(:ncol,lt,lchnk) + dep_rb(:ncol,lt,lchnk)) 
+                      wrk(:) = wrk(:) + lnd_frc(:)/(dep_ra(:ncol,lt,lchnk) + dep_rb(:ncol,lt,lchnk))
                    endwhere
                 else
                    where( fr_lnduse(:ncol,lt) )

--- a/src/control/cam_history.F90
+++ b/src/control/cam_history.F90
@@ -97,15 +97,19 @@ module cam_history
   type (active_entry), target, allocatable :: restarthistory_tape(:) ! restart history tapes
 
   type rvar_id
-    type(var_desc_t), pointer :: vdesc => null()
-    integer :: type
-    integer :: ndims
-    integer :: dims(4)
+    type(var_desc_t), pointer      :: vdesc => null()
+    integer                        :: type
+    integer                        :: ndims
+    integer                        :: dims(4)
     character(len=fieldname_lenp2) :: name
+    logical                        :: fillset = .false.
+    integer                        :: ifill
+    real(r4)                       :: rfill
+    real(r8)                       :: dfill
   end type rvar_id
   type rdim_id
-    integer :: len
-    integer :: dimid
+    integer                        :: len
+    integer                        :: dimid
     character(len=fieldname_lenp2) :: name
   end type rdim_id
   !
@@ -1044,6 +1048,8 @@ CONTAINS
     restartvars(rvindex)%ndims = 2
     restartvars(rvindex)%dims(1) = maxnflds_dim_ind
     restartvars(rvindex)%dims(2) = ptapes_dim_ind
+    restartvars(rvindex)%fillset = .true.
+    restartvars(rvindex)%ifill = 0
 
     rvindex = rvindex + 1
     restartvars(rvindex)%name = 'numlev'
@@ -1051,6 +1057,8 @@ CONTAINS
     restartvars(rvindex)%ndims = 2
     restartvars(rvindex)%dims(1) = maxnflds_dim_ind
     restartvars(rvindex)%dims(2) = ptapes_dim_ind
+    restartvars(rvindex)%fillset = .true.
+    restartvars(rvindex)%ifill = 0
 
     rvindex = rvindex + 1
     restartvars(rvindex)%name = 'hrestpath'
@@ -1065,6 +1073,8 @@ CONTAINS
     restartvars(rvindex)%ndims = 2
     restartvars(rvindex)%dims(1) = maxnflds_dim_ind
     restartvars(rvindex)%dims(2) = ptapes_dim_ind
+    restartvars(rvindex)%fillset = .true.
+    restartvars(rvindex)%ifill = 0
 
     rvindex = rvindex + 1
     restartvars(rvindex)%name = 'avgflag'
@@ -1130,6 +1140,9 @@ CONTAINS
     restartvars(rvindex)%ndims = 2
     restartvars(rvindex)%dims(1) = maxnflds_dim_ind
     restartvars(rvindex)%dims(2) = ptapes_dim_ind
+    restartvars(rvindex)%fillset = .true.
+    restartvars(rvindex)%dfill = 0.0
+
 
     rvindex = rvindex + 1
     restartvars(rvindex)%name = 'mdims'
@@ -1189,6 +1202,8 @@ CONTAINS
     restartvars(rvindex)%ndims = 2
     restartvars(rvindex)%dims(1) = maxnflds_dim_ind
     restartvars(rvindex)%dims(2) = ptapes_dim_ind
+    restartvars(rvindex)%fillset = .true.
+    restartvars(rvindex)%ifill = 0
 
     rvindex = rvindex + 1
     restartvars(rvindex)%name = 'zonal_complement'
@@ -1196,6 +1211,8 @@ CONTAINS
     restartvars(rvindex)%ndims = 2
     restartvars(rvindex)%dims(1) = maxnflds_dim_ind
     restartvars(rvindex)%dims(2) = ptapes_dim_ind
+    restartvars(rvindex)%fillset = .true.
+    restartvars(rvindex)%ifill = 0
 
   end subroutine restart_vars_setnames
 
@@ -1276,7 +1293,19 @@ CONTAINS
         allocate(restartvars(i)%vdesc)
         ierr = pio_def_var(File, restartvars(i)%name, restartvars(i)%type, dimids(1:ndims), restartvars(i)%vdesc)
         call cam_pio_handle_error(ierr, 'INIT_RESTART_HISTORY: Error defining '//trim(restartvars(i)%name))
-
+        if(restartvars(i)%fillset) then
+           if(restartvars(i)%type == PIO_INT) then
+              ierr = pio_put_att(File, restartvars(i)%vdesc, "_FillValue",    &
+                   restartvars(i)%ifill)
+           elseif(restartvars(i)%type == PIO_REAL) then
+              ierr = pio_put_att(File, restartvars(i)%vdesc, "_FillValue",    &
+                   restartvars(i)%rfill)
+           elseif(restartvars(i)%type == PIO_DOUBLE) then
+              ierr = pio_put_att(File, restartvars(i)%vdesc, "_FillValue",    &
+                   restartvars(i)%dfill)
+           endif
+           call cam_pio_handle_error(ierr, 'INIT_RESTART_HISTORY: Error setting fill'//trim(restartvars(i)%name))
+        endif
       end do
     end if
   end subroutine init_restart_history
@@ -4683,6 +4712,7 @@ end subroutine print_active_fldlst
     integer                          :: fdecomp
     integer                          :: num_patches
     integer                          :: mdimsize   ! Total # on-node elements
+    integer                          :: bdim3, edim3
     logical                          :: interpolate
     logical                          :: patch_output
     type(history_patch_t), pointer   :: patchptr
@@ -4760,11 +4790,25 @@ end subroutine print_active_fldlst
           end if
         else if (nadims == 2) then
           ! Special case for 2D field (no levels) due to hbuf structure
-          call cam_grid_write_dist_array(tape(t)%File, fdecomp,               &
-               adims(1:nadims), fdims(1:frank), tape(t)%hlist(f)%hbuf(:,1,:), varid)
+           if(tape(t)%hlist(f)%hwrt_prec == 4) Then
+              call cam_grid_write_dist_array(tape(t)%File, fdecomp,           &
+                   adims(1:nadims), fdims(1:frank),                           &
+                   real(tape(t)%hlist(f)%hbuf(:,1,:), kind=r4), varid)
+           else
+              call cam_grid_write_dist_array(tape(t)%File, fdecomp,           &
+                   adims(1:nadims), fdims(1:frank),                           &
+                   tape(t)%hlist(f)%hbuf(:,1,:), varid)
+           end if
         else
-          call cam_grid_write_dist_array(tape(t)%File, fdecomp, adims,        &
-               fdims(1:frank), tape(t)%hlist(f)%hbuf, varid)
+           if(tape(t)%hlist(f)%hwrt_prec == 4) Then
+              call cam_grid_write_dist_array(tape(t)%File, fdecomp, adims,    &
+                   fdims(1:frank),                                            &
+                   real(tape(t)%hlist(f)%hbuf, kind=r4), varid)
+           else
+              call cam_grid_write_dist_array(tape(t)%File, fdecomp, adims,    &
+                   fdims(1:frank),                                            &
+                   tape(t)%hlist(f)%hbuf, varid)
+           end if
         end if
       end if
     end do
@@ -4774,11 +4818,13 @@ end subroutine print_active_fldlst
            ! write variance data to restart file for standard deviation calc
           if (nadims == 2) then
            ! Special case for 2D field (no levels) due to sbuf structure
-             call cam_grid_write_dist_array(tape(t)%File, fdecomp, adims(1:nadims), &
-                  fdims(1:frank), tape(t)%hlist(f)%sbuf(:,1,:), tape(t)%hlist(f)%sbuf_varid)
+             call cam_grid_write_dist_array(tape(t)%File, fdecomp,            &
+                  adims(1:nadims), fdims(1:frank),                            &
+                  tape(t)%hlist(f)%sbuf(:,1,:), tape(t)%hlist(f)%sbuf_varid)
           else
-             call cam_grid_write_dist_array(tape(t)%File, fdecomp, adims,        &
-                  fdims(1:frank), tape(t)%hlist(f)%sbuf, tape(t)%hlist(f)%sbuf_varid)
+             call cam_grid_write_dist_array(tape(t)%File, fdecomp, adims,     &
+                  fdims(1:frank), tape(t)%hlist(f)%sbuf,                      &
+                  tape(t)%hlist(f)%sbuf_varid)
           endif
        endif
      !! NACS
@@ -4788,11 +4834,14 @@ end subroutine print_active_fldlst
              nadims = 2
           end if
           call cam_grid_dimensions(fdecomp, fdims(1:2), nacsrank)
-          call cam_grid_write_dist_array(tape(t)%File, fdecomp, adims(1:nadims), &
-               fdims(1:nacsrank), tape(t)%hlist(f)%nacs, tape(t)%hlist(f)%nacs_varid)
+          call cam_grid_write_dist_array(tape(t)%File, fdecomp, &
+               adims(1:nadims), fdims(1:nacsrank), &
+               tape(t)%hlist(f)%nacs, tape(t)%hlist(f)%nacs_varid)
        else
-          ierr = pio_put_var(tape(t)%File, tape(t)%hlist(f)%nacs_varid,     &
-               tape(t)%hlist(f)%nacs(:, tape(t)%hlist(f)%field%begdim3:tape(t)%hlist(f)%field%enddim3))
+          bdim3 = tape(t)%hlist(f)%field%begdim3
+          edim3 = tape(t)%hlist(f)%field%enddim3
+          ierr = pio_put_var(tape(t)%File, tape(t)%hlist(f)%nacs_varid,       &
+               tape(t)%hlist(f)%nacs(:, bdim3:edim3))
        end if
     end if
 

--- a/src/control/cam_history.F90
+++ b/src/control/cam_history.F90
@@ -1141,7 +1141,7 @@ CONTAINS
     restartvars(rvindex)%dims(1) = maxnflds_dim_ind
     restartvars(rvindex)%dims(2) = ptapes_dim_ind
     restartvars(rvindex)%fillset = .true.
-    restartvars(rvindex)%dfill = 0.0
+    restartvars(rvindex)%dfill = 0.0_r8
 
 
     rvindex = rvindex + 1
@@ -1285,10 +1285,10 @@ CONTAINS
              restartdims(i)%dimid, existOK=.true.)
       end do
 
-      do i=1,restartvarcnt
-        ndims= restartvars(i)%ndims
-        do k=1,ndims
-          dimids(k)=restartdims(restartvars(i)%dims(k))%dimid
+      do i = 1, restartvarcnt
+        ndims = restartvars(i)%ndims
+        do k = 1 ,ndims
+          dimids(k) = restartdims(restartvars(i)%dims(k))%dimid
         end do
         allocate(restartvars(i)%vdesc)
         ierr = pio_def_var(File, restartvars(i)%name, restartvars(i)%type, dimids(1:ndims), restartvars(i)%vdesc)
@@ -1297,15 +1297,15 @@ CONTAINS
            if(restartvars(i)%type == PIO_INT) then
               ierr = pio_put_att(File, restartvars(i)%vdesc, "_FillValue",    &
                    restartvars(i)%ifill)
-           elseif(restartvars(i)%type == PIO_REAL) then
+           else if(restartvars(i)%type == PIO_REAL) then
               ierr = pio_put_att(File, restartvars(i)%vdesc, "_FillValue",    &
                    restartvars(i)%rfill)
-           elseif(restartvars(i)%type == PIO_DOUBLE) then
+           else if(restartvars(i)%type == PIO_DOUBLE) then
               ierr = pio_put_att(File, restartvars(i)%vdesc, "_FillValue",    &
                    restartvars(i)%dfill)
-           endif
+           end if
            call cam_pio_handle_error(ierr, 'INIT_RESTART_HISTORY: Error setting fill'//trim(restartvars(i)%name))
-        endif
+        end if
       end do
     end if
   end subroutine init_restart_history

--- a/src/control/cam_restart.F90
+++ b/src/control/cam_restart.F90
@@ -6,7 +6,7 @@ use shr_kind_mod,     only: cl=>shr_kind_cl
 use spmd_utils,       only: masterproc
 use cam_control_mod,  only: restart_run, caseid
 use ioFileMod,        only: opnfil
-use camsrfexch,       only: cam_in_t, cam_out_t     
+use camsrfexch,       only: cam_in_t, cam_out_t
 use dyn_comp,         only: dyn_import_t, dyn_export_t
 use physics_buffer,   only: physics_buffer_desc
 use units,            only: getunit, freeunit
@@ -53,11 +53,11 @@ subroutine cam_read_restart(cam_in, cam_out, dyn_in, dyn_out, pbuf2d, &
 
    character(len=*), parameter :: sub = 'cam_read_restart'
    !---------------------------------------------------------------------------
-  
+
    ! get filehandle pointer to primary restart file
    fh_ini => initial_file_get_id()
 
-   call read_restart_dynamics(fh_ini, dyn_in, dyn_out)   
+   call read_restart_dynamics(fh_ini, dyn_in, dyn_out)
    call ionosphere_read_restart(fh_ini)
 
    call hub2atm_alloc(cam_in)
@@ -79,7 +79,7 @@ subroutine cam_write_restart(cam_in, cam_out, dyn_out, pbuf2d, &
                              yr_spec, mon_spec, day_spec, sec_spec )
 
    use filenames,        only: interpret_filename_spec
-   use cam_pio_utils,    only: cam_pio_createfile
+   use cam_pio_utils,    only: cam_pio_createfile, cam_pio_set_fill
    use restart_dynamics, only: write_restart_dynamics, init_restart_dynamics
    use restart_physics,  only: write_restart_physics, init_restart_physics
    use cam_history,      only: write_restart_history, init_restart_history
@@ -114,7 +114,7 @@ subroutine cam_write_restart(cam_in, cam_out, dyn_out, pbuf2d, &
    end if
 
    call cam_pio_createfile(fh, trim(fname), 0)
-
+   ierr = cam_pio_set_fill(fh)
    call init_restart_dynamics(fh, dyn_out)
    call ionosphere_init_restart(fh)
    call init_restart_physics(fh, pbuf2d)
@@ -142,7 +142,7 @@ subroutine cam_write_restart(cam_in, cam_out, dyn_out, pbuf2d, &
 
    ! Close the primary restart file
    call pio_closefile(fh)
-      
+
    ! Update the restart pointer file
    call write_rest_pfile(fname)
 
@@ -161,7 +161,7 @@ subroutine write_rest_pfile(restart_file)
    integer :: nsds, ierr
    character(len=*), parameter :: sub='write_rest_pfile'
    !---------------------------------------------------------------------------
-   
+
    if (masterproc) then
 
       nsds = getunit()

--- a/src/dynamics/fv/dyn_grid.F90
+++ b/src/dynamics/fv/dyn_grid.F90
@@ -1113,8 +1113,13 @@ subroutine define_cam_grids()
     ind = ind + 1
     grid_map(1, ind) = 1
     grid_map(2, ind) = i
-    grid_map(3, ind) = 1
-    grid_map(4, ind) = i
+    if (beglonxy == 1) then
+      grid_map(3, ind) = 1
+      grid_map(4, ind) = i
+    else
+      grid_map(3, ind) = 0
+      grid_map(4, ind) = 0
+    end if
   end do
   ! We need a special, size-one "longigude" coordinate
   ! NB: This is never a distributed coordinate so calc even on inactive PEs

--- a/src/dynamics/se/dyn_comp.F90
+++ b/src/dynamics/se/dyn_comp.F90
@@ -2159,11 +2159,12 @@ subroutine read_dyn_field_2d(fieldname, fh, dimname, buffer)
 
    ! Local variables
    logical                  :: found
+   real(r8)                 :: fillvalue
    !----------------------------------------------------------------------------
 
    buffer = 0.0_r8
    call infld(trim(fieldname), fh, dimname, 1, npsq, 1, nelemd, buffer,    &
-         found, gridname=ini_grid_name)
+        found, gridname=ini_grid_name, fillvalue=fillvalue)
    if(.not. found) then
       call endrun('READ_DYN_FIELD_2D: Could not find '//trim(fieldname)//' field on input datafile')
    end if
@@ -2171,7 +2172,8 @@ subroutine read_dyn_field_2d(fieldname, fh, dimname, buffer)
    ! This code allows use of compiler option to set uninitialized values
    ! to NaN.  In that case infld can return NaNs where the element GLL points
    ! are not "unique columns"
-   where (isnan(buffer)) buffer = 0.0_r8
+   ! Set NaNs or fillvalue points to zero
+   where (isnan(buffer) .or. (buffer==fillvalue)) buffer = 0.0_r8
 
 end subroutine read_dyn_field_2d
 
@@ -2187,11 +2189,12 @@ subroutine read_dyn_field_3d(fieldname, fh, dimname, buffer)
 
    ! Local variables
    logical                  :: found
+   real(r8)                 :: fillvalue
    !----------------------------------------------------------------------------
 
    buffer = 0.0_r8
-   call infld(trim(fieldname), fh, dimname, 'lev',  1, npsq, 1, nlev,      &
-         1, nelemd, buffer, found, gridname=ini_grid_name)
+   call infld(trim(fieldname), fh, dimname, 'lev',  1, npsq, 1, nlev,         &
+        1, nelemd, buffer, found, gridname=ini_grid_name, fillvalue=fillvalue)
    if(.not. found) then
       call endrun('READ_DYN_FIELD_3D: Could not find '//trim(fieldname)//' field on input datafile')
    end if
@@ -2199,7 +2202,8 @@ subroutine read_dyn_field_3d(fieldname, fh, dimname, buffer)
    ! This code allows use of compiler option to set uninitialized values
    ! to NaN.  In that case infld can return NaNs where the element GLL points
    ! are not "unique columns"
-   where (isnan(buffer)) buffer = 0.0_r8
+   ! Set NaNs or fillvalue points to zero
+   where (isnan(buffer) .or. (buffer == fillvalue)) buffer = 0.0_r8
 
 end subroutine read_dyn_field_3d
 

--- a/src/utils/cam_pio_utils.F90
+++ b/src/utils/cam_pio_utils.F90
@@ -1202,6 +1202,7 @@ contains
         old_mode = oldfill
      end if
 #else
+     ierr = 0
      if (present(old_mode)) then
         old_mode = 0
      end if

--- a/src/utils/cam_pio_utils.F90
+++ b/src/utils/cam_pio_utils.F90
@@ -3,7 +3,7 @@ module cam_pio_utils
 
   use pio,          only: io_desc_t, iosystem_desc_t, file_desc_t, var_desc_t
   use pio,          only: pio_freedecomp, pio_rearr_subset, pio_rearr_box
-  use shr_kind_mod, only: r8=>shr_kind_r8
+  use shr_kind_mod, only: r4 => shr_kind_r4, r8 => shr_kind_r8
   use cam_logfile,  only: iulog
   use perf_mod,     only: t_startf, t_stopf
   use spmd_utils,   only: masterproc
@@ -20,6 +20,8 @@ module cam_pio_utils
   public :: init_pio_subsystem   ! called from cam_comp
   public :: cam_pio_get_decomp   ! Find an existing decomp or create a new one
   public :: cam_pio_handle_error ! If error, print a custom error message
+  public :: cam_pio_set_fill     ! Set the PIO fill value to PIO_FILL
+  public :: cam_pio_inq_var_fill ! Return the buffer fill value
 
   public :: cam_permute_array
   public :: calc_permutation
@@ -77,6 +79,12 @@ module cam_pio_utils
     module procedure cam_pio_get_var_3d_r8
     module procedure cam_pio_get_var_3d_r8_perm
   end interface
+
+  interface cam_pio_inq_var_fill
+     module procedure inq_var_fill_i4
+     module procedure inq_var_fill_r4
+     module procedure inq_var_fill_r8
+  end interface cam_pio_inq_var_fill
 
   interface calc_permutation
     module procedure calc_permutation_int
@@ -554,14 +562,7 @@ contains
     integer(kind=PIO_OFFSET_KIND),     intent(in)  :: dof(:)
     integer,                           intent(in)  :: dtype
 
-    if(pio_iotype == pio_iotype_pnetcdf) then
-       pio_rearranger = PIO_REARR_SUBSET
-    else
-       pio_rearranger = PIO_REARR_BOX
-    endif
-
-    call pio_initdecomp(pio_subsystem, dtype, dims, dof, iodesc,              &
-         rearr=pio_rearranger)
+    call pio_initdecomp(pio_subsystem, dtype, dims, dof, iodesc)
 
   end subroutine cam_pio_newdecomp
 
@@ -1177,6 +1178,98 @@ contains
     call pio_seterrorhandling(File, err_handling)
 
   end function cam_pio_fileexists
+
+  integer function cam_pio_set_fill(File, fillmode, old_mode) result(ierr)
+#ifdef PIO2
+     use pio, only: PIO_FILL, pio_set_fill
+#endif
+     ! Dummy arguments
+     type(File_desc_t), intent(in)  :: File
+     integer, optional, intent(in)  :: fillmode
+     integer, optional, intent(out) :: old_mode
+     ! Local variables
+     integer                        :: oldfill
+     integer                        :: fillval
+
+#ifdef PIO2
+     if (present(fillmode)) then
+        fillval = fillmode
+     else
+        fillval = PIO_FILL
+     end if
+     ierr =  pio_set_fill(File, fillval, oldfill)
+     if (present(old_mode)) then
+        old_mode = oldfill
+     end if
+#else
+     if (present(old_mode)) then
+        old_mode = 0
+     end if
+#endif
+  end function cam_pio_set_fill
+
+  integer function inq_var_fill_i4(File, vdesc, fillvalue, no_fill) result(ierr)
+#ifdef PIO2
+     use pio, only: pio_inq_var_fill
+#endif
+     use pio, only: PIO_NOERR
+
+     type(File_desc_t),  intent(in)  :: File
+     type(var_desc_t),   intent(in)  :: vdesc
+     ! fillvalue needs to not be optional to avoid ambiguity
+     integer, target,    intent(out) :: fillvalue
+     integer, optional,  intent(out) :: no_fill
+
+#ifdef PIO2
+     ierr = pio_inq_var_fill(File, vdesc, no_fill, fillvalue)
+#else
+     ierr = PIO_NOERR
+     fillvalue = 0
+#endif
+
+  end function inq_var_fill_i4
+
+  integer function inq_var_fill_r4(File, vdesc, fillvalue, no_fill) result(ierr)
+#ifdef PIO2
+     use pio, only: pio_inq_var_fill
+#endif
+     use pio, only: PIO_NOERR
+
+     type(File_desc_t),   intent(in)  :: File
+     type(var_desc_t),    intent(in)  :: vdesc
+     ! fillvalue needs to not be optional to avoid ambiguity
+     real(r4), target,    intent(out) :: fillvalue
+     integer,  optional,  intent(out) :: no_fill
+
+#ifdef PIO2
+     ierr = pio_inq_var_fill(File, vdesc, no_fill, fillvalue)
+#else
+     ierr = PIO_NOERR
+     fillvalue = 0.0_R4
+#endif
+
+  end function inq_var_fill_r4
+
+  integer function inq_var_fill_r8(File, vdesc, fillvalue, no_fill) result(ierr)
+#ifdef PIO2
+     use pio, only: pio_inq_var_fill
+#endif
+     use pio, only: PIO_NOERR
+
+     type(File_desc_t),   intent(in)  :: File
+     type(var_desc_t),    intent(in)  :: vdesc
+     ! fillvalue needs to not be optional to avoid ambiguity
+     real(r8), target,    intent(out) :: fillvalue
+     integer,  optional,  intent(out) :: no_fill
+
+#ifdef PIO2
+     ierr = pio_inq_var_fill(File, vdesc, no_fill, fillvalue)
+#else
+     ierr = PIO_NOERR
+     fillvalue = 0.0_R8
+#endif
+
+  end function inq_var_fill_r8
 
   subroutine find_dump_filename(fieldname, filename)
 


### PR DESCRIPTION
Fixes to allow CAM to operate with PIO2
Unread buffer locations properly initialized after read for SE dycore.
Fixes to nudging code to work with new weak-scaling infrastructure
Fixes #237 
Fixes #248 
Fixes #263 
Fixes #282 
Closes #241 
Closes #247 