### PR TITLE
part of cam6_3_071: Corrections to WACCMX coordinate maps for oplus and geomag history grids

### DIFF
--- a/cime_config/config_pes.xml
+++ b/cime_config/config_pes.xml
@@ -1026,14 +1026,14 @@
       <pes pesize="any" compset="_CAM\d0%WX">
 	<comment>none</comment>
 	<ntasks>
-	  <ntasks_atm>720</ntasks_atm>
-	  <ntasks_lnd>720</ntasks_lnd>
-	  <ntasks_rof>720</ntasks_rof>
-	  <ntasks_ice>720</ntasks_ice>
-	  <ntasks_ocn>720</ntasks_ocn>
-	  <ntasks_glc>720</ntasks_glc>
-	  <ntasks_wav>720</ntasks_wav>
-	  <ntasks_cpl>720</ntasks_cpl>
+	  <ntasks_atm>864</ntasks_atm>
+	  <ntasks_lnd>864</ntasks_lnd>
+	  <ntasks_rof>864</ntasks_rof>
+	  <ntasks_ice>864</ntasks_ice>
+	  <ntasks_ocn>864</ntasks_ocn>
+	  <ntasks_glc>864</ntasks_glc>
+	  <ntasks_wav>864</ntasks_wav>
+	  <ntasks_cpl>864</ntasks_cpl>
 	</ntasks>
 	<nthrds>
 	  <nthrds_atm>1</nthrds_atm>

--- a/cime_config/testdefs/testlist_cam.xml
+++ b/cime_config/testdefs/testlist_cam.xml
@@ -604,7 +604,7 @@
   </test>
   <test compset="QPX2000" grid="ne5pg3_ne5pg3_mg37" name="SMS_D_Ln3_Vnuopc" testmods="cam/outfrq3s">
     <machines>
-      <machine name="cheyenne" compiler="intel" category="aux_cam"/>
+      <machine name="izumi" compiler="nag" category="aux_cam"/>
       <machine name="izumi" compiler="nag" category="waccmx"/>
     </machines>
     <options>
@@ -2156,7 +2156,7 @@
       <option name="wallclock">00:50:00</option>
     </options>
   </test>
-  <test compset="FXHIST" grid="f09_f09_mg17" name="SMS_D_Ln9_Vnuopc"   testmods="cam/waccmx_weimer">
+  <test compset="FXHIST" grid="f09_f09_mg17" name="SMS_D_Ln9_Vnuopc_P384x3"   testmods="cam/waccmx_weimer">
     <machines>
       <machine name="cheyenne" compiler="intel" category="waccmx"/>
     </machines>

--- a/cime_config/testdefs/testlist_cam.xml
+++ b/cime_config/testdefs/testlist_cam.xml
@@ -2304,7 +2304,7 @@
   <test compset="FW4madSD" grid="f19_f19_mg17" name="SMS_P48x1_D_Ln9_Vnuopc" testmods="cam/outfrq9s" supported="false">
     <machines>
       <machine name="izumi" compiler="nag" category="waccm"/>
-      <machine name="izumi" compiler="nag" category="aux_cam"/>
+      <machine name="izumi" compiler="gnu" category="aux_cam"/>
     </machines>
     <options>
       <option name="wallclock">00:40:00</option>

--- a/cime_config/testdefs/testmods_dirs/cam/waccmx_weimer/shell_commands
+++ b/cime_config/testdefs/testmods_dirs/cam/waccmx_weimer/shell_commands
@@ -1,1 +1,2 @@
 ./xmlchange RUN_STARTDATE=2005-12-31
+./xmlchange ROF_NCPL=\$ATM_NCPL

--- a/src/ionosphere/waccmx/edyn_init.F90
+++ b/src/ionosphere/waccmx/edyn_init.F90
@@ -181,14 +181,22 @@ contains
       end do
 
       allocate(coord_map(mlat1 - mlat0 + 1))
-      coord_map = (/ (i, i = mlat0, mlat1) /)
+      if (mlon0==1) then
+         coord_map = (/ (i, i = mlat0, mlat1) /)
+      else
+         coord_map = 0
+      end if
       lat_coord => horiz_coord_create('mlat', '', nmlat, 'latitude',           &
            'degrees_north', mlat0, mlat1, gmlat(mlat0:mlat1),                  &
            map=coord_map)
       nullify(coord_map)
 
       allocate(coord_map(omlon1 - mlon0 + 1))
-      coord_map = (/ (i, i = mlon0, omlon1) /)
+      if (mlat0==1) then
+         coord_map = (/ (i, i = mlon0, omlon1) /)
+      else
+         coord_map = 0
+      end if
       lon_coord => horiz_coord_create('mlon', '', nmlon, 'longitude',          &
            'degrees_east', mlon0, omlon1, gmlon(mlon0:omlon1),                 &
            map=coord_map)
@@ -214,14 +222,23 @@ contains
       end do
 
       allocate(coord_map(lat1 - lat0 + 1))
-      coord_map = (/ (i, i = lat0, lat1) /)
+      if (lon0==1) then
+         coord_map = (/ (i, i = lat0, lat1) /)
+      else
+         coord_map = 0
+      end if
       lat_coord => horiz_coord_create('glat', '', nlat, 'latitude',           &
            'degrees_north', lat0, lat1, glat(lat0:lat1),                  &
            map=coord_map)
       nullify(coord_map)
 
       allocate(coord_map(lon1 - lon0 + 1))
-      coord_map = (/ (i, i = lon0, lon1) /)
+      if (lat0==1) then
+         coord_map = (/ (i, i = lon0, lon1) /)
+      else
+         coord_map = 0
+      end if
+
       lon_coord => horiz_coord_create('glon', '', nlon, 'longitude',          &
            'degrees_east', lon0, lon1, glon(lon0:lon1),                 &
            map=coord_map)


### PR DESCRIPTION
Fixes issue #624 

The follow test passes with these changes:
 SMS_D_Ln3_Vnuopc.ne5pg3_ne5pg3_mg37.QPX2000.izumi_nag.cam-outfrq3s

This PR moves this WACCMX test back to izumi_nag
