### PR TITLE
cam6_3_023: fix for mpas regression failure (issue #389) and MPAS makefile update for NUOPC

### DIFF
--- a/Externals_CAM.cfg
+++ b/Externals_CAM.cfg
@@ -59,7 +59,7 @@ local_path = src/dynamics/mpas/dycore
 protocol = git
 repo_url = https://github.com/MPAS-Dev/MPAS-Model.git
 sparse = ../.mpas_sparse_checkout
-hash = 224740a
+hash = 8fb89189
 required = True
 
 [externals_description]

--- a/bld/configure
+++ b/bld/configure
@@ -2304,6 +2304,7 @@ sub write_mpas_makefile
     print $fh_out  <<"EOF";
 
 MPAS_SRC_ROOT := $cam_dir/src/dynamics/mpas
+COMP_INTERFACE:= $cpl
 
 EOF
 

--- a/src/dynamics/mpas/Makefile
+++ b/src/dynamics/mpas/Makefile
@@ -2,8 +2,8 @@ CPPFLAGS := -D_MPI -DMPAS_NATIVE_TIMERS -DMPAS_GIT_VERSION=unknown -DMPAS_NAMELI
 ifdef PIODEF
   CPPFLAGS += $(PIODEF)
 endif
-ifdef ESMFDEF
-  CPPFLAGS += $(ESMFDEF)
+ifeq ($(strip $(COMP_INTERFACE)),nuopc)
+  CPPFLAGS += -DMPAS_EXTERNAL_ESMF_LIB
 endif
 
 REGISTRY_FILE := $(MPAS_SRC_ROOT)/dycore/src/core_atmosphere/Registry.xml


### PR DESCRIPTION
New MPAS external hash to fix MPAS base/rest regression failure introduced in cam6_3_020.  Updated MPAS build routines to allow MPAS dycore library to link with the CESM ESMF library.  This change completes NUOPC compatibility for MPAS.

closes #389 