### PR TITLE
fixes for dae test

### DIFF
--- a/src/cpl/nuopc/atm_comp_nuopc.F90
+++ b/src/cpl/nuopc/atm_comp_nuopc.F90
@@ -364,7 +364,6 @@ contains
     real(r8)                :: obliqr
     real(r8)                :: lambm0
     real(r8)                :: mvelpp
-    logical                 :: dart_mode_in
     !character(len=cl)      :: atm_resume_all_inst(num_inst_atm) ! atm resume file
     integer                 :: lbnum
     character(CS)           :: inst_name
@@ -529,14 +528,6 @@ contains
     ! TODO: must obtain model_doi_url from gcomp - for now hardwire to 'not_set'
     model_doi_url = 'not_set'
 
-    ! TODO: obtain dart_mode as a attribute variable
-    ! DART always starts up as an initial run.
-    if (dart_mode) then
-       initial_run = .true.
-       restart_run = .false.
-       branch_run  = .false.
-    end if
-
     ! Initialize CAM, allocate cam_in and cam_out and determine
     ! atm decomposition (needed to initialize gsmap)
     ! for an initial run, cam_in and cam_out are allocated in cam_init
@@ -556,6 +547,16 @@ contains
        branch_run = .true.
     else
        call shr_sys_abort( subname//' ERROR: unknown start_type' )
+    end if
+
+    ! DART always starts up as an initial run.
+    call NUOPC_CompAttributeGet(gcomp, name='data_assimilation_atm', value=cvalue, rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
+    read(cvalue,*) dart_mode
+    if (dart_mode) then
+       initial_run = .true.
+       restart_run = .false.
+       branch_run  = .false.
     end if
 
     ! Get properties from clock
@@ -595,7 +596,6 @@ contains
     end if
 
     ! Initialize module orbital values and update orbital
-
     call cam_orbital_init(gcomp, iulog, masterproc, rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
     call cam_orbital_update(clock, iulog, masterproc, eccen, obliqr, lambm0, mvelpp, rc)

--- a/src/cpl/nuopc/atm_comp_nuopc.F90
+++ b/src/cpl/nuopc/atm_comp_nuopc.F90
@@ -370,7 +370,7 @@ contains
     integer                 :: inst_index
     character(CS)           :: inst_suffix
     integer                 :: lmpicom
-    logical                 :: isPresent
+    logical                 :: isPresent, isSet
     character(len=512)      :: diro
     character(len=512)      :: logfile
     integer                 :: compid                            ! component id
@@ -550,9 +550,12 @@ contains
     end if
 
     ! DART always starts up as an initial run.
-    call NUOPC_CompAttributeGet(gcomp, name='data_assimilation_atm', value=cvalue, rc=rc)
+    call NUOPC_CompAttributeGet(gcomp, name='data_assimilation_atm', value=cvalue, &
+         isPresent=isPresent, isSet=isSet, rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
-    read(cvalue,*) dart_mode
+    if (isPresent and isSet) then
+       read(cvalue,*) dart_mode
+    end if
     if (dart_mode) then
        initial_run = .true.
        restart_run = .false.

--- a/src/cpl/nuopc/atm_comp_nuopc.F90
+++ b/src/cpl/nuopc/atm_comp_nuopc.F90
@@ -553,7 +553,7 @@ contains
     call NUOPC_CompAttributeGet(gcomp, name='data_assimilation_atm', value=cvalue, &
          isPresent=isPresent, isSet=isSet, rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
-    if (isPresent and isSet) then
+    if (isPresent .and. isSet) then
        read(cvalue,*) dart_mode
     end if
     if (dart_mode) then


### PR DESCRIPTION
This fixes #670 - but also needs an accompanying CMEPS PR https://github.com/ESCOMP/CMEPS/pull/314.
To have the DAE test pass, the CMEPS must point to cmeps0.13.74 or later. However, this PR can be merged without a  CMEPS PR as long as the DAE test is not expected to pass.