### PR TITLE
namelist parameter for photolysis max solar zenith

### DIFF
--- a/bld/build-namelist
+++ b/bld/build-namelist
@@ -2544,6 +2544,19 @@ if ($chem eq 'trop_mam7') {
 
 my $waccmx = $cfg->get('waccmx');
 
+# set maximum solar zenith angle for photolysis
+my $maxzen = 0.0;
+if ($waccmx){
+    $maxzen = 116.;
+} elsif ($chem =~ "trop_strat" or $chem =~ "waccm_") {
+    $maxzen = 97.01;
+} elsif ($chem =~ "trop_mam" or $chem =~ "trop_mozart") {
+    $maxzen = 88.85;
+}
+if ($maxzen>0.0) {
+    add_default($nl, 'photo_max_zen', 'val'=>"${maxzen}D0");
+}
+
 # WACCM options.
 if ($chem =~ /waccm_ma/ or $chem =~ /waccm_tsmlt/) {
 

--- a/bld/namelist_files/namelist_definition.xml
+++ b/bld/namelist_files/namelist_definition.xml
@@ -2547,7 +2547,7 @@ Default: 1
 
 <entry id="micro_mg_autocon_fact" type="real" category="microphys"
        group="micro_mg_nl" valid_values="" >
-Unitless ratio to directly scale the autoconversion process in microphysics as a method of accounting for unrepresented subgridscale variability. 
+Unitless ratio to directly scale the autoconversion process in microphysics as a method of accounting for unrepresented subgridscale variability.
 Default: 0.01
 </entry>
 
@@ -3679,7 +3679,7 @@ Default: 25.0e-6 m
 
 <entry id="clubb_detphase_lowtemp" type="real" category="pblrad"
        group="clubb_params_nl" valid_values="" >
-Temperature at which detrained water is classified as entirely ice (no liquid) 
+Temperature at which detrained water is classified as entirely ice (no liquid)
 in the CLUBB parameterization in units of (K).
 Default: 238.15 K
 </entry>
@@ -6801,6 +6801,13 @@ Default: set by build-namelist.
 Full pathname of cross section dataset for short wavelengh photolysis
 Default: set by build-namelist.
 </entry>
+
+<entry id="photo_max_zen" type="real" category="cam_chem"
+       group="chem_inparm" valid_values="" >
+Maximum zeniith angle (degrees) used for photolysis.
+Default: set by build-namelist.
+</entry>
+
 
 <!-- Namelist read by seq_drydep_mod and shared by CAM and CLM -->
 

--- a/bld/namelist_files/namelist_definition.xml
+++ b/bld/namelist_files/namelist_definition.xml
@@ -6804,7 +6804,7 @@ Default: set by build-namelist.
 
 <entry id="photo_max_zen" type="real" category="cam_chem"
        group="chem_inparm" valid_values="" >
-Maximum zeniith angle (degrees) used for photolysis.
+Maximum zenith angle (degrees) used for photolysis.
 Default: set by build-namelist.
 </entry>
 

--- a/src/chemistry/mozart/chemistry.F90
+++ b/src/chemistry/mozart/chemistry.F90
@@ -14,7 +14,7 @@ module chemistry
   use spmd_utils,       only : masterproc
   use cam_logfile,      only : iulog
   use mo_gas_phase_chemdr, only : map2chm
-  use shr_megan_mod,    only : shr_megan_mechcomps, shr_megan_mechcomps_n 
+  use shr_megan_mod,    only : shr_megan_mechcomps, shr_megan_mechcomps_n
   use srf_field_check,  only : active_Fall_flxvoc
   use tracer_data,      only : MAXTRCRS
   use gcr_ionization,   only : gcr_ionization_readnl, gcr_ionization_init, gcr_ionization_adv
@@ -32,7 +32,7 @@ module chemistry
 !---------------------------------------------------------------------------------
   public :: chem_is                        ! identify which chemistry is being used
   public :: chem_register                  ! register consituents
-  public :: chem_readnl                    ! read chem namelist 
+  public :: chem_readnl                    ! read chem namelist
   public :: chem_is_active                 ! returns true
   public :: chem_implements_cnst           ! returns true if consituent is implemented by this package
   public :: chem_init_cnst                 ! initialize mixing ratios if not read from initial file
@@ -46,11 +46,11 @@ module chemistry
   public :: chem_emissions
 
   integer, public :: imozart = -1       ! index of 1st constituent
-  
+
   ! Namelist variables
-  
+
   ! control
-  
+
   integer :: chem_freq = 1 ! time steps
 
   ! ghg
@@ -74,13 +74,14 @@ module chemistry
   character(len=shr_kind_cl) :: xs_long_file = 'xs_long_file'
   character(len=shr_kind_cl) :: electron_file = 'electron_file'
   character(len=shr_kind_cl) :: euvac_file = 'NONE'
+  real(r8)                   :: photo_max_zen=-huge(1._r8)
 
   ! solar / geomag data
 
   character(len=shr_kind_cl) :: photon_file = 'photon_file'
 
   ! dry dep
-  
+
   character(len=shr_kind_cl) :: depvel_lnd_file = 'depvel_lnd_file'
 
   ! emis
@@ -100,7 +101,7 @@ module chemistry
   integer            :: ext_frc_fixed_tod = 0
 
   ! fixed stratosphere
-  
+
   character(len=shr_kind_cl) :: fstrat_file = 'fstrat_file'
   character(len=16)  :: fstrat_list(pcnst)  = ''
 
@@ -128,9 +129,9 @@ module chemistry
 
   character(len=32) :: chem_name = 'NONE'
   logical :: chem_rad_passive = .false.
-  
+
   ! for MEGAN emissions
-  integer, allocatable :: megan_indices_map(:) 
+  integer, allocatable :: megan_indices_map(:)
   real(r8),allocatable :: megan_wght_factors(:)
 
   logical :: chem_use_chemtrop = .false.
@@ -150,10 +151,10 @@ end function chem_is
 !================================================================================================
 
   subroutine chem_register
-!----------------------------------------------------------------------- 
-! 
+!-----------------------------------------------------------------------
+!
 ! Purpose: register advected constituents and physics buffer fields
-! 
+!
 !-----------------------------------------------------------------------
 
     use mo_sim_dat,          only : set_sim_dat
@@ -176,7 +177,7 @@ end function chem_is
     logical  :: ic_from_cam2                        ! wrk variable for initial cond input
     logical  :: has_fixed_ubc                       ! wrk variable for upper bndy cond
     logical  :: has_fixed_ubflx                     ! wrk variable for upper bndy flux
-    integer  :: ch4_ndx, n2o_ndx, o3_ndx 
+    integer  :: ch4_ndx, n2o_ndx, o3_ndx
     integer  :: cfc11_ndx, cfc12_ndx, o2_1s_ndx, o2_1d_ndx, o2_ndx
     integer  :: n_ndx, no_ndx, h_ndx, h2_ndx, o_ndx, e_ndx, np_ndx
     integer  :: op_ndx, o1d_ndx, n2d_ndx, nop_ndx, n2p_ndx, o2p_ndx
@@ -226,7 +227,7 @@ end function chem_is
     !-----------------------------------------------------------------------
     !----------------------------------------------------------------------------------
     ! For WACCM-X, change variable has_fixed_ubc from .true. to .false. which is a flag
-    ! used later to check for a fixed upper boundary condition for species. 
+    ! used later to check for a fixed upper boundary condition for species.
     !----------------------------------------------------------------------------------
      do m = 1,gas_pcnst
      ! setting of these variables is for registration of transported species
@@ -237,14 +238,14 @@ end function chem_is
        molectype = 'minor'
 
        qmin = 1.e-36_r8
-       
+
        if ( lng_name(1:5) .eq. 'num_a' ) then ! aerosol number density
           qmin = 1.e-5_r8
        else if ( m == o3_ndx ) then
           qmin = 1.e-12_r8
        else if ( m == ch4_ndx ) then
           qmin = 1.e-12_r8
-          if ( waccmx_is('ionosphere') .or. waccmx_is('neutral') ) then 
+          if ( waccmx_is('ionosphere') .or. waccmx_is('neutral') ) then
             has_fixed_ubc = .false.   ! diffusive equilibrium at UB
           else
             has_fixed_ubc = .true.
@@ -262,7 +263,7 @@ end function chem_is
           end if
        else if ( m==o2_ndx .or. m==n_ndx .or. m==no_ndx .or. m==h_ndx .or. m==h2_ndx .or. m==o_ndx .or. m==hf_ndx &
                .or. m==f_ndx ) then
-         if ( waccmx_is('ionosphere') .or. waccmx_is('neutral') ) then 
+         if ( waccmx_is('ionosphere') .or. waccmx_is('neutral') ) then
            has_fixed_ubc = .false.   ! diffusive equilibrium at UB
            if ( m == h_ndx ) has_fixed_ubflx = .true. ! fixed flux value for H at UB
            if ( m == o2_ndx .or. m == o_ndx ) molectype = 'major'
@@ -310,22 +311,22 @@ end function chem_is
        endif
 
     end do
-    
+
     call register_short_lived_species()
     call register_cfc11star()
 
-    if ( waccmx_is('ionosphere') ) then 
+    if ( waccmx_is('ionosphere') ) then
        call photo_register()
        call aurora_register()
     endif
-    
+
     ! add fields to pbuf needed by aerosol models
     call aero_model_register()
 
   end subroutine chem_register
 
 !================================================================================================
-  
+
   subroutine chem_readnl(nlfile)
 
     ! Read chem namelist group.
@@ -357,9 +358,9 @@ end function chem_is
     ! trop_mozart prescribed constituent concentratons
     character(len=shr_kind_cl) :: tracer_cnst_file              ! prescribed data file
     character(len=shr_kind_cl) :: tracer_cnst_filelist          ! list of prescribed data files (series of files)
-    character(len=shr_kind_cl) :: tracer_cnst_datapath          ! absolute path of prescribed data files 
+    character(len=shr_kind_cl) :: tracer_cnst_datapath          ! absolute path of prescribed data files
     character(len=24)  :: tracer_cnst_type              ! 'INTERP_MISSING_MONTHS' | 'CYCLICAL' | 'SERIAL' (default)
-    character(len=shr_kind_cl) :: tracer_cnst_specifier(MAXTRCRS) ! string array where each 
+    character(len=shr_kind_cl) :: tracer_cnst_specifier(MAXTRCRS) ! string array where each
     logical            :: tracer_cnst_rmfile            ! remove data file from local disk (default .false.)
     integer            :: tracer_cnst_cycle_yr
     integer            :: tracer_cnst_fixed_ymd
@@ -368,9 +369,9 @@ end function chem_is
     ! trop_mozart prescribed constituent sourrces/sinks
     character(len=shr_kind_cl) :: tracer_srcs_file              ! prescribed data file
     character(len=shr_kind_cl) :: tracer_srcs_filelist          ! list of prescribed data files (series of files)
-    character(len=shr_kind_cl) :: tracer_srcs_datapath          ! absolute path of prescribed data files 
+    character(len=shr_kind_cl) :: tracer_srcs_datapath          ! absolute path of prescribed data files
     character(len=24)  :: tracer_srcs_type              ! 'INTERP_MISSING_MONTHS' | 'CYCLICAL' | 'SERIAL' (default)
-    character(len=shr_kind_cl) :: tracer_srcs_specifier(MAXTRCRS) ! string array where each 
+    character(len=shr_kind_cl) :: tracer_srcs_specifier(MAXTRCRS) ! string array where each
     logical            :: tracer_srcs_rmfile            ! remove data file from local disk (default .false.)
     integer            :: tracer_srcs_cycle_yr
     integer            :: tracer_srcs_fixed_ymd
@@ -391,7 +392,7 @@ end function chem_is
          euvac_file, photon_file, electron_file, &
          xs_coef_file, xs_short_file, &
          exo_coldens_file, tuv_xsect_file, o2_xsect_file, &
-         xs_long_file, rsf_file, &
+         xs_long_file, rsf_file, photo_max_zen, &
          lght_no_prd_factor, xactive_prates, &
          depvel_lnd_file, drydep_srf_file, &
          srf_emis_type, srf_emis_cycle_yr, srf_emis_fixed_ymd, srf_emis_fixed_tod, srf_emis_specifier,  &
@@ -412,8 +413,8 @@ end function chem_is
          tracer_srcs_file, tracer_srcs_filelist, tracer_srcs_datapath, &
          tracer_srcs_type, tracer_srcs_specifier, &
          tracer_cnst_rmfile, tracer_cnst_cycle_yr, tracer_cnst_fixed_ymd, tracer_cnst_fixed_tod, &
-         tracer_srcs_rmfile, tracer_srcs_cycle_yr, tracer_srcs_fixed_ymd, tracer_srcs_fixed_tod 
-    
+         tracer_srcs_rmfile, tracer_srcs_cycle_yr, tracer_srcs_fixed_ymd, tracer_srcs_fixed_tod
+
     ! upper boundary conditions
     namelist /chem_inparm/ tgcm_ubc_file, tgcm_ubc_data_type, tgcm_ubc_cycle_yr, tgcm_ubc_fixed_ymd, tgcm_ubc_fixed_tod, &
                            snoe_ubc_file, t_pert_ubc, no_xfac_ubc
@@ -432,7 +433,7 @@ end function chem_is
          tracer_cnst_rmfile_out    = tracer_cnst_rmfile,    &
          tracer_cnst_cycle_yr_out  = tracer_cnst_cycle_yr,  &
          tracer_cnst_fixed_ymd_out = tracer_cnst_fixed_ymd, &
-         tracer_cnst_fixed_tod_out = tracer_cnst_fixed_tod  ) 
+         tracer_cnst_fixed_tod_out = tracer_cnst_fixed_tod  )
     call tracer_srcs_defaultopts( &
          tracer_srcs_file_out      = tracer_srcs_file,      &
          tracer_srcs_filelist_out  = tracer_srcs_filelist,  &
@@ -497,6 +498,7 @@ end function chem_is
     call mpibcast (xs_coef_file,      len(xs_coef_file),               mpichar, 0, mpicom)
     call mpibcast (xs_short_file,     len(xs_short_file),              mpichar, 0, mpicom)
     call mpibcast (xs_long_file,      len(xs_long_file),               mpichar, 0, mpicom)
+    call mpibcast (photo_max_zen,     1,                               mpir8,   0, mpicom)
     call mpibcast (xactive_prates,    1,                               mpilog,  0, mpicom)
     call mpibcast (electron_file,     len(electron_file),              mpichar, 0, mpicom)
     call mpibcast (euvac_file,        len(euvac_file),                 mpichar, 0, mpicom)
@@ -602,7 +604,7 @@ end function chem_is
         tgcm_ubc_fixed_tod_in = tgcm_ubc_fixed_tod )
 
    call aero_model_readnl(nlfile)
-   call dust_readnl(nlfile)     
+   call dust_readnl(nlfile)
 !
    call gas_wetdep_readnl(nlfile)
    call gcr_ionization_readnl(nlfile)
@@ -618,7 +620,7 @@ end function chem_is
 !================================================================================================
 
 function chem_is_active()
-!----------------------------------------------------------------------- 
+!-----------------------------------------------------------------------
 ! Purpose: return true if this package is active
 !-----------------------------------------------------------------------
    logical :: chem_is_active
@@ -629,12 +631,12 @@ end function chem_is_active
 !================================================================================================
 
   function chem_implements_cnst(name)
-!----------------------------------------------------------------------- 
-! 
+!-----------------------------------------------------------------------
+!
 ! Purpose: return true if specified constituent is implemented by this package
-! 
+!
 ! Author: B. Eaton
-! 
+!
 !-----------------------------------------------------------------------
     use chem_mods,       only : gas_pcnst, inv_lst, nfs
     use mo_tracname,     only : solsym
@@ -648,7 +650,7 @@ end function chem_is_active
 !       ... local variables
 !-----------------------------------------------------------------------
     integer :: m
-    
+
     chem_implements_cnst = .false.
     do m = 1,gas_pcnst
        if( trim(name) /= 'H2O' ) then
@@ -671,20 +673,20 @@ end function chem_is_active
 
   subroutine chem_init(phys_state, pbuf2d)
 
-!----------------------------------------------------------------------- 
-! 
+!-----------------------------------------------------------------------
+!
 ! Purpose: initialize parameterized greenhouse gas chemistry
 !          (declare history variables)
-! 
-! Method: 
-! <Describe the algorithm(s) used in the routine.> 
-! <Also include any applicable external references.> 
-! 
+!
+! Method:
+! <Describe the algorithm(s) used in the routine.>
+! <Also include any applicable external references.>
+!
 ! Author: NCAR CMS
-! 
+!
 !-----------------------------------------------------------------------
     use physics_buffer,      only : physics_buffer_desc, pbuf_get_index
-    
+
     use constituents,        only : cnst_get_ind
     use cam_history,         only : addfld, add_default, horiz_only, fieldname_len
     use chem_mods,           only : gas_pcnst
@@ -704,11 +706,11 @@ end function chem_is_active
     use fire_emissions,      only : fire_emissions_init
     use short_lived_species, only : short_lived_species_initic
     use ocean_emis,          only : ocean_emis_init
-    
+
     type(physics_buffer_desc), pointer :: pbuf2d(:,:)
     type(physics_state), intent(in):: phys_state(begchunk:endchunk)
 
-    
+
 !-----------------------------------------------------------------------
 ! Local variables
 !-----------------------------------------------------------------------
@@ -719,7 +721,7 @@ end function chem_is_active
     logical :: history_chemistry
     logical :: history_cesm_forcing
 
-    character(len=2)  :: unit_basename  ! Units 'kg' or '1' 
+    character(len=2)  :: unit_basename  ! Units 'kg' or '1'
     logical :: history_budget                 ! output tendencies and state variables for CAM
                                               ! temperature, water vapor, cloud ice and cloud
                                               ! liquid budgets.
@@ -767,17 +769,17 @@ end function chem_is_active
        srcnam(m) = 'CT_' // spc_name ! chem tendancy (source/sink)
 
        call addfld( srcnam(m), (/ 'lev' /), 'A', 'kg/kg/s', trim(spc_name)//' source/sink' )
-       call cnst_get_ind(solsym(m), n, abort=.false. ) 
+       call cnst_get_ind(solsym(m), n, abort=.false. )
        if ( n > 0 ) then
 
           if (sflxnam(n)(3:5) == 'num') then  ! name is in the form of "SF****"
              unit_basename = ' 1'
           else
-             unit_basename = 'kg'  
+             unit_basename = 'kg'
           endif
 
           call addfld (sflxnam(n),horiz_only,    'A',  unit_basename//'/m2/s',trim(solsym(m))//' surface flux')
-          if ( history_aerosol .or. history_chemistry ) then 
+          if ( history_aerosol .or. history_chemistry ) then
              call add_default( sflxnam(n), 1, ' ' )
           endif
 
@@ -786,12 +788,12 @@ end function chem_is_active
                 call add_default( sflxnam(n), 1, ' ' )
              endif
           endif
-  
+
        endif
     end do
 
     ! Add chemical tendency of water vapor to water budget output
-    if ( history_budget ) then 
+    if ( history_budget ) then
       call add_default ('CT_H2O'  , history_budget_histfile_num, ' ')
     endif
 
@@ -800,7 +802,7 @@ end function chem_is_active
     !      required because water vapor is not declared by chemistry but
     !      has a fixed ubc only if WACCM chemistry is running.
     !-----------------------------------------------------------------------
-    ! this is moved out of chem_register because we need to know where (what pressure) 
+    ! this is moved out of chem_register because we need to know where (what pressure)
     ! the upper boundary is to determine if this is a high top configuration -- after
     ! initialization of ref_pres ...
     if ( 1.e-2_r8 >= ptop_ref .and. ptop_ref > 1.e-5_r8 ) then ! around waccm top, below top of waccmx
@@ -823,6 +825,7 @@ end function chem_is_active
        , xs_coef_file &
        , xs_short_file &
        , xs_long_file &
+       , photo_max_zen &
        , rsf_file &
        , fstrat_file &
        , fstrat_list &
@@ -849,7 +852,7 @@ end function chem_is_active
      endif
 
      call init_cfc11star(pbuf2d)
-     
+
      ! MEGAN emissions initialize
      if (shr_megan_mechcomps_n>0) then
 
@@ -876,7 +879,7 @@ end function chem_is_active
 
         enddo
      endif
-     
+
      call noy_ubc_init()
 
      ! Galatic Cosmic Rays ...
@@ -888,14 +891,14 @@ end function chem_is_active
      call short_lived_species_initic()
 
      call ocean_emis_init()
-     
+
   end subroutine chem_init
 
 !================================================================================
 !================================================================================
   subroutine chem_emissions( state, cam_in )
     use aero_model,       only: aero_model_emissions
-    use camsrfexch,       only: cam_in_t     
+    use camsrfexch,       only: cam_in_t
     use constituents,     only: sflxnam
     use cam_history,      only: outfld
     use mo_srf_emissions, only: set_srf_emissions
@@ -910,28 +913,28 @@ end function chem_is_active
     ! local vars
 
     integer :: lchnk, ncol
-    integer :: i, m,n 
+    integer :: i, m,n
 
     real(r8) :: sflx(pcols,gas_pcnst)
     real(r8) :: megflx(pcols)
 
     lchnk = state%lchnk
     ncol = state%ncol
-    
+
     ! initialize chemistry constituent surface fluxes to zero
     do m = 2,pcnst
        n = map2chm(m)
-       if (n>0) cam_in%cflx(:,m) = 0._r8 
+       if (n>0) cam_in%cflx(:,m) = 0._r8
     enddo
 
     ! aerosol emissions ...
     call aero_model_emissions( state, cam_in )
 
    ! MEGAN emissions ...
- 
+
     if ( active_Fall_flxvoc .and. shr_megan_mechcomps_n>0 ) then
 
-       ! set MEGAN fluxes 
+       ! set MEGAN fluxes
        do n = 1,shr_megan_mechcomps_n
           do i =1,ncol
              megflx(i) = -cam_in%meganflx(i,n) * megan_wght_factors(n)
@@ -946,9 +949,9 @@ end function chem_is_active
 
    ! prescribed emissions from file ...
 
-    !-----------------------------------------------------------------------      
+    !-----------------------------------------------------------------------
     !        ... Set surface emissions
-    !-----------------------------------------------------------------------      
+    !-----------------------------------------------------------------------
     call set_srf_emissions( lchnk, ncol, sflx(:,:) )
 
     do m = 1,pcnst
@@ -970,11 +973,11 @@ end function chem_is_active
 !================================================================================
 
   subroutine chem_init_cnst( name, latvals, lonvals, mask, q)
-!----------------------------------------------------------------------- 
-! 
-! Purpose: 
+!-----------------------------------------------------------------------
+!
+! Purpose:
 ! Specify initial mass mixing ratios
-! 
+!
 !-----------------------------------------------------------------------
 
     use chem_mods, only : inv_lst
@@ -996,7 +999,7 @@ end function chem_is_active
 !-----------------------------------------------------------------------
 ! Local variables
 !-----------------------------------------------------------------------
-    
+
     real(r8) :: rmwn2o != mwn2o/mwdry ! ratio of mol weight n2o   to dry air
     real(r8) :: rmwch4 != mwch4/mwdry ! ratio of mol weight ch4   to dry air
     real(r8) :: rmwf11 != mwf11/mwdry ! ratio of mol weight cfc11 to dry air
@@ -1007,10 +1010,10 @@ end function chem_is_active
 ! initialize local variables
 !-----------------------------------------------------------------------
 
-    rmwn2o = mwn2o/mwdry 
-    rmwch4 = mwch4/mwdry 
-    rmwf11 = mwf11/mwdry 
-    rmwf12 = mwf12/mwdry 
+    rmwn2o = mwn2o/mwdry
+    rmwch4 = mwch4/mwdry
+    rmwf11 = mwf11/mwdry
+    rmwf12 = mwf12/mwdry
 
 !-----------------------------------------------------------------------
 ! Get initial mixing ratios
@@ -1077,7 +1080,7 @@ end function chem_is_active
 
     implicit none
 
-    type(physics_state), intent(inout) :: phys_state(begchunk:endchunk)                 
+    type(physics_state), intent(inout) :: phys_state(begchunk:endchunk)
     type(physics_buffer_desc), pointer :: pbuf2d(:,:)
 
     !-----------------------------------------------------------------------
@@ -1134,7 +1137,7 @@ end function chem_is_active
     if ( ghg_chem ) then
        call ghg_chem_timestep_init(phys_state)
     endif
-    
+
     !-----------------------------------------------------------------------
     ! Set up aurora
     !-----------------------------------------------------------------------
@@ -1146,7 +1149,7 @@ end function chem_is_active
     call photo_timestep_init( calday )
 
     call update_cfc11star( pbuf2d, phys_state )
-    
+
     ! Galatic Cosmic Rays ...
     call gcr_ionization_adv( pbuf2d, phys_state )
     call epp_ionization_adv()
@@ -1157,31 +1160,31 @@ end function chem_is_active
 
   subroutine chem_timestep_tend( state, ptend, cam_in, cam_out, dt, pbuf,  fh2o)
 
-!----------------------------------------------------------------------- 
-! 
-! Purpose: 
+!-----------------------------------------------------------------------
+!
+! Purpose:
 ! Interface to parameterized greenhouse gas chemisty (source/sink).
-! 
-! Method: 
-! <Describe the algorithm(s) used in the routine.> 
-! <Also include any applicable external references.> 
-! 
+!
+! Method:
+! <Describe the algorithm(s) used in the routine.>
+! <Also include any applicable external references.>
+!
 ! Author: B.A. Boville
-! 
+!
 !-----------------------------------------------------------------------
 
     use physics_buffer,      only : physics_buffer_desc, pbuf_get_field, pbuf_old_tim_idx
     use cam_history,         only : outfld
     use time_manager,        only : get_curr_calday
     use mo_gas_phase_chemdr, only : gas_phase_chemdr
-    use camsrfexch,          only : cam_in_t, cam_out_t     
+    use camsrfexch,          only : cam_in_t, cam_out_t
     use perf_mod,            only : t_startf, t_stopf
     use tropopause,          only : tropopause_findChemTrop, tropopause_find
     use mo_drydep,           only : drydep_update
     use mo_neu_wetdep,       only : neu_wetdep_tend
     use aerodep_flx,         only : aerodep_flx_prescribed
     use short_lived_species, only : short_lived_species_writeic
-    
+
     implicit none
 
 !-----------------------------------------------------------------------
@@ -1193,7 +1196,7 @@ end function chem_is_active
     type(cam_in_t),      intent(inout) :: cam_in
     type(cam_out_t),     intent(inout) :: cam_out
     real(r8),            intent(out)   :: fh2o(pcols)     ! h2o flux to balance source from chemistry
-    
+
 
     type(physics_buffer_desc), pointer :: pbuf(:)
 
@@ -1243,7 +1246,7 @@ end function chem_is_active
     if ( ghg_chem ) lq(1) = .true.
 
     call physics_ptend_init(ptend, state%psetcols, 'chemistry', lq=lq)
-    
+
     call drydep_update( state, cam_in )
 
 !-----------------------------------------------------------------------
@@ -1315,7 +1318,7 @@ end function chem_is_active
           call outfld( srcnam(m), ptend%q(:,:,n), pcols, lchnk )
        end if
 
-       ! if the user has specified prescribed aerosol dep fluxes then 
+       ! if the user has specified prescribed aerosol dep fluxes then
        ! do not set cam_out dep fluxes according to the prognostic aerosols
        if (.not.aerodep_flx_prescribed()) then
           ! set deposition fluxes in the export state
@@ -1361,7 +1364,7 @@ end function chem_is_active
     do k = 1,pver
        fh2o(:ncol) = fh2o(:ncol) + ptend%q(:ncol,k,1)*state%pdel(:ncol,k)/gravit
     end do
-    
+
   end subroutine chem_timestep_tend
 
 !-------------------------------------------------------------------

--- a/src/chemistry/mozart/mo_chemini.F90
+++ b/src/chemistry/mozart/mo_chemini.F90
@@ -21,6 +21,7 @@ contains
        , xs_coef_file &
        , xs_short_file &
        , xs_long_file &
+       , photo_max_zen &
        , rsf_file &
        , fstrat_file &
        , fstrat_list &
@@ -63,7 +64,7 @@ contains
     use mo_setext,         only : setext_inti
     use mo_setinv,         only : setinv_inti
     use mo_gas_phase_chemdr,only: gas_phase_chemdr_inti
-    
+
     use tracer_cnst,       only : tracer_cnst_init
     use tracer_srcs,       only : tracer_srcs_init
     use mo_chem_utls,      only : get_spc_ndx
@@ -78,7 +79,7 @@ contains
     use mo_waccm_hrates,   only : init_hrates
     use mo_aurora,         only : aurora_inti
     use clybry_fam,        only : clybry_fam_init
-    use mo_neu_wetdep,     only : neu_wetdep_init 
+    use mo_neu_wetdep,     only : neu_wetdep_init
     use physics_buffer,    only : physics_buffer_desc
     use cam_abortutils,    only : endrun
 
@@ -91,6 +92,7 @@ contains
     character(len=*), intent(in) :: xs_coef_file
     character(len=*), intent(in) :: xs_short_file
     character(len=*), intent(in) :: xs_long_file
+    real(r8),         intent(in) :: photo_max_zen
     character(len=*), intent(in) :: rsf_file
     character(len=*), intent(in) :: fstrat_file
     character(len=*), intent(in) :: fstrat_list(:)
@@ -206,7 +208,7 @@ contains
 
     call photo_inti( xs_coef_file, xs_short_file, xs_long_file, rsf_file, &
          photon_file, electron_file, &
-         exo_coldens_file, tuv_xsect_file, o2_xsect_file, xactive_prates )
+         exo_coldens_file, tuv_xsect_file, o2_xsect_file, xactive_prates, photo_max_zen )
 
     if (masterproc) write(iulog,*) 'chemini: after photo_inti on node ',iam
 

--- a/src/chemistry/mozart/mo_photo.F90
+++ b/src/chemistry/mozart/mo_photo.F90
@@ -7,7 +7,7 @@ module mo_photo
   use ppgrid,           only : pcols, pver, pverp, begchunk, endchunk
   use cam_abortutils,   only : endrun
   use mo_constants,     only : pi,r2d,boltz,d2r
-  use ref_pres,         only : num_pr_lev, ptop_ref 
+  use ref_pres,         only : num_pr_lev, ptop_ref
   use pio
   use cam_pio_utils,    only : cam_pio_openfile
   use spmd_utils,       only : masterproc
@@ -21,7 +21,7 @@ module mo_photo
 
   public :: photo_inti, table_photo, xactive_photo
   public :: set_ub_col
-  public :: setcol 
+  public :: setcol
   public :: photo_timestep_init
   public :: photo_register
 
@@ -71,7 +71,7 @@ module mo_photo
   integer :: jhno3_ndx, jno3_ndx, jpan_ndx, jmpan_ndx
 
   integer :: jo1da_ndx, jo3pa_ndx, jno2a_ndx, jn2o5a_ndx, jn2o5b_ndx
-  integer :: jhno3a_ndx, jno3a_ndx, jpana_ndx, jmpana_ndx, jho2no2a_ndx 
+  integer :: jhno3a_ndx, jno3a_ndx, jpana_ndx, jmpana_ndx, jho2no2a_ndx
   integer :: jonitra_ndx
 
   integer :: jppi_ndx, jepn1_ndx, jepn2_ndx, jepn3_ndx, jepn4_ndx, jepn6_ndx
@@ -85,7 +85,7 @@ module mo_photo
 
 contains
 
-  
+
   !----------------------------------------------------------------------
   !----------------------------------------------------------------------
   subroutine photo_register
@@ -94,7 +94,7 @@ contains
 
     ! add photo-ionization rates to phys buffer for waccmx ionosphere module
 
-    call pbuf_add_field('IonRates' , 'physpkg', dtype_r8, (/pcols,pver,nIonRates/), ion_rates_idx) ! Ionization rates for O+,O2+,N+,N2+,NO+ 
+    call pbuf_add_field('IonRates' , 'physpkg', dtype_r8, (/pcols,pver,nIonRates/), ion_rates_idx) ! Ionization rates for O+,O2+,N+,N2+,NO+
 
   endsubroutine photo_register
 
@@ -102,7 +102,7 @@ contains
   !----------------------------------------------------------------------
   subroutine photo_inti( xs_coef_file, xs_short_file, xs_long_file, rsf_file, &
        photon_file, electron_file, &
-       exo_coldens_file, tuv_xsect_file, o2_xsect_file, xactive_prates )
+       exo_coldens_file, tuv_xsect_file, o2_xsect_file, xactive_prates, maxzen )
     !----------------------------------------------------------------------
     !	... initialize photolysis module
     !----------------------------------------------------------------------
@@ -110,7 +110,7 @@ contains
     use mo_photoin,    only : photoin_inti
     use mo_tuv_inti,   only : tuv_inti
     use mo_tuv_inti,   only : nlng
-    use mo_seto2,      only : o2_xsect_inti      
+    use mo_seto2,      only : o2_xsect_inti
     use interpolate_data, only: lininterp_init, lininterp, lininterp_finish, interp_type
     use chem_mods,     only : phtcnt
     use chem_mods,     only : ncol_abs => nabscol
@@ -122,7 +122,7 @@ contains
     use seasalt_model, only : sslt_names=>seasalt_names, sslt_ncnst=>seasalt_nbin
     use mo_jshort,     only : jshort_init
     use mo_jeuv,       only : jeuv_init, neuv
-    use phys_grid,     only : get_ncols_p, get_rlat_all_p    
+    use phys_grid,     only : get_ncols_p, get_rlat_all_p
     use solar_irrad_data,only : has_spectrum
     use photo_bkgrnd,  only : photo_bkgrnd_init
     use cam_history,   only : addfld
@@ -137,7 +137,8 @@ contains
     character(len=*), intent(in) :: tuv_xsect_file
     character(len=*), intent(in) :: o2_xsect_file
     logical, intent(in)          :: xactive_prates
-    ! waccm 
+    real(r8), intent(in)         :: maxzen
+    ! waccm
     character(len=*), intent(in) :: xs_coef_file
     character(len=*), intent(in) :: xs_short_file
     character(len=*), intent(in) :: photon_file
@@ -173,25 +174,22 @@ contains
        return
     end if
 
-    !----------------------------------------------------------------------------
-    !  Need a larger maximum zenith angle for WACCM-X extended to high altitudes
-    !----------------------------------------------------------------------------
-    if ( waccmx_is('ionosphere') .or. waccmx_is('neutral') ) then 
-       max_zen_angle = 116._r8
-    else if ( ptop_ref < 10._r8 ) then
-       max_zen_angle = 97.01_r8 ! degrees
-    else
-       max_zen_angle = 88.85_r8 ! degrees
-    endif
+    ! maximum solar zenith angle for which photo-chemical rates are computed
+    max_zen_angle = maxzen
+    if (.not. max_zen_angle>0._r8) then
+       write(*,*) 'photo_inti: max_zen_angle = ',max_zen_angle
+       call endrun ('photo_inti: max_zen_angle must be greater then zero')
+    end if
 
-    ! jeuv_1,,, jeuv_25 --> need euv calculations --> must be waccm 
+
+    ! jeuv_1,,, jeuv_25 --> need euv calculations --> must be waccm
     ! how to determine if shrt calc is needed ?? -- use top level pressure => waccm = true ? false
 
     if ( .not. has_spectrum ) then
        write(iulog,*) 'photo_inti: solar_irrad_data file needs to contain irradiance spectrum'
        call endrun('photo_inti: ERROR -- solar irradiance spectrum is missing')
     endif
-    
+
     !----------------------------------------------------------------------
     !	... allocate indexers
     !----------------------------------------------------------------------
@@ -287,7 +285,7 @@ contains
     end if
 
     do_jshort = o_ndx>0 .and. o2_ndx>0 .and. (o3_ndx>0.or.o3_inv_ndx>0) .and. n2_ndx>0 .and. no_ndx>0
-    
+
     call jeuv_init( photon_file, electron_file, euv_indexer )
     do_jeuv = any(euv_indexer(:)>0)
 
@@ -645,7 +643,7 @@ contains
     real(r8), allocatable ::  lng_prates(:,:) ! photorates matrix (1/s)
     real(r8), allocatable ::  sht_prates(:,:) ! photorates matrix (1/s)
     real(r8), allocatable ::  euv_prates(:,:) ! photorates matrix (1/s)
-    
+
 
     real(r8), allocatable :: zarg(:)
     real(r8), allocatable :: tline(:)               ! vertical temperature array
@@ -682,7 +680,7 @@ contains
 
     if ((.not.do_jshort) .or. (ptop_ref < 10._r8)) then
        n_jshrt_levs = pver
-       p1 = 1 
+       p1 = 1
        p2 = pver
     else
        n_jshrt_levs = pver+1
@@ -714,7 +712,7 @@ contains
           end if
        endif
     endif
-    
+
     if (nsht>0) then
        allocate( sht_prates(n_jshrt_levs,nsht),stat=astat )
        if( astat /= 0 ) then
@@ -787,7 +785,7 @@ contains
           lwc_line(:) = lwc(i,:)
           cld_line(:) = clouds(i,:)
 
-          
+
           tline(p1:p2) = temper(i,:pver)
 
           zarg(p1:p2) = zmid(i,:pver)
@@ -805,7 +803,7 @@ contains
             if (jpni3_ndx > 0 ) photos(i,:,jpni3_ndx) = photos(i,:,jpni3_ndx) + esfact * 0.15_r8
             if (jpni4_ndx > 0 ) photos(i,:,jpni4_ndx) = photos(i,:,jpni4_ndx) + esfact * 6.2e-3_r8
             ! added to v02
-            if (jpni5_ndx > 0 ) photos(i,:,jpni5_ndx) = photos(i,:,jpni5_ndx) + esfact * 1.0_r8 
+            if (jpni5_ndx > 0 ) photos(i,:,jpni5_ndx) = photos(i,:,jpni5_ndx) + esfact * 1.0_r8
         endif
           if (do_jshort) then
              if ( ptop_ref > 10._r8 ) then
@@ -840,7 +838,7 @@ contains
              !	... short wave length component
              !-----------------------------------------------------------------
              call jshort( n_jshrt_levs, sza, n2_den, o2_den, o3_den, &
-                  no_den, tline, zarg, jo2_sht, jno_sht, sht_prates )  
+                  no_den, tline, zarg, jo2_sht, jno_sht, sht_prates )
 
              do m = 1,phtcnt
                 if( sht_indexer(m) > 0 ) then
@@ -880,7 +878,7 @@ contains
           !-----------------------------------------------------------------
           !	... long wave length component
           !-----------------------------------------------------------------
-          call jlong( pver, sza, eff_alb, parg, tline, colo3, lng_prates )          
+          call jlong( pver, sza, eff_alb, parg, tline, colo3, lng_prates )
           do m = 1,phtcnt
              if( lng_indexer(m) > 0 ) then
                 alias_factor = pht_alias_mult(m,2)
@@ -912,9 +910,9 @@ contains
 
           !  Save photo-ionization rates to physics buffer accessed in ionosphere module for WACCMX
           if (ion_rates_idx>0) then
-							 
+
                 ionRates(i,1:pver,1:nIonRates) = esfact * euv_prates(1:pver,1:nIonRates)
-							 
+
           endif
 
        end if daylight
@@ -930,7 +928,7 @@ contains
        endif
 
     end do col_loop
-    
+
     if ( do_jeuv ) then
        qbktot(:ncol,:) = qbko1(:ncol,:)+qbko2(:ncol,:)+qbkn2(:ncol,:)+qbkn1(:ncol,:)+qbkno(:ncol,:)
        call outfld( 'Qbkgndtot', qbktot(:ncol,:),ncol, lchnk )
@@ -1032,15 +1030,15 @@ contains
     real(r8)    ::   xfrc(pverp)                   ! cloud fraction      xuexi
     real(r8)    ::   airdens(pverp)                ! atmospheric density
     real(r8)    ::   o3line(pverp)                 ! vertical o3 vmr
-    real(r8)    ::   aerocs1(pverp)   
-    real(r8)    ::   aerocs2(pverp)   
-    real(r8)    ::   aercbs1(pverp)   
-    real(r8)    ::   aercbs2(pverp)   
-    real(r8)    ::   aersoa(pverp)   
-    real(r8)    ::   aerant(pverp)   
-    real(r8)    ::   aerso4(pverp)   
+    real(r8)    ::   aerocs1(pverp)
+    real(r8)    ::   aerocs2(pverp)
+    real(r8)    ::   aercbs1(pverp)
+    real(r8)    ::   aercbs2(pverp)
+    real(r8)    ::   aersoa(pverp)
+    real(r8)    ::   aerant(pverp)
+    real(r8)    ::   aerso4(pverp)
     real(r8)    ::   aerds(4,pverp)
-    real(r8)    ::   rh(pverp)   
+    real(r8)    ::   rh(pverp)
     real(r8)    ::   zarg(pverp)                   ! vertical height array
     real(r8)    ::   aersal(pverp,4)
     real(r8)    ::   albedo(kw)                    ! wavelenght dependent albedo
@@ -1177,7 +1175,7 @@ secant_in_bounds : &
                 do ndx = 1,4
                    aerds(ndx,pverp:2:-1) = dust_vmr(i,:,ndx)
                 end do
-             else 
+             else
                 do ndx = 1,4
                    aerds(ndx,pverp:2:-1) = 0._r8
                 end do
@@ -1213,8 +1211,8 @@ secant_in_bounds : &
                            airdens, aerocs1, aerocs2, aercbs1, aercbs2, &
                            aersoa, aerant, aerso4, aersal, aerds, o3line, rh, &
                            prates, sza, nw, dt_xdiag )
-             dt_diag(i,:) = dt_xdiag(:) 
-             
+             dt_diag(i,:) = dt_xdiag(:)
+
              do m = 1,phtcnt
                 if( lng_indexer(m) > 0 ) then
                    alias_factor = pht_alias_mult(m,2)
@@ -1444,7 +1442,7 @@ secant_in_bounds : &
     real(r8)    :: o2_exo_col(ncol)
     real(r8)    :: o3_exo_col(ncol)
     integer :: i
- 
+
     !---------------------------------------------------------------
     !        ... assign column density at the upper boundary
     !            the first column is o3 and the second is o2.
@@ -1466,8 +1464,8 @@ secant_in_bounds : &
                         + delp * (o2_exo_coldens(ki,i,lchnk,next) &
                         - o2_exo_coldens(kl,i,lchnk,next))
                 else
-                   tint_vals(1) = o2_exo_coldens( 1,i,lchnk,last) 
-                   tint_vals(2) = o2_exo_coldens( 1,i,lchnk,next) 
+                   tint_vals(1) = o2_exo_coldens( 1,i,lchnk,last)
+                   tint_vals(2) = o2_exo_coldens( 1,i,lchnk,next)
                 endif
                 o2_exo_col(i) = tint_vals(1) + dels * (tint_vals(2) - tint_vals(1))
              end do
@@ -1484,8 +1482,8 @@ secant_in_bounds : &
                         + delp * (o3_exo_coldens(ki,i,lchnk,next) &
                         - o3_exo_coldens(kl,i,lchnk,next))
                 else
-                   tint_vals(1) = o3_exo_coldens( 1,i,lchnk,last) 
-                   tint_vals(2) = o3_exo_coldens( 1,i,lchnk,next) 
+                   tint_vals(1) = o3_exo_coldens( 1,i,lchnk,last)
+                   tint_vals(2) = o3_exo_coldens( 1,i,lchnk,next)
                 endif
                 o3_exo_col(i) = tint_vals(1) + dels * (tint_vals(2) - tint_vals(1))
              end do
@@ -1721,7 +1719,7 @@ secant_in_bounds : &
     ! Set jlong etf
     !-----------------------------------------------------------------------
     call jlong_timestep_init
-    
+
     if ( do_jshort ) then
        !-----------------------------------------------------------------------
        ! Set jshort etf


### PR DESCRIPTION
This implements a namelist variable for maximum solar zenith angle for photolysis.  The maximum solar zenith for CAM-Chem is increased to the value used in WACCM.

This changes answers for CAM-Chem compsets only.

closes #321