### PR TITLE
Point CAM to the CARMA_base github repository instead of SVN repository

### DIFF
--- a/Externals_CAM.cfg
+++ b/Externals_CAM.cfg
@@ -7,9 +7,9 @@ required = True
 
 [carma]
 local_path = src/physics/carma/base
-protocol = svn
-repo_url = https://svn-ccsm-models.cgd.ucar.edu/carma/release_tags
-tag = carma3_49_rel
+protocol = git
+repo_url = https://github.com/ESCOMP/CARMA_base.git
+tag = carma3_49
 required = True
 
 [cosp2]


### PR DESCRIPTION
Edited the file Externals_CAM.cfg to point CAM to the CARMA_base github repository instead of the SVN repository.

[carma]
-local_path = src/physics/carma/base
-protocol = svn
-repo_url = https://svn-ccsm-models.cgd.ucar.edu/carma/release_tags
-tag = carma3_49_rel
+local_path = src/physics/carma/base
+protocol = git
+repo_url = https://github.com/ESCOMP/CARMA_base.git
+tag = carma3_49
required = True
