### PR TITLE
Update 'nhtfrq' namelist definition to remove incorrect text.

### DIFF
--- a/bld/namelist_files/namelist_definition.xml
+++ b/bld/namelist_files/namelist_definition.xml
@@ -2149,9 +2149,8 @@ Default: 2,2,2,2,2,2,2,2,2,2
        group="cam_history_nl" valid_values="" >
 
 Array of write frequencies for each history file series.
-If {{ hilight }}nhtfrq(1){{ closehilight }} = 0, the file will be a monthly average.
-Only the first file series may be a monthly average.  If
-{{ hilight }}nhtfrq(i){{ closehilight }} &gt; 0, frequency is specified as number of
+If {{ hilight }}nhtfrq(i){{ closehilight }} = 0, the file will be a monthly average.
+If {{ hilight }}nhtfrq(i){{ closehilight }} &gt; 0, frequency is specified as number of
 timesteps.  If {{ hilight }}nhtfrq(i){{ closehilight }} &lt; 0, frequency is specified
 as number of hours.
 


### PR DESCRIPTION
Fixes #265 

@cacraigucar If you could incorporate this change into the upcoming "miscellaneous" tag PR that would be super-helpful.  Thanks!