### PR TITLE
cam6_3_078: Making nextsw_cday a double type to fix cam_dev restart bug.

### DIFF
--- a/src/physics/camrt/radiation.F90
+++ b/src/physics/camrt/radiation.F90
@@ -582,7 +582,7 @@ subroutine radiation_define_restart(file)
 
    call pio_seterrorhandling(File, PIO_BCAST_ERROR)
 
-   ierr = pio_def_var(File, 'nextsw_cday', pio_int, nextsw_cday_desc)
+   ierr = pio_def_var(File, 'nextsw_cday', pio_double, nextsw_cday_desc)
    ierr = pio_put_att(File, nextsw_cday_desc, 'long_name', 'future radiation calday for surface models')
 
    if (radiation_do('aeres')) then

--- a/src/physics/rrtmg/radiation.F90
+++ b/src/physics/rrtmg/radiation.F90
@@ -33,7 +33,7 @@ use cam_history,         only: addfld, add_default, horiz_only, outfld, hist_fld
 use cam_history_support, only: fillvalue
 
 use pio,                 only: file_desc_t, var_desc_t,               &
-                               pio_int, pio_noerr,                    &
+                               pio_int, pio_double, pio_noerr,        &
                                pio_seterrorhandling, pio_bcast_error, &
                                pio_inq_varid, pio_def_var,            &
                                pio_put_var, pio_get_var, pio_put_att
@@ -647,7 +647,7 @@ subroutine radiation_define_restart(file)
 
    call pio_seterrorhandling(File, PIO_BCAST_ERROR)
 
-   ierr = pio_def_var(File, 'nextsw_cday', pio_int, nextsw_cday_desc)
+   ierr = pio_def_var(File, 'nextsw_cday', pio_double, nextsw_cday_desc)
    ierr = pio_put_att(File, nextsw_cday_desc, 'long_name', 'future radiation calday for surface models')
    if (docosp) then
       ierr = pio_def_var(File, 'cosp_cnt_init', pio_int, cospcnt_desc)


### PR DESCRIPTION
Closes #655 

This fixes a bug where restarts were changing answers on some timesteps.

Compared with previous tags:
BFB for regular runs
Answer changing for restart runs when radiation was run on the restart time step.

Note this was reviewed in #659 when was going to be combined with a couple of other PRs