### PR TITLE
part of cam6_3_087: Turn off unit 155 ECPP writing by default

### DIFF
--- a/src/physics/spcam/ecpp/module_ecpp_ppdriver2.F90
+++ b/src/physics/spcam/ecpp/module_ecpp_ppdriver2.F90
@@ -703,28 +703,7 @@ end type ptr2d_t
 !	and cloudy subareas
 
 !
-	idiagaa_ecpp(:) = 0
-!        idiagaa_ecpp(60:63) = 1
-        idiagaa_ecpp(60:63) = -1
-	idiagaa_ecpp(115:119) = 1 ; idiagaa_ecpp(118) = 111
-	idiagaa_ecpp(121:125) = 1
-        idiagaa_ecpp(131:135) = 1
-        idiagaa_ecpp(141:143) = 1
-
-	idiagaa_ecpp(155) = -1
-	idiagaa_ecpp(161) = 1 ; idiagaa_ecpp(162) = 1 ; idiagaa_ecpp(164) = 1
-
-        idiagaa_ecpp(131:135) = -1  ! not output in the MMF model
-        idiagaa_ecpp(115:117) = -1  ! not dump the original field in parampollu_td240clm
-        idiagaa_ecpp(118:119) = -1
-        idiagaa_ecpp(121:125) = -1
-        idiagaa_ecpp(141:143) = -1
-        idiagaa_ecpp(165:167) = -1
-        idiagaa_ecpp(164) = -1
-        idiagaa_ecpp(161) = -1
-        idiagaa_ecpp(162) = -1
-
-        idiagaa_ecpp(121) = -1
+	idiagaa_ecpp(:) = -1
 
 	do i = 1, 199
 	    ldiagaa_ecpp(i) = i

--- a/src/physics/spcam/ecpp/module_ecpp_ppdriver2.F90
+++ b/src/physics/spcam/ecpp/module_ecpp_ppdriver2.F90
@@ -711,7 +711,7 @@ end type ptr2d_t
         idiagaa_ecpp(131:135) = 1
         idiagaa_ecpp(141:143) = 1
 
-	idiagaa_ecpp(155) = 1
+	idiagaa_ecpp(155) = -1
 	idiagaa_ecpp(161) = 1 ; idiagaa_ecpp(162) = 1 ; idiagaa_ecpp(164) = 1
 
         idiagaa_ecpp(131:135) = -1  ! not output in the MMF model


### PR DESCRIPTION
Closes #717

Note that this was just turned off like all of the other optional writing commands in ECPP with a -1.

This code mod was tested before and after making the change using ` ./create_test ERS_Ln9_Vnuopc.f19_f19_mg17.FSPCAMM.izumi_gnu.cam-outfrq9s` and the fort.155 file was not written out once the change was made.  