### PR TITLE
update python paths, only build ali_arms with waccm

### DIFF
--- a/bld/configure
+++ b/bld/configure
@@ -1660,7 +1660,7 @@ elsif ($fc =~ /nvfor/)  { $fc_type = 'nvhpc'; }
 
 # User override for Fortran compiler type
 if (defined $opts{'fc_type'}) { $fc_type = $opts{'fc_type'}; }
-
+if ($fc_type == "oneapi") {$fc_type = 'intel'; }
 if ($fc_type) {
     $cfg_ref->set('fc_type', $fc_type);
     if ($print>=2) { print "Fortran compiler type: $fc_type$eol"; }
@@ -2150,6 +2150,9 @@ sub write_filepath
     }
     if ($waccm_phys) {
         print $fh "$camsrcdir/src/physics/waccm\n";
+	print $fh "$camsrcdir/src/physics/ali_arms\n";
+	print $fh "$camsrcdir/src/physics/ali_arms/subs\n";
+	print $fh "$camsrcdir/src/physics/ali_arms/include\n";
     }
     print $fh "$camsrcdir/src/ionosphere\n";
 
@@ -2177,10 +2180,6 @@ sub write_filepath
     } else {
 	print $fh "$camsrcdir/src/physics/pumas-frozen\n";
     }
-
-    print $fh "$camsrcdir/src/physics/ali_arms\n";
-    print $fh "$camsrcdir/src/physics/ali_arms/subs\n";
-    print $fh "$camsrcdir/src/physics/ali_arms/include\n";
 
     # Superparameterization
     if ($phys_pkg eq 'spcam_m2005' or $phys_pkg eq 'spcam_sam1mom') {

--- a/cime_config/buildcpp
+++ b/cime_config/buildcpp
@@ -11,7 +11,7 @@ import os, sys, re
 CIMEROOT = os.environ.get("CIMEROOT")
 if CIMEROOT is None:
     raise SystemExit("ERROR: must set CIMEROOT environment variable")
-sys.path.append(os.path.join(CIMEROOT, "scripts", "Tools"))
+sys.path.append(os.path.join(CIMEROOT, "CIME", "Tools"))
 
 from standard_script_setup import *
 

--- a/cime_config/buildlib
+++ b/cime_config/buildlib
@@ -12,7 +12,7 @@ _CIMEROOT = os.environ.get("CIMEROOT")
 if _CIMEROOT is None:
     raise SystemExit("ERROR: must set CIMEROOT environment variable")
 
-_LIBDIR = os.path.join(_CIMEROOT, "scripts", "Tools")
+_LIBDIR = os.path.join(_CIMEROOT, "CIME", "Tools")
 sys.path.append(_LIBDIR)
 
 from standard_script_setup import *
@@ -99,7 +99,7 @@ def _build_cam(caseroot, libroot, bldroot):
         complib  = os.path.join(libroot, "libatm.a")
         makefile = os.path.join(casetools, "Makefile")
 
-        cmd = "{} complib -j {} MODEL=cam COMPLIB={} -f {} {} " \
+        cmd = "{} complib -j {} COMP_NAME=cam COMPLIB={} -f {} {} " \
             .format(gmake, gmake_j, complib, makefile, get_standard_makefile_args(case))
         if cam_cppdefs:
             cmd += " USER_CPPDEFS='{}'".format(cam_cppdefs)


### PR DESCRIPTION
Changes found in the port to gust.   python paths to cime needed to be updated.  ali_arms has an issue with the nvhpc compiler but is only needed by waccm and so most builds can avoid this issue.   oneapi compiler needed to be added. 
(oneapi is the ncar name for the llvm based version of the intel compiler) Finally MODEL has been depricated in the call to make and replaced by COMP_NAME.

Closes #705 