### PR TITLE
reduce the number of times orb_param is printed to log

### DIFF
--- a/src/cpl/nuopc/atm_comp_nuopc.F90
+++ b/src/cpl/nuopc/atm_comp_nuopc.F90
@@ -1485,6 +1485,7 @@ contains
     integer           :: year     ! model year at current time
     integer           :: orb_year ! orbital year for current orbital computation
     character(len=CL) :: msgstr   ! temporary
+    logical, save     :: logprint = .true.
     character(len=*) , parameter :: subname = "(cam_orbital_update)"
     !-------------------------------------------
 
@@ -1499,10 +1500,14 @@ contains
     else
        orb_year = orb_iyear
     end if
-
+    if(.not. (logprint .and. mastertask)) then
+       logprint = .false.
+    endif
+    
     eccen = orb_eccen
-    call shr_orb_params(orb_year, eccen, orb_obliq, orb_mvelp, obliqr, lambm0, mvelpp, mastertask)
 
+    call shr_orb_params(orb_year, eccen, orb_obliq, orb_mvelp, obliqr, lambm0, mvelpp, logprint)
+    logprint = .false.
     if ( eccen  == SHR_ORB_UNDEF_REAL .or. obliqr == SHR_ORB_UNDEF_REAL .or. &
          mvelpp == SHR_ORB_UNDEF_REAL .or. lambm0 == SHR_ORB_UNDEF_REAL) then
        write (msgstr, *) subname//' ERROR: orb params incorrect'


### PR DESCRIPTION
Although orbital parameters were not being printed on every timestep as reported in #704 they were still being printed more than once, this should address that issue.  