### PR TITLE
cam6_3_031: Update externals to cesm2_3_alpha05c

### DIFF
--- a/Externals.cfg
+++ b/Externals.cfg
@@ -11,7 +11,7 @@ protocol = git
 repo_url = https://github.com/ESCOMP/CESM_CICE
 local_path = components/cice6
 externals = Externals.cfg
-required = True
+required = False
 
 [cmeps]
 tag = cmeps0.13.25

--- a/Externals.cfg
+++ b/Externals.cfg
@@ -1,56 +1,104 @@
-[externals_description]
-schema_version = 1.0.0
-
 [cice]
-tag = cice5_20200430
+tag = cice5_20210802
 protocol = git
 repo_url = https://github.com/ESCOMP/CESM_CICE5
 local_path = components/cice
 required = True
 
-[cime]
-tag = cime5.8.44
+[cice6]
+tag = cesm_cice6_2_0_5
 protocol = git
-repo_url = https://github.com/ESMCI/cime.git
+repo_url = https://github.com/ESCOMP/CESM_CICE
+local_path = components/cice6
+externals = Externals.cfg
+required = True
+
+[cmeps]
+tag = cmeps0.13.25
+protocol = git
+repo_url = https://github.com/ESCOMP/CMEPS.git
+local_path = components/cmeps
+required = True
+
+[cdeps]
+tag = cdeps0.12.21
+protocol = git
+repo_url = https://github.com/ESCOMP/CDEPS.git
+local_path = components/cdeps
+externals =  Externals_CDEPS.cfg
+required = True
+
+[cpl7]
+tag = cpl7.0.5
+protocol = git
+repo_url = https://github.com/ESCOMP/CESM_CPL7andDataComps
+local_path = components/cpl7
+required = True
+
+[share]
+tag = share1.0.7
+protocol = git
+repo_url = https://github.com/ESCOMP/CESM_share
+local_path = share
+required = True
+
+[mct]
+tag = MCT_2.11.0
+protocol = git
+repo_url = https://github.com/MCSclimate/MCT
+local_path = libraries/mct
+required = True
+
+[parallelio]
+tag = pio2_5_4
+protocol = git
+repo_url = https://github.com/NCAR/ParallelIO
+local_path = libraries/parallelio
+required = True
+
+[cime]
+tag = cime6.0.6
+protocol = git
+repo_url = https://github.com/ESMCI/cime
 local_path = cime
 required = True
 
 [cism]
-tag = cism2_1_69
+tag = cismwrap_2_1_88
 protocol = git
-repo_url = https://github.com/ESCOMP/cism-wrapper
+repo_url = https://github.com/ESCOMP/CISM-wrapper
 local_path = components/cism
 externals = Externals_CISM.cfg
 required = True
 
 [clm]
-tag = ctsm5.1.dev019
+tag = ctsm5.1.dev053
 protocol = git
-repo_url = https://github.com/ESCOMP/ctsm
+repo_url = https://github.com/ESCOMP/CTSM
 local_path = components/clm
 externals = Externals_CLM.cfg
 required = True
 
+[fms]
+tag = fi_20210708b
+protocol = git
+repo_url = https://github.com/ESCOMP/FMS_interface
+local_path = libraries/FMS
+externals = Externals_FMS.cfg
+required = False
+
 [mosart]
-tag = branch_tag/pio2.n01_mosart1_0_38
+tag = mosart1_0_43
 protocol = git
 repo_url = https://github.com/ESCOMP/MOSART
 local_path = components/mosart
 required = True
 
 [rtm]
-tag = branch_tag/nuopc_cap.n01_rtm1_0_73
+tag = rtm1_0_77
 protocol = git
 repo_url = https://github.com/ESCOMP/RTM
 local_path = components/rtm
-required = True
-
-[fms]
-tag = fi_20200609
-protocol = git
-repo_url = https://github.com/ESCOMP/FMS_interface.git
-local_path = libraries/FMS
-externals = Externals_FMS.cfg
 required = True
 
 [cam]
@@ -58,3 +106,6 @@ local_path = .
 protocol = externals_only
 externals = Externals_CAM.cfg
 required = True
+
+[externals_description]
+schema_version = 1.0.0

--- a/test/system/test_driver.sh
+++ b/test/system/test_driver.sh
@@ -117,6 +117,7 @@ fi
 
 # Initialize variables which may not be set
 submit_script_cime=''
+xml_driver="mct"
 
 while [ "${1:0:1}" == "-" ]; do
     case $1 in


### PR DESCRIPTION
Update Externals.cfg to match CESM 2.3 alpha 05c
Addresses #423 

Testing is a bit tricky since the test names are different in the new CIME. To allow checks to pass, I created a set of dummy baseline directories that is mostly a renamed version of the cam6_3_030 baselines:
- Test directories have the new name (with `_Vmct` added at the end of the test type field)
- Files inside the top level of the test directory are soft links to the cam6_3_030 baseline files (saves disk space)
- Files inside CaseDocs are copies of the cam6_3_030 baseline files _except_:
    - esp_modelio.nml: new value for `pio_netcdf_format`
    - drv_in: new `case_name` that includes driver type

Because of the updated component externals, there are numerous namelist changes (GLC, CLM, and driver) and a few baseline changes (I believe due to CLM changes but I will have to double check).