### PR TITLE
part of cam6_3_017: Fix TR8 and TGIT return code checks

### DIFF
--- a/test/system/test_driver.sh
+++ b/test/system/test_driver.sh
@@ -446,7 +446,7 @@ if [ "${cesm_test_suite}" != "none" -a -n "${cesm_test_mach}" ]; then
       ark_file="/fs/cgd/csm/tools/addrealkind/addrealkind"
       tr8_script="${CAM_ROOT}/test/system/TR8.sh"
       export ADDREALKIND_EXE="${ark_file}"; ${tr8_script} | tee -a ${logfile}
-      res=$?
+      res=${PIPESTATUS[0]}
       if [ $res -eq 0 ]; then
         echo "TR8 test PASS" | tee -a ${logfile}
       else
@@ -454,7 +454,7 @@ if [ "${cesm_test_suite}" != "none" -a -n "${cesm_test_mach}" ]; then
       fi
       echo "${sepstr}" | tee -a ${logfile}
       ${CAM_ROOT}/test/system/TGIT.sh | tee -a ${logfile}
-      res=$?
+      res==${PIPESTATUS[0]}
       if [ $res -eq 0 ]; then
         echo "TGIT test PASS" | tee -a ${logfile}
       else


### PR DESCRIPTION
TR8 and TGIT tests always report "PASS" as they were reporting on the tee command.  Use PIPESTATUS return code instead.

Tested by removing "_r8" on a random variable.  The resulting overall status said FAIL.  Did not test the TGIT logic as it had the exact same structure as the R8.

Closes #341