### PR TITLE
cam6_3_011: MPAS doesn't build under CESM checkout.

### DIFF
--- a/bld/configure
+++ b/bld/configure
@@ -2314,7 +2314,7 @@ sub write_mpas_makefile
 
     print $fh_out  <<"EOF";
 
-MPAS_SRC_ROOT := $cam_root/src/dynamics/mpas
+MPAS_SRC_ROOT := $cam_dir/src/dynamics/mpas
 
 EOF
 

--- a/bld/namelist_files/namelist_defaults_cam.xml
+++ b/bld/namelist_files/namelist_defaults_cam.xml
@@ -43,7 +43,7 @@
 <ncdata nlev="32" analytic_ic="1" >atm/cam/inic/cam_vcoords_L32_c180105.nc</ncdata>
 
 <!-- Vertical coordinates and grid only -->
-<ncdata hgrid="mpasa480" nlev="32" analytic_ic="1" >atm/cam/inic/mpas/mpasa480_L32_v6.1.grid_c190924.nc</ncdata>
+<ncdata hgrid="mpasa480" nlev="32" analytic_ic="1" >atm/cam/inic/mpas/mpasa480_L32_notopo_grid_c201125.nc</ncdata>
 <ncdata hgrid="mpasa120" nlev="32" analytic_ic="1" >atm/cam/inic/mpas/mpasa120_L32_topo_grid_c201022.nc</ncdata>
 
 <!-- Files with initial conditions -->

--- a/bld/namelist_files/namelist_defaults_cam.xml
+++ b/bld/namelist_files/namelist_defaults_cam.xml
@@ -42,9 +42,9 @@
 <ncdata nlev="30" analytic_ic="1" >atm/cam/inic/cam_vcoords_L30_c180105.nc</ncdata>
 <ncdata nlev="32" analytic_ic="1" >atm/cam/inic/cam_vcoords_L32_c180105.nc</ncdata>
 
-<!-- Vertical coordinates and grid only -->
-<ncdata hgrid="mpasa480" nlev="32" analytic_ic="1" >atm/cam/inic/mpas/mpasa480_L32_notopo_grid_c201125.nc</ncdata>
-<ncdata hgrid="mpasa120" nlev="32" analytic_ic="1" >atm/cam/inic/mpas/mpasa120_L32_topo_grid_c201022.nc</ncdata>
+<!-- Vertical/Horizontal coordinates only - MPAS initial files for analytic cases-->
+<ncdata hgrid="mpasa480" nlev="32" analytic_ic="1" >atm/cam/inic/mpas/mpasa480_L32_notopo_coords_c201125.nc</ncdata>
+<ncdata hgrid="mpasa120" nlev="32" analytic_ic="1" >atm/cam/inic/mpas/mpasa120_L32_topo_coords_c201022.nc</ncdata>
 
 <!-- Files with initial conditions -->
 <ncdata dyn="fv"  hgrid="0.23x0.31" nlev="26" ic_ymd="101"      >atm/cam/inic/fv/cami_0000-01-01_0.23x0.31_L26_c100513.nc</ncdata>


### PR DESCRIPTION
CAM's bld/configure routine needs to be updated for MPAS to allow it to build under CAM or CESM checkouts.  The namelist defaults also need to be updated to get a MPAS CESM regression test to pass. Fixes #337 