### PR TITLE
cam6_3_030: Update the MPAS-A dycore to MPAS-Atmosphere v7+

### DIFF
--- a/Externals_CAM.cfg
+++ b/Externals_CAM.cfg
@@ -59,7 +59,7 @@ local_path = src/dynamics/mpas/dycore
 protocol = git
 repo_url = https://github.com/MPAS-Dev/MPAS-Model.git
 sparse = ../.mpas_sparse_checkout
-hash = 8fb89189
+hash = ba25bd07
 required = True
 
 [externals_description]

--- a/bld/build-namelist
+++ b/bld/build-namelist
@@ -3730,6 +3730,8 @@ if ($dyn =~ /mpas/) {
     add_default($nl, 'mpas_rayleigh_damp_u');
     add_default($nl, 'mpas_rayleigh_damp_u_timescale_days');
     add_default($nl, 'mpas_number_rayleigh_damp_u_levels');
+    add_default($nl, 'mpas_apply_lbcs');
+    add_default($nl, 'mpas_jedi_da');
     add_default($nl, 'mpas_do_restart');
     add_default($nl, 'mpas_print_global_minmax_vel');
     add_default($nl, 'mpas_print_detailed_minmax_vel');

--- a/bld/namelist_files/namelist_defaults_cam.xml
+++ b/bld/namelist_files/namelist_defaults_cam.xml
@@ -2819,6 +2819,8 @@
 <mpas_rayleigh_damp_u         > .true. </mpas_rayleigh_damp_u>
 <mpas_rayleigh_damp_u_timescale_days> 5.0 </mpas_rayleigh_damp_u_timescale_days>
 <mpas_number_rayleigh_damp_u_levels> 3 </mpas_number_rayleigh_damp_u_levels>
+<mpas_apply_lbcs> .false. </mpas_apply_lbcs>
+<mpas_jedi_da> .false. </mpas_jedi_da>
 <mpas_print_detailed_minmax_vel> .true.  </mpas_print_detailed_minmax_vel>
 <mpas_block_decomp_file_prefix hgrid="mpasa480">atm/cam/inic/mpas/mpasa480.graph.info.part.</mpas_block_decomp_file_prefix>
 <mpas_block_decomp_file_prefix hgrid="mpasa120">atm/cam/inic/mpas/mpasa120.graph.info.part.</mpas_block_decomp_file_prefix>

--- a/bld/namelist_files/namelist_definition.xml
+++ b/bld/namelist_files/namelist_definition.xml
@@ -7832,6 +7832,19 @@ damping linearly ramps to zero by layer number from the top
 Default: 3
 </entry>
 
+<entry id="mpas_apply_lbcs" type="logical" category="mpas"
+       group="limited_area" valid_values="">
+Whether to apply lateral boundary conditions
+Default: FALSE
+</entry>
+
+<entry id="mpas_jedi_da" type="logical" category="mpas"
+       group="assimilation" valid_values="">
+Whether this run is within the JEDI data assimilation framework; used to add
+temperature and specific humidity as diagnostics
+Default: FALSE
+</entry>
+
 <entry id="mpas_block_decomp_file_prefix" type="char*512" input_pathname="abs" category="mpas"
        group="decomposition" valid_values="">
 Prefix of the MPAS graph decomposition file, to be suffixed with the MPI

--- a/src/dynamics/mpas/Makefile
+++ b/src/dynamics/mpas/Makefile
@@ -22,6 +22,7 @@ INTERFACE_OBJS = \
 
 DYN_OBJS = \
 	mpas_atm_time_integration.o \
+	mpas_atm_boundaries.o \
 	mpas_atm_iau.o
 
 DIAG_OBJS = \
@@ -228,7 +229,7 @@ incs: $(REGISTRY_FILE)
 #
 dycore: $(DYN_OBJS) $(DIAGNOSTICS) $(DIAG_OBJS) $(INTERFACE_OBJS)
 
-mpas_atm_time_integration.o: mpas_atm_iau.o mpas_atm_dimensions.o
+mpas_atm_time_integration.o: mpas_atm_iau.o mpas_atm_dimensions.o mpas_atm_boundaries.o
 
 
 #

--- a/src/dynamics/mpas/driver/cam_mpas_subdriver.F90
+++ b/src/dynamics/mpas/driver/cam_mpas_subdriver.F90
@@ -100,6 +100,7 @@ contains
        domain_ptr % core => corelist
 
        call mpas_allocate_domain(domain_ptr)
+       domain_ptr % domainID = 0
 
 
        !
@@ -1378,10 +1379,6 @@ contains
        type (field1DReal), pointer :: u_init
        type (field1DReal), pointer :: qv_init
 
-       type (field2DReal), pointer :: tend_ru_physics
-       type (field2DReal), pointer :: tend_rtheta_physics
-       type (field2DReal), pointer :: tend_rho_physics
-
 
        call MPAS_createStream(restart_stream, domain_ptr % ioContext, 'not_used', MPAS_IO_NETCDF, &
                               direction, pio_file_desc=fh_rst, ierr=ierr)
@@ -1500,10 +1497,6 @@ contains
 
        call mpas_pool_get_field(allFields, 'u_init', u_init)
        call mpas_pool_get_field(allFields, 'qv_init', qv_init)
-
-       call mpas_pool_get_field(allFields, 'tend_ru_physics', tend_ru_physics)
-       call mpas_pool_get_field(allFields, 'tend_rtheta_physics', tend_rtheta_physics)
-       call mpas_pool_get_field(allFields, 'tend_rho_physics', tend_rho_physics)
 
        ierr_total = 0
 
@@ -1710,13 +1703,6 @@ contains
        call MPAS_streamAddField(restart_stream, qv_init, ierr=ierr)
        if (ierr /= MPAS_STREAM_NOERR) ierr_total = ierr_total + 1
 
-       call MPAS_streamAddField(restart_stream, tend_ru_physics, ierr=ierr)
-       if (ierr /= MPAS_STREAM_NOERR) ierr_total = ierr_total + 1
-       call MPAS_streamAddField(restart_stream, tend_rtheta_physics, ierr=ierr)
-       if (ierr /= MPAS_STREAM_NOERR) ierr_total = ierr_total + 1
-       call MPAS_streamAddField(restart_stream, tend_rho_physics, ierr=ierr)
-       if (ierr /= MPAS_STREAM_NOERR) ierr_total = ierr_total + 1
-
        if (ierr_total > 0) then
            write(errString, '(a,i0,a)') subname//': FATAL: Failed to add ', ierr_total, ' fields to restart stream.'
            call endrun(trim(errString))
@@ -1886,10 +1872,6 @@ contains
        call cam_mpas_update_halo('rho_p', endrun)
        call cam_mpas_update_halo('surface_pressure', endrun)
        call cam_mpas_update_halo('t_init', endrun)
-
-       call cam_mpas_update_halo('tend_ru_physics', endrun)
-       call cam_mpas_update_halo('tend_rtheta_physics', endrun)
-       call cam_mpas_update_halo('tend_rho_physics', endrun)
 
        !
        ! Re-index from global index space to local index space

--- a/src/dynamics/mpas/driver/cam_mpas_subdriver.F90
+++ b/src/dynamics/mpas/driver/cam_mpas_subdriver.F90
@@ -311,6 +311,7 @@ contains
                                       mpas_pool_get_field, mpas_pool_get_array, mpas_pool_initialize_time_levels
        use atm_core, only : atm_mpas_init_block, core_clock => clock
        use mpas_dmpar, only : mpas_dmpar_exch_halo_field
+       use atm_time_integration, only : mpas_atm_dynamics_init
 
        procedure(halt_model) :: endrun
 
@@ -409,6 +410,11 @@ contains
 
        call mpas_pool_get_field(diag, 'rw', rw_field)
        call mpas_dmpar_exch_halo_field(rw_field)
+
+       !
+       ! Prepare the dynamics for integration
+       !
+       call mpas_atm_dynamics_init(domain_ptr)
 
     end subroutine cam_mpas_init_phase4
 
@@ -2314,11 +2320,17 @@ contains
        use mpas_log, only : mpas_log_finalize
        use mpas_timer, only : mpas_timer_stop
        use mpas_framework, only : mpas_framework_finalize
+       use atm_time_integration, only : mpas_atm_dynamics_finalize
 
        ! Local variables
        integer :: ierr
        character(len=*), parameter :: subname = 'cam_mpas_subdriver::cam_mpas_finalize'
 
+
+       !
+       ! Finalize the dynamics
+       !
+       call mpas_atm_dynamics_finalize(domain_ptr)
 
        call mpas_destroy_clock(clock, ierr)
        call mpas_decomp_destroy_decomp_list(domain_ptr % decompositions)


### PR DESCRIPTION
Update the MPAS-A dycore in CAM to a stable hash on the MPAS-Model's 'develop' branch.

With the update to a newer MPAS-A dycore, several changes are needed in CAM-MPAS:
1. New MPAS-A namelist options need to be handled in CAM-MPAS
2. The dycore Makefile needs to correctly account for new dependencies in the dycore
3. Additional calls to MPAS-A init/finalize routines need to be made at appropriate points in CAM-MPAS
4. Acquisition of pointers to certain dycore fields need to be moved to account for new memory allocation strategies in the updated dycore

This PR closes #417.