### PR TITLE
part of cam6_3_016: support for nuopc threading

### DIFF
--- a/src/physics/cam/physics_types.F90
+++ b/src/physics/cam/physics_types.F90
@@ -200,7 +200,6 @@ contains
 !-----------------------------------------------------------------------
 ! Update the state and or tendency structure with the parameterization tendencies
 !-----------------------------------------------------------------------
-    use shr_sys_mod,  only: shr_sys_flush
     use constituents, only: cnst_get_ind
     use scamMod,      only: scm_crm_mode, single_column
     use phys_control, only: phys_getopts
@@ -426,9 +425,6 @@ contains
                            + gravit*state%zm(:ncol,k) + state%phis(:ncol)
        end do
     end if
-
-    ! Good idea to do this regularly.
-!    call shr_sys_flush(iulog)
 
     if (state_debug_checks) call physics_state_check(state, ptend%name)
 

--- a/src/physics/cam/physics_types.F90
+++ b/src/physics/cam/physics_types.F90
@@ -428,7 +428,7 @@ contains
     end if
 
     ! Good idea to do this regularly.
-    call shr_sys_flush(iulog)
+!    call shr_sys_flush(iulog)
 
     if (state_debug_checks) call physics_state_check(state, ptend%name)
 


### PR DESCRIPTION
This is a port for CMEPS threading in CAM.  The change in physics_types.F90 is due to a stack size issue in the call to flush.  It could also be solved via an OMP master region, but I think that that call in the code is really old and crusty and no longer required.  
Fixes issue #349