### PR TITLE
cam_cesm2_2_rel_05: Secondary advection bug cesm2 2

### DIFF
--- a/src/dynamics/se/dycore/prim_advance_mod.F90
+++ b/src/dynamics/se/dycore/prim_advance_mod.F90
@@ -548,6 +548,8 @@ contains
                              ( hvcoord%hybi(k+1) - hvcoord%hybi(k) )*hvcoord%ps0
         !
         ! pel@ucar.edu: resolved noise issue over Antarctica
+        ! dp3d_ref is the reference-level thickness that includes topography
+        ! dp0 is the reference thickness without topography
         !
         dp3d_ref(:,:,k,ie) = dp3d_ref(:,:,k,ie) - dp0
         tmp                = hvcoord%hyam(k)*hvcoord%ps0+hvcoord%hybm(k)*ps_ref(:,:,ie)

--- a/src/dynamics/se/dycore/prim_advance_mod.F90
+++ b/src/dynamics/se/dycore/prim_advance_mod.F90
@@ -503,7 +503,7 @@ contains
     real (kind=r8), dimension(np,np,ksponge_end  ):: pmid
     real (kind=r8), dimension(np,np,nlev)       :: tmp_kmvis,tmp_kmcnd
     real (kind=r8), dimension(np,np,2)          :: lap_v
-    real (kind=r8)                              :: v1,v2,v1new,v2new,dt,heating,T0,T1
+    real (kind=r8)                              :: v1,v2,v1new,v2new,dt,heating,T0,T1,dp0
     real (kind=r8)                              :: laplace_fluxes(nc,nc,4)
     real (kind=r8)                              :: rhypervis_subcycle
     real (kind=r8)                              :: nu_ratio1, ptop, inv_rho
@@ -544,6 +544,12 @@ contains
       do k=1,nlev
         dp3d_ref(:,:,k,ie) = ((hvcoord%hyai(k+1)-hvcoord%hyai(k))*hvcoord%ps0 + &
                               (hvcoord%hybi(k+1)-hvcoord%hybi(k))*ps_ref(:,:,ie))
+        dp0                = ( hvcoord%hyai(k+1) - hvcoord%hyai(k) )*hvcoord%ps0 + &
+                             ( hvcoord%hybi(k+1) - hvcoord%hybi(k) )*hvcoord%ps0
+        !
+        ! pel@ucar.edu: resolved noise issue over Antarctica
+        !
+        dp3d_ref(:,:,k)    = dp3d_ref(:,:,:) - dp0
         tmp                = hvcoord%hyam(k)*hvcoord%ps0+hvcoord%hybm(k)*ps_ref(:,:,ie)
         tmp2               = (tmp/hvcoord%ps0)**cappa
         T_ref(:,:,k,ie)    = (T0+T1*tmp2)

--- a/src/dynamics/se/dycore/prim_advance_mod.F90
+++ b/src/dynamics/se/dycore/prim_advance_mod.F90
@@ -549,7 +549,7 @@ contains
         !
         ! pel@ucar.edu: resolved noise issue over Antarctica
         !
-        dp3d_ref(:,:,k)    = dp3d_ref(:,:,:) - dp0
+        dp3d_ref(:,:,k,ie) = dp3d_ref(:,:,k,ie) - dp0
         tmp                = hvcoord%hyam(k)*hvcoord%ps0+hvcoord%hybm(k)*ps_ref(:,:,ie)
         tmp2               = (tmp/hvcoord%ps0)**cappa
         T_ref(:,:,k,ie)    = (T0+T1*tmp2)


### PR DESCRIPTION
Same fix as #685 

TT_UN noise indeed disappears at ~270hPa:

![image](https://user-images.githubusercontent.com/26393487/200066475-aa3e928a-925b-455c-b6ea-9fa0253fe703.png)

Answers at ~3hPa seem more different than in cam_development:

![image](https://user-images.githubusercontent.com/26393487/200066602-31864a9d-0848-4f3c-a41f-2d4549b1bcae.png)


closes #678 