### PR TITLE
Add defaults for a number of MPAS grids

### DIFF
--- a/bld/namelist_files/namelist_defaults_cam.xml
+++ b/bld/namelist_files/namelist_defaults_cam.xml
@@ -42,6 +42,7 @@
 <dtime dyn="mpas"  hgrid="mpasa15" >180</dtime> <!-- 2x mpas_dt -->
 <dtime dyn="mpas"  hgrid="mpasa15-3-conus">36</dtime> <!-- 2x mpas_dt -->
 <dtime dyn="mpas"  hgrid="mpasa7.5" >90</dtime> <!-- 2x mpas_dt -->
+<dtime dyn="mpas"  hgrid="mpasa3.75">46</dtime> <!-- 2x mpas_dt -->
 
 <!-- Initial files -->
 
@@ -2816,6 +2817,7 @@
 <mpas_dt hgrid="mpasa15"      >   90.0D0 </mpas_dt>
 <mpas_dt hgrid="mpasa15-3-conus"> 18.0D0 </mpas_dt>
 <mpas_dt hgrid="mpasa7.5"     >   45.0D0 </mpas_dt>
+<mpas_dt hgrid="mpasa3.75"    >   23.0D0 </mpas_dt>
 
 <mpas_split_dynamics_transport>.true.</mpas_split_dynamics_transport>
 <mpas_number_of_sub_steps     > 2 </mpas_number_of_sub_steps>
@@ -2836,6 +2838,7 @@
 <mpas_len_disp hgrid="mpasa15" >15000.0D0</mpas_len_disp>
 <mpas_len_disp hgrid="mpasa15-3-conus">3000.0D0</mpas_len_disp>
 <mpas_len_disp hgrid="mpasa7.5">7500.0D0</mpas_len_disp>
+<mpas_len_disp hgrid="mpasa3.75">3750.0D0</mpas_len_disp>
 
 <mpas_visc4_2dsmag            > 0.05D0 </mpas_visc4_2dsmag>
 <mpas_del4u_div_factor        > 10.0D0 </mpas_del4u_div_factor>

--- a/bld/namelist_files/namelist_defaults_cam.xml
+++ b/bld/namelist_files/namelist_defaults_cam.xml
@@ -35,6 +35,11 @@
 <dtime dyn="se"    hgrid="ne0np4.ARCTICGRIS.ne30x8">225</dtime>
 
 <dtime dyn="mpas"                  >1800</dtime>
+<dtime dyn="mpas"  hgrid="mpasa480">5760</dtim> <!-- 2x mpas_dt -->
+<dtime dyn="mpas"  hgrid="mpasa60" >720</dtime> <!-- 2x mpas_dt -->
+<dtime dyn="mpas"  hgrid="mpasa30" >360</dtime> <!-- 2x mpas_dt -->
+<dtime dyn="mpas"  hgrid="mpasa15" >180</dtime> <!-- 2x mpas_dt -->
+<dtime dyn="mpas"  hgrid="mpasa7.5" >90</dtime> <!-- 2x mpas_dt -->
 
 <!-- Initial files -->
 
@@ -2790,6 +2795,7 @@
 <mpas_time_integration        > SRK3 </mpas_time_integration>
 <mpas_time_integration_order  > 2 </mpas_time_integration_order>
 <mpas_dt                      > 1800.0D0 </mpas_dt>
+<mpas_dt hgrid="mpasa480"     > 2880.0D0 </mpas_dt>
 <mpas_dt hgrid="mpasa120"     >  900.0D0 </mpas_dt>
 
 <mpas_split_dynamics_transport>.true.</mpas_split_dynamics_transport>

--- a/bld/namelist_files/namelist_defaults_cam.xml
+++ b/bld/namelist_files/namelist_defaults_cam.xml
@@ -2822,7 +2822,7 @@
 <mpas_dt hgrid="mpasa15"      >   90.0D0 </mpas_dt>
 <mpas_dt hgrid="mpasa15-3-conus"> 18.0D0 </mpas_dt>
 <mpas_dt hgrid="mpasa7.5"     >   45.0D0 </mpas_dt>
-<mpas_dt hgrid="mpasa3.75"    >   23.0D0 </mpas_dt>
+<mpas_dt hgrid="mpasa3.75"    >   24.0D0 </mpas_dt>
 
 <mpas_split_dynamics_transport>.true.</mpas_split_dynamics_transport>
 <mpas_number_of_sub_steps     > 2 </mpas_number_of_sub_steps>

--- a/bld/namelist_files/namelist_defaults_cam.xml
+++ b/bld/namelist_files/namelist_defaults_cam.xml
@@ -40,6 +40,7 @@
 <dtime dyn="mpas"  hgrid="mpasa60" >720</dtime> <!-- 2x mpas_dt -->
 <dtime dyn="mpas"  hgrid="mpasa30" >360</dtime> <!-- 2x mpas_dt -->
 <dtime dyn="mpas"  hgrid="mpasa15" >180</dtime> <!-- 2x mpas_dt -->
+<dtime dyn="mpas"  hgrid="mpasa15-3-conus">36</dtime> <!-- 2x mpas_dt -->
 <dtime dyn="mpas"  hgrid="mpasa7.5" >90</dtime> <!-- 2x mpas_dt -->
 
 <!-- Initial files -->
@@ -2813,6 +2814,7 @@
 <mpas_dt hgrid="mpasa60"      >  360.0D0 </mpas_dt>
 <mpas_dt hgrid="mpasa30"      >  180.0D0 </mpas_dt>
 <mpas_dt hgrid="mpasa15"      >   90.0D0 </mpas_dt>
+<mpas_dt hgrid="mpasa15-3-conus"> 18.0D0 </mpas_dt>
 <mpas_dt hgrid="mpasa7.5"     >   45.0D0 </mpas_dt>
 
 <mpas_split_dynamics_transport>.true.</mpas_split_dynamics_transport>
@@ -2832,6 +2834,7 @@
 <mpas_len_disp hgrid="mpasa60" >60000.0D0</mpas_len_disp>
 <mpas_len_disp hgrid="mpasa30" >30000.0D0</mpas_len_disp>
 <mpas_len_disp hgrid="mpasa15" >15000.0D0</mpas_len_disp>
+<mpas_len_disp hgrid="mpasa15-3-conus">3000.0D0</mpas_len_disp>
 <mpas_len_disp hgrid="mpasa7.5">7500.0D0</mpas_len_disp>
 
 <mpas_visc4_2dsmag            > 0.05D0 </mpas_visc4_2dsmag>

--- a/bld/namelist_files/namelist_defaults_cam.xml
+++ b/bld/namelist_files/namelist_defaults_cam.xml
@@ -1728,6 +1728,7 @@
 
 <drydep_srf_file hgrid="mpasa3.75">atm/cam/chem/trop_mam/atmsrf_mpasa3.75_20210804.nc</drydep_srf_file>
 <drydep_srf_file hgrid="mpasa7.5">atm/cam/chem/trop_mam/atmsrf_mpasa7.5_20210824.nc</drydep_srf_file>
+<drydep_srf_file hgrid="mpasa15-3-conus">atm/cam/chem/trop_mam/atmsrf_mpasa15-3.conus_210609.nc</drydep_srf_file>
 <drydep_srf_file hgrid="mpasa15">atm/cam/chem/trop_mam/atmsrf_mpasa15_20210804.nc</drydep_srf_file>
 <drydep_srf_file hgrid="mpasa30">atm/cam/chem/trop_mam/atmsrf_mpasa30_20210804.nc</drydep_srf_file>
 <drydep_srf_file hgrid="mpasa60">atm/cam/chem/trop_mam/atmsrf_mpasa60_20210803.nc</drydep_srf_file>

--- a/bld/namelist_files/namelist_defaults_cam.xml
+++ b/bld/namelist_files/namelist_defaults_cam.xml
@@ -35,7 +35,7 @@
 <dtime dyn="se"    hgrid="ne0np4.ARCTICGRIS.ne30x8">225</dtime>
 
 <dtime dyn="mpas"                  >1800</dtime>
-<dtime dyn="mpas"  hgrid="mpasa480">5760</dtim> <!-- 2x mpas_dt -->
+<dtime dyn="mpas"  hgrid="mpasa480">5760</dtime> <!-- 2x mpas_dt -->
 <dtime dyn="mpas"  hgrid="mpasa240">2880</dtime><!-- 2x mpas_dt -->
 <dtime dyn="mpas"  hgrid="mpasa60" >720</dtime> <!-- 2x mpas_dt -->
 <dtime dyn="mpas"  hgrid="mpasa30" >360</dtime> <!-- 2x mpas_dt -->

--- a/bld/namelist_files/namelist_defaults_cam.xml
+++ b/bld/namelist_files/namelist_defaults_cam.xml
@@ -36,6 +36,7 @@
 
 <dtime dyn="mpas"                  >1800</dtime>
 <dtime dyn="mpas"  hgrid="mpasa480">5760</dtim> <!-- 2x mpas_dt -->
+<dtime dyn="mpas"  hgrid="mpasa240">2880</dtime><!-- 2x mpas_dt -->
 <dtime dyn="mpas"  hgrid="mpasa60" >720</dtime> <!-- 2x mpas_dt -->
 <dtime dyn="mpas"  hgrid="mpasa30" >360</dtime> <!-- 2x mpas_dt -->
 <dtime dyn="mpas"  hgrid="mpasa15" >180</dtime> <!-- 2x mpas_dt -->
@@ -2807,6 +2808,7 @@
 <mpas_time_integration_order  > 2 </mpas_time_integration_order>
 <mpas_dt                      > 1800.0D0 </mpas_dt>
 <mpas_dt hgrid="mpasa480"     > 2880.0D0 </mpas_dt>
+<mpas_dt hgrid="mpasa240"     > 1440.0D0 </mpas_dt>
 <mpas_dt hgrid="mpasa120"     >  900.0D0 </mpas_dt>
 <mpas_dt hgrid="mpasa60"      >  360.0D0 </mpas_dt>
 <mpas_dt hgrid="mpasa30"      >  180.0D0 </mpas_dt>
@@ -2825,6 +2827,7 @@
 <mpas_horiz_mixing            > 2d_smagorinsky </mpas_horiz_mixing>
 
 <mpas_len_disp hgrid="mpasa480">480000.0D0</mpas_len_disp>
+<mpas_len_disp hgrid="mpasa240">240000.0D0</mpas_len_disp>
 <mpas_len_disp hgrid="mpasa120">120000.0D0</mpas_len_disp>
 <mpas_len_disp hgrid="mpasa60" >60000.0D0</mpas_len_disp>
 <mpas_len_disp hgrid="mpasa30" >30000.0D0</mpas_len_disp>

--- a/bld/namelist_files/namelist_defaults_cam.xml
+++ b/bld/namelist_files/namelist_defaults_cam.xml
@@ -2797,6 +2797,7 @@
 <mpas_dt                      > 1800.0D0 </mpas_dt>
 <mpas_dt hgrid="mpasa480"     > 2880.0D0 </mpas_dt>
 <mpas_dt hgrid="mpasa120"     >  900.0D0 </mpas_dt>
+<mpas_dt hgrid="mpasa60"      >  360.0D0 </mpas_dt>
 
 <mpas_split_dynamics_transport>.true.</mpas_split_dynamics_transport>
 <mpas_number_of_sub_steps     > 2 </mpas_number_of_sub_steps>
@@ -2811,6 +2812,7 @@
 
 <mpas_len_disp hgrid="mpasa480">480000.0D0</mpas_len_disp>
 <mpas_len_disp hgrid="mpasa120">120000.0D0</mpas_len_disp>
+<mpas_len_disp hgrid="mpasa60" >60000.0D0</mpas_len_disp>
 
 <mpas_visc4_2dsmag            > 0.05D0 </mpas_visc4_2dsmag>
 <mpas_del4u_div_factor        > 10.0D0 </mpas_del4u_div_factor>

--- a/bld/namelist_files/namelist_defaults_cam.xml
+++ b/bld/namelist_files/namelist_defaults_cam.xml
@@ -1714,6 +1714,7 @@
 <drydep_srf_file hgrid="C384">atm/cam/chem/trop_mam/atmsrf_C384_c200625.nc</drydep_srf_file>
 
 <drydep_srf_file hgrid="mpasa3.75">atm/cam/chem/trop_mam/atmsrf_mpasa3.75_20210804.nc</drydep_srf_file>
+<drydep_srf_file hgrid="mpasa7.5">atm/cam/chem/trop_mam/atmsrf_mpasa7.5_20210824.nc</drydep_srf_file>
 <drydep_srf_file hgrid="mpasa15">atm/cam/chem/trop_mam/atmsrf_mpasa15_20210804.nc</drydep_srf_file>
 <drydep_srf_file hgrid="mpasa30">atm/cam/chem/trop_mam/atmsrf_mpasa30_20210804.nc</drydep_srf_file>
 <drydep_srf_file hgrid="mpasa60">atm/cam/chem/trop_mam/atmsrf_mpasa60_20210803.nc</drydep_srf_file>
@@ -2800,6 +2801,7 @@
 <mpas_dt hgrid="mpasa60"      >  360.0D0 </mpas_dt>
 <mpas_dt hgrid="mpasa30"      >  180.0D0 </mpas_dt>
 <mpas_dt hgrid="mpasa15"      >   90.0D0 </mpas_dt>
+<mpas_dt hgrid="mpasa7.5"     >   45.0D0 </mpas_dt>
 
 <mpas_split_dynamics_transport>.true.</mpas_split_dynamics_transport>
 <mpas_number_of_sub_steps     > 2 </mpas_number_of_sub_steps>
@@ -2817,6 +2819,7 @@
 <mpas_len_disp hgrid="mpasa60" >60000.0D0</mpas_len_disp>
 <mpas_len_disp hgrid="mpasa30" >30000.0D0</mpas_len_disp>
 <mpas_len_disp hgrid="mpasa15" >15000.0D0</mpas_len_disp>
+<mpas_len_disp hgrid="mpasa7.5">7500.0D0</mpas_len_disp>
 
 <mpas_visc4_2dsmag            > 0.05D0 </mpas_visc4_2dsmag>
 <mpas_del4u_div_factor        > 10.0D0 </mpas_del4u_div_factor>
@@ -2853,6 +2856,7 @@
 <mpas_block_decomp_file_prefix hgrid="mpasa15">atm/cam/inic/mpas/mpasa15.graph.info.part.</mpas_block_decomp_file_prefix>
 <mpas_block_decomp_file_prefix hgrid="mpasa12">atm/cam/inic/mpas/mpasa12.graph.info.part.</mpas_block_decomp_file_prefix>
 <mpas_block_decomp_file_prefix hgrid="mpasa15-3">atm/cam/inic/mpas/mpasa15-3.graph.info.part.</mpas_block_decomp_file_prefix>
+<mpas_block_decomp_file_prefix hgrid="mpasa7.5">atm/cam/inic/mpas/mpasa7.5.graph.info.part</mpas_block_decomp_file_prefix>
 
 <mpas_do_restart               > .false. </mpas_do_restart>
 <mpas_print_global_minmax_vel  > .true. </mpas_print_global_minmax_vel>

--- a/bld/namelist_files/namelist_defaults_cam.xml
+++ b/bld/namelist_files/namelist_defaults_cam.xml
@@ -2798,6 +2798,7 @@
 <mpas_dt hgrid="mpasa480"     > 2880.0D0 </mpas_dt>
 <mpas_dt hgrid="mpasa120"     >  900.0D0 </mpas_dt>
 <mpas_dt hgrid="mpasa60"      >  360.0D0 </mpas_dt>
+<mpas_dt hgrid="mpasa30"      >  180.0D0 </mpas_dt>
 
 <mpas_split_dynamics_transport>.true.</mpas_split_dynamics_transport>
 <mpas_number_of_sub_steps     > 2 </mpas_number_of_sub_steps>
@@ -2813,6 +2814,7 @@
 <mpas_len_disp hgrid="mpasa480">480000.0D0</mpas_len_disp>
 <mpas_len_disp hgrid="mpasa120">120000.0D0</mpas_len_disp>
 <mpas_len_disp hgrid="mpasa60" >60000.0D0</mpas_len_disp>
+<mpas_len_disp hgrid="mpasa30" >30000.0D0</mpas_len_disp>
 
 <mpas_visc4_2dsmag            > 0.05D0 </mpas_visc4_2dsmag>
 <mpas_del4u_div_factor        > 10.0D0 </mpas_del4u_div_factor>

--- a/bld/namelist_files/namelist_defaults_cam.xml
+++ b/bld/namelist_files/namelist_defaults_cam.xml
@@ -52,6 +52,8 @@
 <ncdata hgrid="mpasa480" nlev="32" analytic_ic="1" >atm/cam/inic/mpas/mpasa480_L32_notopo_coords_c201125.nc</ncdata>
 <ncdata hgrid="mpasa120" nlev="32" analytic_ic="1" >atm/cam/inic/mpas/mpasa120_L32_notopo_coords_c201216.nc</ncdata>
 <ncdata hgrid="mpasa120" nlev="32" analytic_ic="1" phys="cam6" >atm/cam/inic/mpas/mpasa120_L32_topo_coords_c201022.nc</ncdata>
+<ncdata hgrid="mpasa60"  nlev="32" analytic_ic="1" >atm/cam/inic/mpas/mpasa60_L32_notopo_coords_c210518.nc</ncdata>
+<ncdata hgrid="mpasa60"  nlev="32" analytic_ic="1" phys="cam6" >atm/cam/inic/mpas/mpasa60_L32_topo_coords_c210518.nc</ncdata>
 
 <!-- Files with initial conditions -->
 <ncdata dyn="fv"  hgrid="0.23x0.31" nlev="26" ic_ymd="101"      >atm/cam/inic/fv/cami_0000-01-01_0.23x0.31_L26_c100513.nc</ncdata>
@@ -251,6 +253,7 @@
 
 <ncdata hgrid="mpasa120" nlev="32" >atm/cam/inic/mpas/cami_01-01-2000_00Z_mpasa120_L32_CFSR_c210426.nc</ncdata>
 <ncdata hgrid="mpasa480" nlev="32" >atm/cam/inic/mpas/cami_01-01-2000_00Z_mpasa480_L32_CFSR_c211013.nc</ncdata>
+<ncdata hgrid="mpasa60"  nlev="32" >atm/cam/inic/mpas/mpasa60.CFSR2000.L32.210518.nc</ncdata>
 
 <!-- Topography -->
 <bnd_topo hgrid="256x512" >atm/cam/topo/topo-from-cami_0000-01-01_256x512_L26_c030918.nc</bnd_topo>
@@ -306,6 +309,7 @@
 <bnd_topo hgrid="ne0np4.ARCTICGRIS.ne30x8" >atm/cam/topo/se/ne30x8_ARCTICGRIS_nc3000_Co060_Fi001_MulG_PF_RR_Nsw042_c200428.nc</bnd_topo>
 
 <bnd_topo hgrid="mpasa120" >atm/cam/topo/mpas/mpas_120_nc3000_Co060_Fi001_MulG_PF_Nsw042_c200921.nc</bnd_topo>
+<<<<<<< HEAD
 <bnd_topo hgrid="mpasa480" >atm/cam/topo/mpas_480_nc3000_Co240_Fi001_MulG_PF_Nsw170.nc</bnd_topo>
 
 <!-- Scale Dry Air Mass: 0=> no scaling / +nnn=>scale to nnn Pressure  -->
@@ -317,6 +321,9 @@
 <scale_dry_air_mass phys="cam6"                                                    >  98288.0D0 </scale_dry_air_mass>
 <scale_dry_air_mass phys="spcam_m2005"                                             >  98288.0D0 </scale_dry_air_mass>
 <scale_dry_air_mass phys="spcam_sam1mom"                                           >  98288.0D0 </scale_dry_air_mass>
+=======
+<bnd_topo hgrid="mpasa60"  >atm/cam/topo/mpas_60_nc3000_Co030_Fi001_MulG_PF_Nsw021.nc</bnd_topo>
+>>>>>>> 8dbed14f1... Add mpasa60 topography and initial conditions to namelist defaults
 
 <!-- Ridge parameterization (gamma) -->
 <bnd_rdggm hgrid="0.9x1.25">atm/cam/topo/fv_0.9x1.25_nc3000_Nsw006_Nrs002_Co008_Fi001_ZR_c160505.nc</bnd_rdggm>

--- a/bld/namelist_files/namelist_defaults_cam.xml
+++ b/bld/namelist_files/namelist_defaults_cam.xml
@@ -1708,8 +1708,14 @@
 <drydep_srf_file hgrid="C192">atm/cam/chem/trop_mam/atmsrf_C192_c200625.nc</drydep_srf_file>
 <drydep_srf_file hgrid="C384">atm/cam/chem/trop_mam/atmsrf_C384_c200625.nc</drydep_srf_file>
 
+<drydep_srf_file hgrid="mpasa3.75">atm/cam/chem/trop_mam/atmsrf_mpasa3.75_20210804.nc</drydep_srf_file>
+<drydep_srf_file hgrid="mpasa15">atm/cam/chem/trop_mam/atmsrf_mpasa15_20210804.nc</drydep_srf_file>
+<drydep_srf_file hgrid="mpasa30">atm/cam/chem/trop_mam/atmsrf_mpasa30_20210804.nc</drydep_srf_file>
+<drydep_srf_file hgrid="mpasa60">atm/cam/chem/trop_mam/atmsrf_mpasa60_20210803.nc</drydep_srf_file>
 <drydep_srf_file hgrid="mpasa120">atm/cam/chem/trop_mam/atmsrf_mpasa120_c090720.nc</drydep_srf_file>
+<drydep_srf_file hgrid="mpasa240">/atm/cam/chem/trop_mam/atmsrf_mpasa240_20211115.nc</drydep_srf_file>
 <drydep_srf_file hgrid="mpasa480">atm/cam/chem/trop_mam/atmsrf_mpasa480_c090720.nc</drydep_srf_file>
+
 
 <!-- depvel data -->
 <depvel_lnd_file>atm/cam/chem/trop_mozart/dvel/regrid_vegetation.nc</depvel_lnd_file>

--- a/bld/namelist_files/namelist_defaults_cam.xml
+++ b/bld/namelist_files/namelist_defaults_cam.xml
@@ -2799,6 +2799,7 @@
 <mpas_dt hgrid="mpasa120"     >  900.0D0 </mpas_dt>
 <mpas_dt hgrid="mpasa60"      >  360.0D0 </mpas_dt>
 <mpas_dt hgrid="mpasa30"      >  180.0D0 </mpas_dt>
+<mpas_dt hgrid="mpasa15"      >   90.0D0 </mpas_dt>
 
 <mpas_split_dynamics_transport>.true.</mpas_split_dynamics_transport>
 <mpas_number_of_sub_steps     > 2 </mpas_number_of_sub_steps>
@@ -2815,6 +2816,7 @@
 <mpas_len_disp hgrid="mpasa120">120000.0D0</mpas_len_disp>
 <mpas_len_disp hgrid="mpasa60" >60000.0D0</mpas_len_disp>
 <mpas_len_disp hgrid="mpasa30" >30000.0D0</mpas_len_disp>
+<mpas_len_disp hgrid="mpasa15" >15000.0D0</mpas_len_disp>
 
 <mpas_visc4_2dsmag            > 0.05D0 </mpas_visc4_2dsmag>
 <mpas_del4u_div_factor        > 10.0D0 </mpas_del4u_div_factor>

--- a/bld/namelist_files/namelist_defaults_cam.xml
+++ b/bld/namelist_files/namelist_defaults_cam.xml
@@ -59,6 +59,10 @@
 <ncdata hgrid="mpasa60"  nlev="32" analytic_ic="1" phys="cam6" >atm/cam/inic/mpas/mpasa60_L32_topo_coords_c210518.nc</ncdata>
 <ncdata hgrid="mpasa30"  nlev="32" analytic_ic="1" >atm/cam/inic/mpas/mpasa30_L32_notopo_coords_c210611.nc</ncdata>
 <ncdata hgrid="mpasa30"  nlev="32" analytic_ic="1" phys="cam6">atm/cam/inic/mpas/mpasa30_L32_topo_coords_c210611.nc</ncdata>
+<ncdata hgrid="mpasa15"  nlev="32" analytic_ic="1" >atm/cam/inic/mpas/mpasa15_L32_notopo_coords_c211118.nc</ncdata>
+<ncdata hgrid="mpasa15-3-conus"  nlev="32" analytic_ic="1" >atm/cam/inic/mpas/mpasa15-3_CONUS_L32_notopo_coords_c211118.nc</ncdata>
+<ncdata hgrid="mpasa7.5" nlev="32" analytic_ic="1" >atm/cam/inic/mpas/mpasa7.5_L32_notopo_coords_c211118.nc</ncdata>
+<ncdata hgrid="mpasa3.75" nlev="32" analytic_ic="1">atm/cam/inic/mpas/mpasa3.75_L32_notopo_coords_c211118.nc</ncdata>
 
 <!-- Files with initial conditions -->
 <ncdata dyn="fv"  hgrid="0.23x0.31" nlev="26" ic_ymd="101"      >atm/cam/inic/fv/cami_0000-01-01_0.23x0.31_L26_c100513.nc</ncdata>
@@ -2870,13 +2874,17 @@
 <mpas_jedi_da> .false. </mpas_jedi_da>
 <mpas_print_detailed_minmax_vel> .true.  </mpas_print_detailed_minmax_vel>
 <mpas_block_decomp_file_prefix hgrid="mpasa480">atm/cam/inic/mpas/mpasa480.graph.info.part.</mpas_block_decomp_file_prefix>
+<mpas_block_decomp_file_prefix hgrid="mpasa240">atm/cam/inic/mpas/mpasa240.graph.info.part.</mpas_block_decomp_file_prefix>
 <mpas_block_decomp_file_prefix hgrid="mpasa120">atm/cam/inic/mpas/mpasa120.graph.info.part.</mpas_block_decomp_file_prefix>
 <mpas_block_decomp_file_prefix hgrid="mpasa60">atm/cam/inic/mpas/mpasa60.graph.info.part.</mpas_block_decomp_file_prefix>
 <mpas_block_decomp_file_prefix hgrid="mpasa30">atm/cam/inic/mpas/mpasa30.graph.info.part.</mpas_block_decomp_file_prefix>
 <mpas_block_decomp_file_prefix hgrid="mpasa15">atm/cam/inic/mpas/mpasa15.graph.info.part.</mpas_block_decomp_file_prefix>
 <mpas_block_decomp_file_prefix hgrid="mpasa12">atm/cam/inic/mpas/mpasa12.graph.info.part.</mpas_block_decomp_file_prefix>
 <mpas_block_decomp_file_prefix hgrid="mpasa15-3">atm/cam/inic/mpas/mpasa15-3.graph.info.part.</mpas_block_decomp_file_prefix>
+<!-- A rotated MPAS grid can use the same block decomps as the non-rotated - Such as the 15-3 and the 15-3-conus grid -->
+<mpas_block_decomp_file_prefix hgrid="mpasa15-3-conus">atm/cam/inic/mpas/mpasa15-3.graph.info.part.</mpas_block_decomp_file_prefix>
 <mpas_block_decomp_file_prefix hgrid="mpasa7.5">atm/cam/inic/mpas/mpasa7.5.graph.info.part</mpas_block_decomp_file_prefix>
+<mpas_block_decomp_file_prefix hgrid="mpasa3.75">atm/cam/inic/mpas/mpasa3.75.graph.info.part</mpas_block_decomp_file_prefix>
 
 <mpas_do_restart               > .false. </mpas_do_restart>
 <mpas_print_global_minmax_vel  > .true. </mpas_print_global_minmax_vel>

--- a/bld/namelist_files/namelist_defaults_cam.xml
+++ b/bld/namelist_files/namelist_defaults_cam.xml
@@ -54,6 +54,8 @@
 <ncdata hgrid="mpasa120" nlev="32" analytic_ic="1" phys="cam6" >atm/cam/inic/mpas/mpasa120_L32_topo_coords_c201022.nc</ncdata>
 <ncdata hgrid="mpasa60"  nlev="32" analytic_ic="1" >atm/cam/inic/mpas/mpasa60_L32_notopo_coords_c210518.nc</ncdata>
 <ncdata hgrid="mpasa60"  nlev="32" analytic_ic="1" phys="cam6" >atm/cam/inic/mpas/mpasa60_L32_topo_coords_c210518.nc</ncdata>
+<ncdata hgrid="mpasa30"  nlev="32" analytic_ic="1" >atm/cam/inic/mpas/mpasa30_L32_notopo_coords_c210611.nc</ncdata>
+<ncdata hgrid="mpasa30"  nlev="32" analytic_ic="1" phys="cam6">atm/cam/inic/mpas/mpasa30_L32_topo_coords_c210611.nc</ncdata>
 
 <!-- Files with initial conditions -->
 <ncdata dyn="fv"  hgrid="0.23x0.31" nlev="26" ic_ymd="101"      >atm/cam/inic/fv/cami_0000-01-01_0.23x0.31_L26_c100513.nc</ncdata>
@@ -254,6 +256,7 @@
 <ncdata hgrid="mpasa120" nlev="32" >atm/cam/inic/mpas/cami_01-01-2000_00Z_mpasa120_L32_CFSR_c210426.nc</ncdata>
 <ncdata hgrid="mpasa480" nlev="32" >atm/cam/inic/mpas/cami_01-01-2000_00Z_mpasa480_L32_CFSR_c211013.nc</ncdata>
 <ncdata hgrid="mpasa60"  nlev="32" >atm/cam/inic/mpas/mpasa60.CFSR2000.L32.210518.nc</ncdata>
+<ncdata hgrid="mpasa30"  nlev="32" >atm/cam/inic/mpas/mpasa30_L32_CFSR_c210611.nc</ncdata>
 
 <!-- Topography -->
 <bnd_topo hgrid="256x512" >atm/cam/topo/topo-from-cami_0000-01-01_256x512_L26_c030918.nc</bnd_topo>


### PR DESCRIPTION
This commit adds default values for a number of MPAS releated grids including
defaults for ncdata, dtime, bnd_topo (for 60km), drydep_srf_files, and MPAS
namelist settings, mpas_dt, mpas_len_disp, and mpas_block_decomp_file_prefix.

The ncdata files in this commit are avaliable on glade in
/glade/p/cesmdata/inputdata/ (but currently nowhere else) and do not contain
initial conditions.

This PR will only be a draft PR and will serve as a chance for myself to field questions before my departure from NCAR (November 30th). The PR will be handed off to either @mgduda or @jtruesdal .