### PR TITLE
Bug fixes for interpolate_output routines

### DIFF
--- a/src/control/cam_history.F90
+++ b/src/control/cam_history.F90
@@ -4261,7 +4261,6 @@ end subroutine print_active_fldlst
 
       !! Collect some field properties
       call AvgflagToString(tape(t)%hlist(f)%avgflag, tape(t)%hlist(f)%time_op)
-
       if ((tape(t)%hlist(f)%hwrt_prec == 8) .or. restart) then
         ncreal = pio_double
       else
@@ -4719,6 +4718,7 @@ end subroutine print_active_fldlst
     integer                          :: num_patches
     integer                          :: mdimsize   ! Total # on-node elements
     integer                          :: bdim3, edim3
+    integer                          :: ncreal     ! Real output kind (double or single)
     logical                          :: interpolate
     logical                          :: patch_output
     type(history_patch_t), pointer   :: patchptr
@@ -4773,6 +4773,14 @@ end subroutine print_active_fldlst
       else
         ! We are doing output via the field's grid
         if (interpolate) then
+
+          !Determine what the output field kind should be:
+          if (tape(t)%hlist(f)%hwrt_prec == 8) then
+            ncreal = pio_double
+          else
+            ncreal = pio_real
+          end if
+
           mdimsize = tape(t)%hlist(f)%field%enddim2 - tape(t)%hlist(f)%field%begdim2 + 1
           if (mdimsize == 0) then
             mdimsize = tape(t)%hlist(f)%field%numlev
@@ -4784,7 +4792,7 @@ end subroutine print_active_fldlst
             call pio_setframe(tape(t)%File, compid, int(max(1,nfils(t)),kind=PIO_OFFSET_KIND))
             call write_interpolated(tape(t)%File, varid, compid,              &
                  tape(t)%hlist(f)%hbuf, tape(t)%hlist(compind)%hbuf,          &
-                 mdimsize, PIO_DOUBLE, fdecomp)
+                 mdimsize, ncreal, fdecomp)
           else if (tape(t)%hlist(f)%field%zonal_complement > 0) then
             ! We don't want to double write so do nothing here
 !            compind = tape(t)%hlist(f)%field%zonal_complement
@@ -4795,7 +4803,7 @@ end subroutine print_active_fldlst
           else
             ! Scalar field
             call write_interpolated(tape(t)%File, varid,                      &
-                 tape(t)%hlist(f)%hbuf, mdimsize, PIO_DOUBLE, fdecomp)
+                 tape(t)%hlist(f)%hbuf, mdimsize, ncreal, fdecomp)
           end if
         else if (nadims == 2) then
           ! Special case for 2D field (no levels) due to hbuf structure

--- a/src/dynamics/se/dycore/interpolate_mod.F90
+++ b/src/dynamics/se/dycore/interpolate_mod.F90
@@ -15,6 +15,7 @@ module interpolate_mod
   use mesh_mod,               only: MeshUseMeshFile
   use control_mod,            only: cubed_sphere_map
   use cam_logfile,            only: iulog
+  use string_utils,           only: int2str
 
   implicit none
   private
@@ -608,7 +609,7 @@ contains
 
     p = (xp - xoy(ii))/(xoy(ii+1) - xoy(ii))
     q = (yp - xoy(jj))/(xoy(jj+1) - xoy(jj))
-    
+
     fxy = (1.0_r8 - p)*(1.0_r8 - q)* y4(1) + p*(1.0_r8 - q) * y4(2)   &
          + p*q* y4(3) + (1.0_r8 - p)*q * y4(4)
   end function interpol_bilinear
@@ -627,31 +628,31 @@ contains
     use fvm_control_volume_mod, only : fvm_struct
     !  use fvm_reconstruction_mod, only: reconstruction_gradient, recons_val_cart
     use edgetype_mod, only : edgedescriptor_t
-    
+
     type (interpdata_t), intent(in)     :: interpdata
     real (kind=r8), intent(inout)   :: f(1-nhc:nc+nhc,1-nhc:nc+nhc)
     type (fvm_struct), intent(in)       :: fvm
     type (cartesian2d_t), intent(in)    :: corners(:)
     type (edgedescriptor_t),intent(in)  :: desc
     logical, intent(in) :: lmono
-    
+
     real (kind=r8)             :: flatlon(:)
     ! local variables
     real (kind=r8)             :: xp,yp, tmpval
     real (kind=r8)             :: tmpaxp,tmpaxm, tmpayp, tmpaym
     integer                           :: i, ix, jy, starti,endi,tmpi
     real (kind=r8), dimension(1-nhe:nc+nhe,1-nhe:nc+nhe,6)      :: recons
-    
+
     real (kind=r8), dimension(nc+1) :: x, y
-    
+
     !  call reconstruction_gradient(f, fvm,recons,6,lmono)
     !  recons=0.0 ! PCoM
-    
+
     x(1:nc) = fvm%vtx_cart(1,1,1:nc,1   )
     y(1:nc) = fvm%vtx_cart(1,2,1   ,1:nc)
     x(nc+1) = fvm%vtx_cart(2,1,nc,1     )
     y(nc+1) = fvm%vtx_cart(3,2,1   ,nc  )
-    
+
     tmpaxp=(corners(1)%x+corners(2)%x)/2
     tmpaxm=(corners(2)%x-corners(1)%x)/2
     tmpayp=(corners(1)%y+corners(4)%y)/2
@@ -660,7 +661,7 @@ contains
       ! caculation phys grid coordinate of xp point, note the interp_xy are on the reference [-1,1]x[-1,1]
       xp=tan(tmpaxp+interpdata%interp_xy(i)%x*tmpaxm)
       yp=tan(tmpayp+interpdata%interp_xy(i)%y*tmpaym)
-      
+
       ! Search index along "x"  (bisection method)
       starti = 1
       endi = nc+1
@@ -674,7 +675,7 @@ contains
         endif
       enddo
       ix = starti
-      
+
       ! Search index along "y"
       starti = 1
       endi = nc+1
@@ -688,7 +689,7 @@ contains
         endif
       enddo
       jy = starti
-      
+
       !    call recons_val_cart(f(ix,jy), xp,yp, fvm%spherecentroid(ix,jy,:), fvm%recons_metrics(ix,jy,:), &
       !         recons(ix,jy,:), tmpval)
       tmpval=f(ix,jy)
@@ -1489,29 +1490,18 @@ end subroutine interpolate_ce
       call endrun('interpolate_scalar2d: resolution not supported')
     endif
 
-       ! Choice for Native (high-order) or Bilinear interpolations
-    if(present(fillvalue)) then
-       if (itype == 0) then
-          do i=1,interpdata%n_interp
-             fld(i)=interpolate_2d(interpdata%interp_xy(i),fld_cube,interp,nsize,fillvalue)
-          end do
-       elseif (itype == 1) then
-          do i=1,interpdata%n_interp
-             fld(i)=interpol_bilinear(interpdata%interp_xy(i),fld_cube,xoy,imin,imax,fillvalue)
-          end do
-       end if
+    ! Choice for Native (high-order) or Bilinear interpolations
+    if (itype == 0) then
+      do i=1,interpdata%n_interp
+        fld(i)=interpolate_2d(interpdata%interp_xy(i),fld_cube,interp,nsize,fillvalue)
+      end do
+    else if (itype == 1) then
+      do i=1,interpdata%n_interp
+        fld(i)=interpol_bilinear(interpdata%interp_xy(i),fld_cube,xoy,imin,imax,fillvalue)
+      end do
     else
-       if (itype == 0) then
-          do i=1,interpdata%n_interp
-             fld(i)=interpolate_2d(interpdata%interp_xy(i),fld_cube,interp,nsize)
-          end do
-       elseif (itype == 1) then
-          do i=1,interpdata%n_interp
-             fld(i)=interpol_bilinear(interpdata%interp_xy(i),fld_cube,xoy,imin,imax)
-          end do
-       end if
-    endif
-
+      call endrun("interpolate_scalar2d: wrong interpolation type: "//int2str(itype))
+    end if
 
   end subroutine interpolate_scalar2d
   subroutine interpolate_scalar3d(interpdata,fld_cube,nsize,nhalo,nlev,fld, fillvalue)
@@ -1560,37 +1550,20 @@ end subroutine interpolate_ce
     endif
 
     ! Choice for Native (high-order) or Bilinear interpolations
-    if(present(fillvalue)) then
-       if (itype == 0) then
-          do k=1,nlev
-             do i=1,interpdata%n_interp
-                fld(i,k)=interpolate_2d(interpdata%interp_xy(i),fld_cube(:,:,k),interp,nsize,fillvalue)
-             end do
-          end do
-       elseif (itype == 1) then
-          do k=1,nlev
-             do i=1,interpdata%n_interp
-                fld(i,k)=interpol_bilinear(interpdata%interp_xy(i),fld_cube(:,:,k),xoy,imin,imax,fillvalue)
-             end do
-          end do
-       endif
+    if (itype == 0) then
+      do k=1,nlev
+        do i=1,interpdata%n_interp
+          fld(i,k)=interpolate_2d(interpdata%interp_xy(i),fld_cube(:,:,k),interp,nsize,fillvalue)
+        end do
+      end do
+    elseif (itype == 1) then
+      do k=1,nlev
+        do i=1,interpdata%n_interp
+          fld(i,k)=interpol_bilinear(interpdata%interp_xy(i),fld_cube(:,:,k),xoy,imin,imax,fillvalue)
+        end do
+      end do
     else
-       if (itype == 0) then
-          do k=1,nlev
-             do i=1,interpdata%n_interp
-                fld(i,k)=interpolate_2d(interpdata%interp_xy(i),fld_cube(:,:,k),interp,nsize)
-             end do
-          end do
-       elseif (itype == 1) then
-          do k=1,nlev
-             do i=1,interpdata%n_interp
-                fld(i,k)=interpol_bilinear(interpdata%interp_xy(i),fld_cube(:,:,k),xoy,imin,imax)
-             end do
-          end do
-       else
-          write(iulog,*) itype
-          call endrun("wrong interpolation type")
-       endif
+      call endrun("interpolate_scalar3d: wrong interpolation type: "//int2str(itype))
     endif
   end subroutine interpolate_scalar3d
 
@@ -1653,7 +1626,7 @@ end subroutine interpolate_ce
     if (npts==np) then
        interp => interp_p
     else if (npts==np) then
-       call endrun('Error in interpolate_vector(): input must be on velocity grid')
+       call endrun('interpolate_vector2d: Error in interpolate_vector(): input must be on velocity grid')
     endif
 
 
@@ -1670,8 +1643,7 @@ end subroutine interpolate_ce
           fld(i,2)=interpol_bilinear(interpdata%interp_xy(i),fld_contra(:,:,2),interp%glp(:),1,np)
        end do
     else
-       write(iulog,*) itype
-       call endrun("wrong interpolation type")
+       call endrun("interpolate_vector2d: wrong interpolation type: "//int2str(itype))
     endif
     do i=1,interpdata%n_interp
        ! convert fld from contra->latlon
@@ -1744,7 +1716,7 @@ end subroutine interpolate_ce
     if (npts==np) then
        interp => interp_p
     else if (npts==np) then
-       call endrun('Error in interpolate_vector(): input must be on velocity grid')
+       call endrun('interpolate_vector3d: Error in interpolate_vector(): input must be on velocity grid')
     endif
 
 
@@ -1765,7 +1737,7 @@ end subroutine interpolate_ce
           end do
        end do
     else
-       call endrun("wrong interpolation type")
+       call endrun("interpolate_vector3d: wrong interpolation type: "//int2str(itype))
     endif
 
 

--- a/src/dynamics/se/interp_mod.F90
+++ b/src/dynamics/se/interp_mod.F90
@@ -1,5 +1,5 @@
 module interp_mod
-  use shr_kind_mod,        only: r8 => shr_kind_r8
+  use shr_kind_mod,        only: r8 => shr_kind_r8, r4 => shr_kind_r4
   use dimensions_mod,      only: nelemd, np, ne
   use interpolate_mod,     only: interpdata_t
   use interpolate_mod,     only: interp_lat => lat, interp_lon => lon
@@ -191,6 +191,7 @@ CONTAINS
     use pio,              only: iosystem_desc_t
     use pio,              only: pio_initdecomp, pio_freedecomp
     use pio,              only: io_desc_t, pio_write_darray
+    use pio,              only: pio_real
     use interpolate_mod,  only: interpolate_scalar
     use cam_instance,     only: atm_id
     use spmd_dyn,         only: local_dp_map
@@ -382,7 +383,12 @@ CONTAINS
     else
        call pio_initdecomp(pio_subsystem, data_type, (/nlon,nlat,numlev/), idof, iodesc)
     end if
-    call pio_write_darray(File, varid, iodesc, fldout, ierr)
+
+    if(data_type == pio_real) then
+      call pio_write_darray(File, varid, iodesc, real(fldout, r4), ierr)
+    else
+      call pio_write_darray(File, varid, iodesc, fldout, ierr)
+    end if
 
     deallocate(dest)
 
@@ -397,6 +403,7 @@ CONTAINS
     use pio,              only: iosystem_desc_t
     use pio,              only: pio_initdecomp, pio_freedecomp
     use pio,              only: io_desc_t, pio_write_darray
+    use pio,              only: pio_real
     use cam_instance,     only: atm_id
     use interpolate_mod,  only: interpolate_scalar, vec_latlon_to_contra,get_interp_parameter
     use spmd_dyn,         only: local_dp_map
@@ -629,8 +636,13 @@ CONTAINS
        call pio_initdecomp(pio_subsystem, data_type, (/nlon,nlat,numlev/), idof, iodesc)
     end if
 
-    call pio_write_darray(File, varidu, iodesc, fldout(:,:,1), ierr)
-    call pio_write_darray(File, varidv, iodesc, fldout(:,:,2), ierr)
+    if(data_type == pio_real) then
+      call pio_write_darray(File, varidu, iodesc, real(fldout(:,:,1), r4), ierr)
+      call pio_write_darray(File, varidv, iodesc, real(fldout(:,:,2), r4), ierr)
+    else
+      call pio_write_darray(File, varidu, iodesc, fldout(:,:,1), ierr)
+      call pio_write_darray(File, varidv, iodesc, fldout(:,:,2), ierr)
+    end if
 
 
     deallocate(fldout)

--- a/src/dynamics/se/interp_mod.F90
+++ b/src/dynamics/se/interp_mod.F90
@@ -303,8 +303,6 @@ CONTAINS
         do ie = 1, nelemd
           fld_tmp(1:nsize,1:nsize,:,1,ie) = RESHAPE(fld_dyn(:,:,ie),(/nsize,nsize,numlev/))
         end do
-        !check if fill values are present:
-        usefillvalues = any(fld_tmp == fillvalue)
       else
         call initEdgeBuffer(par, edgebuf, elem, numlev,nthreads=1)
 
@@ -344,6 +342,9 @@ CONTAINS
       call get_loop_ranges(hybrid,ibeg=nets,iend=nete)
       call fill_halo_and_extend_panel(elem(nets:nete),fvm(nets:nete),&
            fld_tmp(:,:,:,:,nets:nete),hybrid,nets,nete,nsize,nhcc,nhalo,numlev,1,.true.,.true.)
+
+      !check if fill values are present:
+      usefillvalues = any(fld_tmp(:,:,:,:,nets:nete) == fillvalue)
     end if
     !
     ! WARNING - 1:nelemd and nets:nete
@@ -518,8 +519,6 @@ CONTAINS
         do ie = 1, nelemd
           fld_tmp(1:nsize,1:nsize,:,:,ie) = RESHAPE(fld_dyn(:,:,:,ie),(/nsize,nsize,2,numlev/))
         end do
-        !check if fill values are present:
-        usefillvalues = any(fld_tmp==fillvalue)
       else
         call initEdgeBuffer(par, edgebuf, elem, 2*numlev,nthreads=1)
 
@@ -579,6 +578,9 @@ CONTAINS
       end do
       call fill_halo_and_extend_panel(elem(nets:nete),fvm(nets:nete),&
            fld_tmp(:,:,:,:,nets:nete),hybrid,nets,nete,nsize,nhcc,nhalo,2,numlev,.false.,.true.)
+
+      !check if fill values are present:
+      usefillvalues = any(fld_tmp(:,:,:,:,nets:nete) == fillvalue)
     else
       do ie=1,nelemd
         call vec_latlon_to_contra(elem(ie),nsize,nhcc,numlev,fld_tmp(:,:,:,:,ie))

--- a/src/dynamics/se/interp_mod.F90
+++ b/src/dynamics/se/interp_mod.F90
@@ -303,6 +303,8 @@ CONTAINS
         do ie = 1, nelemd
           fld_tmp(1:nsize,1:nsize,:,1,ie) = RESHAPE(fld_dyn(:,:,ie),(/nsize,nsize,numlev/))
         end do
+        !check if fill values are present:
+        usefillvalues = any(fld_tmp == fillvalue)
       else
         call initEdgeBuffer(par, edgebuf, elem, numlev,nthreads=1)
 
@@ -318,6 +320,7 @@ CONTAINS
           call edgeVunpack(edgebuf, fld_tmp(:,:,1:numlev,1,ie), numlev, 0, ie)
         end do
         call freeEdgeBuffer(edgebuf)
+        !check if fill values are present:
         usefillvalues = any(fld_tmp == fillvalue)
       end if
       deallocate(fld_dyn)
@@ -328,6 +331,8 @@ CONTAINS
       do ie = 1, nelemd
         fld_tmp(1:nsize,1:nsize,1:numlev,1,ie) = RESHAPE(fld(1:nsize*nsize,1:numlev,ie),(/nsize,nsize,numlev/))
       end do
+      !check if fillvalues are present:
+      usefillvalues = any(fld_tmp == fillvalue)
     end if
     !
     ! code for non-GLL grids: need to fill halo and interpolate (if on panel edge/corner) for bilinear interpolation
@@ -513,6 +518,8 @@ CONTAINS
         do ie = 1, nelemd
           fld_tmp(1:nsize,1:nsize,:,:,ie) = RESHAPE(fld_dyn(:,:,:,ie),(/nsize,nsize,2,numlev/))
         end do
+        !check if fill values are present:
+        usefillvalues = any(fld_tmp==fillvalue)
       else
         call initEdgeBuffer(par, edgebuf, elem, 2*numlev,nthreads=1)
 
@@ -529,6 +536,7 @@ CONTAINS
           call edgeVunpack(edgebuf, fld_tmp(:,:,:,:,ie), 2*numlev, 0, ie)
         end do
         call freeEdgeBuffer(edgebuf)
+        !check if fill values are present:
         usefillvalues = any(fld_tmp==fillvalue)
       end if
       deallocate(fld_dyn)
@@ -536,6 +544,7 @@ CONTAINS
       !
       ! not physics decomposition
       !
+      !check if fill values are present:
       usefillvalues = (any(fldu(1:nsize:1,nsize,:)==fillvalue) .or. any(fldv(1:nsize:1,nsize,:)==fillvalue))
       do ie = 1, nelemd
         fld_tmp(1:nsize,1:nsize,1,1:numlev,ie) = RESHAPE(fldu(1:nsize*nsize,1:numlev,ie),(/nsize,nsize,numlev/))


### PR DESCRIPTION
This Pull Request contains a few bug fixes for the `interpolate_output` option for the SE dycore.  Specifically, it allows for single-precision (e.g. `ndens = 2`) interpolated output, and allows for variables with missing values (e.g. `AODVIS`) to be output correctly in the standard monthly average (`h0`) files, at least for certain SE-CSLAM grids. 

Please note however that variables with missing values may still have "bad" values at the missing value margins when either using very high resolution grids or outputting at high frequencies (e.g. every hour or every time step).  To fix this issue completely will potentially require a much larger set of code modifications, which might be beneficial to do in conjunction with future developments (e.g. the creation of a dycore-agnostic interpolation routine), hence why I am creating this smaller PR now.

Fixes #644
Partially addresses #564 

Was reviewed in #659 