### PR TITLE
cam6_3_019:  correction to indexing in mo_usrrxt

### DIFF
--- a/src/chemistry/mozart/mo_usrrxt.F90
+++ b/src/chemistry/mozart/mo_usrrxt.F90
@@ -262,6 +262,11 @@ contains
     usr_PAN_M_ndx        = get_rxt_ndx( 'usr_PAN_M' )
     usr_CH3COCH3_OH_ndx  = get_rxt_ndx( 'usr_CH3COCH3_OH' )
     usr_MCO3_NO2_ndx     = get_rxt_ndx( 'usr_MCO3_NO2' )
+    tag_MCO3_NO2_ndx     = get_rxt_ndx( 'tag_MCO3_NO2' )
+    if( tag_MCO3_NO2_ndx<0 .and. usr_MCO3_NO2_ndx>0 ) then
+       tag_MCO3_NO2_ndx = usr_MCO3_NO2_ndx
+    endif
+
     usr_MPAN_M_ndx       = get_rxt_ndx( 'usr_MPAN_M' )
     usr_XOOH_OH_ndx      = get_rxt_ndx( 'usr_XOOH_OH' )
     usr_SO2_OH_ndx       = get_rxt_ndx( 'usr_SO2_OH' )
@@ -340,7 +345,6 @@ contains
     usr_ISOPNOOHDO2_NOa_ndx     = get_rxt_ndx( 'usr_ISOPNOOHDO2_NOa' )
     usr_NC4CHOO2_NOn_ndx     = get_rxt_ndx( 'usr_NC4CHOO2_NOn' )
     usr_NC4CHOO2_NOa_ndx     = get_rxt_ndx( 'usr_NC4CHOO2_NOa' )
-    tag_MCO3_NO2_ndx   = get_rxt_ndx( 'tag_MCO3_NO2' )
     tag_TERPACO3_NO2_ndx  = get_rxt_ndx( 'tag_TERPACO3_NO2' )
     usr_TERPAPAN_M_ndx     = get_rxt_ndx( 'usr_TERPAPAN_M' )
     tag_TERPA2CO3_NO2_ndx  = get_rxt_ndx( 'tag_TERPA2CO3_NO2' )

--- a/src/control/cam_snapshot.F90
+++ b/src/control/cam_snapshot.F90
@@ -767,7 +767,7 @@ subroutine cam_pbuf_snapshot_init(cam_snapshot_before_num, cam_snapshot_after_nu
 
    do while (npbuf_var < npbuf)
       call snapshot_addfld_nd( npbuf_var, pbuf_snapshot,  cam_snapshot_before_num, cam_snapshot_after_num, &
-        pbuf_info(npbuf_var+1)%name,   'pbuf_'//pbuf_info(npbuf_var+1)%standard_name,   pbuf_info(npbuf_var+1)%units,&
+        pbuf_info(npbuf_var+1)%name,   pbuf_info(npbuf_var+1)%standard_name,   pbuf_info(npbuf_var+1)%units,&
         pbuf_info(npbuf_var+1)%dim_string)
    end do
 


### PR DESCRIPTION
This is a fix for the index issue for setting the MPAN+M reaction rate constant

fixes #364

Answer changing only for some CAM-Chem and WACCM compsets
