### PR TITLE
part of cam6_3_084 : Update maximum CAM history field length to 32 (up from 24).

### DIFF
--- a/src/control/cam_history_support.F90
+++ b/src/control/cam_history_support.F90
@@ -25,7 +25,7 @@ module cam_history_support
 
   integer, parameter, public :: max_string_len = shr_kind_cxx
   integer, parameter, public :: max_chars = shr_kind_cl         ! max chars for char variables
-  integer, parameter, public :: fieldname_len = 24   ! max chars for field name
+  integer, parameter, public :: fieldname_len = 32   ! max chars for field name
   integer, parameter, public :: fieldname_suffix_len =  3 ! length of field name suffix ("&IC")
   integer, parameter, public :: fieldname_lenp2      = fieldname_len + 2 ! allow for extra characters
   ! max_fieldname_len = max chars for field name (including suffix)


### PR DESCRIPTION
Hello,

This updates `cam_history_support`'s `fieldname_len` parameter from `24` to `32`, in order to accommodate longer names for history outputs. This is in support of implementing GEOS-Chem (https://github.com/ESCOMP/CAM/pull/484) into CESM, as we recently implemented a feature to automatically pass GEOS-Chem diagnostic quantities to CAM history. Some of the GEOS-Chem field names are longer than 24 characters and thus we need to increase the maximum length.

The model was verified to run correctly with this change so I'm making a pull request. It would be helpful to discuss here as well if the 24-character limitation was imposed due to impacts on other components, or it is artificial and can be expanded as required.

Thank you!
Haipeng Lin