### PR TITLE
cam6_3_044: match cesm2_3_beta07 externals and bug fix for SE WACCM-X

### DIFF
--- a/Externals.cfg
+++ b/Externals.cfg
@@ -80,6 +80,7 @@ externals = Externals_CLM.cfg
 required = True
 
 [fms]
+# More recent tag than CESM because MOM is unable to support this tag
 tag = fi_20211011
 protocol = git
 repo_url = https://github.com/ESCOMP/FMS_interface

--- a/Externals.cfg
+++ b/Externals.cfg
@@ -14,14 +14,14 @@ externals = Externals.cfg
 required = False
 
 [cmeps]
-tag = cmeps0.13.40
+tag = cmeps0.13.43
 protocol = git
 repo_url = https://github.com/ESCOMP/CMEPS.git
 local_path = components/cmeps
 required = True
 
 [cdeps]
-tag = cdeps0.12.32
+tag = cdeps0.12.33
 protocol = git
 repo_url = https://github.com/ESCOMP/CDEPS.git
 local_path = components/cdeps
@@ -29,14 +29,14 @@ externals =  Externals_CDEPS.cfg
 required = True
 
 [cpl7]
-tag = cpl7.0.5
+tag = cpl7.0.7
 protocol = git
 repo_url = https://github.com/ESCOMP/CESM_CPL7andDataComps
 local_path = components/cpl7
 required = True
 
 [share]
-tag = share1.0.8
+tag = share1.0.10
 protocol = git
 repo_url = https://github.com/ESCOMP/CESM_share
 local_path = share
@@ -72,7 +72,7 @@ externals = Externals_CISM.cfg
 required = True
 
 [clm]
-tag = ctsm5.1.dev067
+tag = ctsm5.1.dev069
 protocol = git
 repo_url = https://github.com/ESCOMP/CTSM
 local_path = components/clm
@@ -88,7 +88,7 @@ externals = Externals_FMS.cfg
 required = True
 
 [mosart]
-tag = mosart1_0_44
+tag = mosart1_0_45
 protocol = git
 repo_url = https://github.com/ESCOMP/MOSART
 local_path = components/mosart

--- a/bld/build-namelist
+++ b/bld/build-namelist
@@ -990,7 +990,7 @@ if ($aer_model eq 'mam' ) {
     %modal_groups = ( 'accum'  => [qw(so4 pom soa bc dst ncl)],
                       'aitken' => [qw(so4 soa ncl dst)],
                       'coarse' => [qw(dst ncl so4)],
-                      'primary_carbon' => [qw(pom bc)], 
+                      'primary_carbon' => [qw(pom bc)],
                       'coarse_strat' => [qw(so4)] );
 
     @mode_num_src  = qw(A A A A A);
@@ -1853,7 +1853,7 @@ if (($chem =~ /trop_mozart/ or $chem =~ /trop_strat/ or $chem =~ /waccm_tsmlt/) 
                    'num_a1   -> ' => 'mam4_num_a1_emis_file',
                    'num_a2   -> ' => 'num_a2_emis_file',
                    'num_a4   -> ' => 'mam4_num_a4_emis_file',
-                   );								
+                   );
     } elsif ($chem =~ /mam4/) {
         %species = (%species,
                    'SOAG     -> ' => 'soag_emis_file',
@@ -2907,6 +2907,8 @@ if (($phys =~ /cam6/ or $phys =~ /cam_dev/) and $nl->get_value('deep_scheme') =~
 # cam_dev specific namelists
 if ($phys =~ /cam_dev/ and $nl->get_value('deep_scheme') =~ /ZM/) {
     add_default($nl, 'zmconv_parcel_pbl', 'val'=>'.true.');
+} else {
+    add_default($nl, 'zmconv_parcel_pbl', 'val'=>'.false.');
 }
 
 # Radiation scheme
@@ -4645,7 +4647,7 @@ sub check_snapshot_settings {
         if ($use_subcol_microp =~ /$TRUE/io) {
             push (@validList_bc, ("'microp_driver_tend_subcol'"));
         }
-        push (@validList_ac, ("'aero_model_wetdep'", 
+        push (@validList_ac, ("'aero_model_wetdep'",
                               "'radiation_tend'",
                               "'aoa_tracers_timestep_tend'",
                               "'co2_cycle_set_ptend'"));

--- a/cime_config/config_pes.xml
+++ b/cime_config/config_pes.xml
@@ -369,6 +369,41 @@
     </mach>
   </grid>
   <grid name="a%ne120">
+    <mach name="cheyenne">
+      <pes pesize="any" compset="_CAM6|_CAM%DEV">
+	<comment>none</comment>
+	<ntasks>
+	  <ntasks_atm>1800</ntasks_atm>
+	  <ntasks_lnd>1800</ntasks_lnd>
+	  <ntasks_rof>1800</ntasks_rof>
+	  <ntasks_ice>1800</ntasks_ice>
+	  <ntasks_ocn>1800</ntasks_ocn>
+	  <ntasks_glc>1800</ntasks_glc>
+	  <ntasks_wav>1800</ntasks_wav>
+	  <ntasks_cpl>1800</ntasks_cpl>
+	</ntasks>
+	<nthrds>
+	  <nthrds_atm>1</nthrds_atm>
+	  <nthrds_lnd>1</nthrds_lnd>
+	  <nthrds_rof>1</nthrds_rof>
+	  <nthrds_ice>1</nthrds_ice>
+	  <nthrds_ocn>1</nthrds_ocn>
+	  <nthrds_glc>1</nthrds_glc>
+	  <nthrds_wav>1</nthrds_wav>
+	  <nthrds_cpl>1</nthrds_cpl>
+	</nthrds>
+	<rootpe>
+	  <rootpe_atm>0</rootpe_atm>
+	  <rootpe_lnd>0</rootpe_lnd>
+	  <rootpe_rof>0</rootpe_rof>
+	  <rootpe_ice>0</rootpe_ice>
+	  <rootpe_ocn>0</rootpe_ocn>
+	  <rootpe_glc>0</rootpe_glc>
+	  <rootpe_wav>0</rootpe_wav>
+	  <rootpe_cpl>0</rootpe_cpl>
+	</rootpe>
+      </pes>
+    </mach>
     <mach name="any">
       <pes pesize="any" compset="any">
 	<comment>none</comment>

--- a/src/dynamics/se/dyn_grid.F90
+++ b/src/dynamics/se/dyn_grid.F90
@@ -546,10 +546,9 @@ subroutine physgrid_copy_attributes_d(gridname, grid_attribute_names)
       grid_attribute_names(2) = 'ne'
    else
       gridname = 'GLL'
-      allocate(grid_attribute_names(3))
-      grid_attribute_names(1) = 'area_d'
-      grid_attribute_names(2) = 'np'
-      grid_attribute_names(3) = 'ne'
+      allocate(grid_attribute_names(2))
+      grid_attribute_names(1) = 'np'
+      grid_attribute_names(2) = 'ne'
    end if
 
 end subroutine physgrid_copy_attributes_d

--- a/src/utils/cam_grid_support.F90
+++ b/src/utils/cam_grid_support.F90
@@ -2203,7 +2203,7 @@ contains
   subroutine write_cam_grid_attr_1d_int(attr, File)
     use pio,           only: file_desc_t, pio_put_att, pio_noerr
     use pio,           only: pio_inq_dimid, pio_int
-    use cam_pio_utils, only: cam_pio_def_var
+    use cam_pio_utils, only: cam_pio_def_var, cam_pio_closefile
 
     ! Dummy arguments
     class(cam_grid_attribute_1d_int_t), intent(inout) :: attr
@@ -2224,6 +2224,7 @@ contains
         ! NB: It should have been defined as part of a coordinate
         write(errormsg, *) 'write_cam_grid_attr_1d_int: dimension, ',         &
              trim(attr%dimname), ', does not exist'
+        call cam_pio_closefile(File)
         call endrun(errormsg)
       end if
       ! Time to define the variable
@@ -2247,7 +2248,7 @@ contains
   subroutine write_cam_grid_attr_1d_r8(attr, File)
     use pio,           only: file_desc_t, pio_put_att, pio_noerr, pio_double, &
          pio_inq_dimid
-    use cam_pio_utils, only: cam_pio_def_var
+    use cam_pio_utils, only: cam_pio_def_var, cam_pio_closefile
 
     ! Dummy arguments
     class(cam_grid_attribute_1d_r8_t), intent(inout) :: attr
@@ -2268,6 +2269,7 @@ contains
         ! NB: It should have been defined as part of a coordinate
         write(errormsg, *) 'write_cam_grid_attr_1d_r8: dimension, ',          &
              trim(attr%dimname), ', does not exist'
+        call cam_pio_closefile(File)
         call endrun(errormsg)
       end if
       ! Time to define the variable


### PR DESCRIPTION
Update externals to match those in cesm2_3_beta07  - The only exception is FMS which is newer than the version in CESM

bug fix for SE WACCM-X bug

From @gold2718 regarding WACCM-X bug:

- In the old days (pre physgrid),  the SE dycore always used the 'ncol' dimension.
- With physgrid, data on the GLL grid used 'ncol_d' and data on the physgrid used 'ncol'.
- When the switch was made to always read initial data on the GLL grid, that broke the logic in dyn_grid so Brian put in a fix (in late 2020).
- However, that fix prevented reading initial data on a physgrid run with the 'wrong' dimension name for the GLL data.
- cam6_3_043 included a fix for that problem, however, due to the change made in 2020, that caused the SE dycore to always write out new initial data files using the same dimension name as was used on input. For initial data runs not using physgrid (GLL-only), that meant 'ncol'.
- However, WACCM-X needs to also write data to the initial data file and always needs to use 'ncol' (as all physics code does).
- So, on a physgrid WACCM-X run that uses a GLL run input data file, the dycore and WACCM-X were both trying to write using 'ncol' but with two different sizes.
- The fix (we hope) is to have the dycore always write initial data files using 'ncol_d'.

More info from @gold2718:
A CAM history file has grid information (latitude, longitude, area, other grid parameters) for each grid represented in the set of 2D or 3D output variables.
For most dycores, this is the same for variables written from the dynamics or written from the physics.
However, for the SE dycore, there are potentially two grids, the native GLL grid and the finite volume physgrid.
We used to try and share grid attributes if they were the same (e.g., ne) and one of those is area when not using physgrid. In these cases, the dycore used 'ncol' and 'area' and the physics just used that as well.
However, now that we are always writing out the dynamics variables with ncol_d and area_d, we cannot share that with physics which always uses 'ncol'. 

So, the bug was, for the case of non-physgrid (e.g., ne5_ne5_mg37 or any refined mesh run), we were trying to write out area_d as an attribute but 'ncol_d' was not defined if there were no dynamics variables on the file (very common).

My fix (see PR) is to always have the physics write out 'area' with dimension 'ncol', even if the dynamics is also writing variables with the same grid. This will result in duplicated coordinates and area attributes but it is the best I can think of right now.



Closes #498
Closes #499 
Closes #500 