### PR TITLE
cam6_3_085: Update externals to match cesm2_3_alpha10b

### DIFF
--- a/Externals.cfg
+++ b/Externals.cfg
@@ -1,5 +1,5 @@
 [ccs_config]
-tag = ccs_config_cesm0.0.45
+tag = ccs_config_cesm0.0.47
 protocol = git
 repo_url = https://github.com/ESMCI/ccs_config_cesm
 local_path = ccs_config
@@ -13,7 +13,7 @@ local_path = components/cice5
 required = True
 
 [cice6]
-tag = cesm_cice6_2_0_21
+tag = cesm_cice6_2_0_34
 protocol = git
 repo_url = https://github.com/ESCOMP/CESM_CICE
 local_path = components/cice
@@ -21,14 +21,14 @@ externals = Externals.cfg
 required = True
 
 [cmeps]
-tag = cmeps0.13.70
+tag = cmeps0.13.78
 protocol = git
 repo_url = https://github.com/ESCOMP/CMEPS.git
 local_path = components/cmeps
 required = True
 
 [cdeps]
-tag = cdeps0.12.47
+tag = cdeps0.12.65
 protocol = git
 repo_url = https://github.com/ESCOMP/CDEPS.git
 local_path = components/cdeps
@@ -64,7 +64,7 @@ local_path = libraries/parallelio
 required = True
 
 [cime]
-tag = cime6.0.46
+tag = cime6.0.64
 protocol = git
 repo_url = https://github.com/ESMCI/cime
 local_path = cime
@@ -79,7 +79,7 @@ externals = Externals_CISM.cfg
 required = True
 
 [clm]
-tag = ctsm5.1.dev103
+tag = ctsm5.1.dev107
 protocol = git
 repo_url = https://github.com/ESCOMP/CTSM
 local_path = components/clm

--- a/Externals.cfg
+++ b/Externals.cfg
@@ -28,7 +28,7 @@ local_path = components/cmeps
 required = True
 
 [cdeps]
-tag = cdeps0.12.66
+tag = cdeps0.12.67
 protocol = git
 repo_url = https://github.com/ESCOMP/CDEPS.git
 local_path = components/cdeps

--- a/Externals.cfg
+++ b/Externals.cfg
@@ -13,7 +13,7 @@ local_path = components/cice5
 required = True
 
 [cice6]
-tag = cesm_cice6_2_0_34
+tag = cesm_cice6_2_0_35
 protocol = git
 repo_url = https://github.com/ESCOMP/CESM_CICE
 local_path = components/cice
@@ -28,7 +28,7 @@ local_path = components/cmeps
 required = True
 
 [cdeps]
-tag = cdeps0.12.65
+tag = cdeps0.12.66
 protocol = git
 repo_url = https://github.com/ESCOMP/CDEPS.git
 local_path = components/cdeps
@@ -43,7 +43,7 @@ local_path = components/cpl7
 required = True
 
 [share]
-tag = share1.0.12
+tag = share1.0.13
 protocol = git
 repo_url = https://github.com/ESCOMP/CESM_share
 local_path = share


### PR DESCRIPTION
Externals updated to match the cesm2_3_alpha10b tag:
- ccs_config_cesm0.0.47
- cmeps0.13.78
- share1.0.13
- cime6.0.64
- ctsm5.1.dev107

Externals with a more recent tag than cesm2_3_alpha10b tag (to fix PE layout issue):
- cesm_cice6_2_0_35
- cdeps0.12.67

closes #661 
closes #673 
addresses #670 
