### PR TITLE
cam6_3_025: Use python3 for cime_config scripts

### DIFF
--- a/cime_config/buildcpp
+++ b/cime_config/buildcpp
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 """
 API for cam's configure

--- a/cime_config/buildlib
+++ b/cime_config/buildlib
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 """
 create the cam library

--- a/cime_config/buildnml
+++ b/cime_config/buildnml
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 """
 CAM namelist creator


### PR DESCRIPTION
Updates python in buildcpp, buildlib and buildnml

Closes #394