### PR TITLE
part of cam6_3_060: Updates to fire emissions namelist options

### DIFF
--- a/bld/namelist_files/use_cases/hist_trop_strat_vbsfire_cam6.xml
+++ b/bld/namelist_files/use_cases/hist_trop_strat_vbsfire_cam6.xml
@@ -27,7 +27,9 @@
       'bc_a4 = bc_a4',
       'pom_a4 = pom_a4',
       'num_a4 = num_a4_bc + num_a4_pom',
-      'SO2 = SO2',
+      'so4_a1 = so4_a1',
+      'num_a1 = num_a1_so4',
+      'SO2 = SO2x0.975',
       'NO = NO',
       'CO = CO',
       'BIGALK = BIGALK',
@@ -59,7 +61,7 @@
       'IVOC = 0.033*C2H4 + 0.035*C2H6 + 0.049*C3H6 + 0.052*C3H8 + 0.066*BIGENE +  0.068*BIGALK + 0.068*CH3COCH3 + 0.085*MEK + 0.052*CH3CHO + 0.035*CH2O + 0.108*TOLUENE + 0.092*BENZENE + 0.125*XYLENE'
 </fire_emis_specifier>
 <fire_emis_elevated>.false.</fire_emis_elevated>
-<fire_emis_factors_file>lnd/clm2/firedata/fire_emission_factors_78PFTs_c20210803.nc</fire_emis_factors_file>
+<fire_emis_factors_file>lnd/clm2/firedata/fire_emission_factors_78PFTs_c20220111.nc</fire_emis_factors_file>
 
 <ext_frc_type>INTERP_MISSING_MONTHS</ext_frc_type>
 

--- a/cime_config/config_compsets.xml
+++ b/cime_config/config_compsets.xml
@@ -57,7 +57,7 @@
 
   <compset>
     <alias>F2000mam5</alias>
-    <lname>2000_CAM60%MAM5_CLM50%SP_CICE%PRES_DOCN%DOM_MOSART_CISM2%NOEVOLVE_SWAV</lname>
+    <lname>2000_CAM60%MAM5_CLM50%SP_CICE%PRES_DOCN%DOM_MOSART_SGLC_SWAV</lname>
   </compset>
 
   <compset>
@@ -433,7 +433,7 @@
   </compset>
   <compset>
     <alias>FW2000mam5</alias>
-    <lname>2000_CAM60%WCTS%MAM5_CLM50%SP_CICE%PRES_DOCN%DOM_MOSART_CISM2%NOEVOLVE_SWAV</lname>
+    <lname>2000_CAM60%WCTS%MAM5_CLM50%SP_CICE%PRES_DOCN%DOM_MOSART_SGLC_SWAV</lname>
   </compset>
 
   <compset>


### PR DESCRIPTION
Updates to fire emissions factors (closes #503)

Replace of %CISM with %SGCL in the MAM5 compsets (closes #340)
