### PR TITLE
cam6_3_088:  Update externals to match cesm2_3_alpha11a - more or less

### DIFF
--- a/Externals.cfg
+++ b/Externals.cfg
@@ -1,5 +1,5 @@
 [ccs_config]
-tag = ccs_config_cesm0.0.47
+tag = ccs_config_cesm0.0.49
 protocol = git
 repo_url = https://github.com/ESMCI/ccs_config_cesm
 local_path = ccs_config
@@ -21,7 +21,7 @@ externals = Externals.cfg
 required = True
 
 [cmeps]
-tag = cmeps0.13.78
+tag = cmeps0.14.5
 protocol = git
 repo_url = https://github.com/ESCOMP/CMEPS.git
 local_path = components/cmeps
@@ -64,7 +64,7 @@ local_path = libraries/parallelio
 required = True
 
 [cime]
-tag = cime6.0.76
+tag = cime6.0.82
 protocol = git
 repo_url = https://github.com/ESMCI/cime
 local_path = cime
@@ -79,7 +79,7 @@ externals = Externals_CISM.cfg
 required = True
 
 [clm]
-tag = ctsm5.1.dev107
+tag = ctsm5.1.dev114
 protocol = git
 repo_url = https://github.com/ESCOMP/CTSM
 local_path = components/clm

--- a/cime_config/testdefs/testmods_dirs/cam/carma_sea_salt/shell_commands
+++ b/cime_config/testdefs/testmods_dirs/cam/carma_sea_salt/shell_commands
@@ -1,2 +1,4 @@
 ./xmlchange --append CAM_CONFIG_OPTS="-carma sea_salt"
 ./xmlchange RUN_STARTDATE="0001-01-01"
+./xmlchange ROF_NCPL=\$ATM_NCPL
+./xmlchange GLC_NCPL=\$ATM_NCPL

--- a/cime_config/testdefs/testmods_dirs/cam/dartcambigens/shell_commands
+++ b/cime_config/testdefs/testmods_dirs/cam/dartcambigens/shell_commands
@@ -1,3 +1,5 @@
 ./xmlchange CALENDAR=GREGORIAN
 ./xmlchange PIO_TYPENAME=pnetcdf
 ./xmlchange ATM_NCPL=48
+./xmlchange ROF_NCPL=\$ATM_NCPL
+./xmlchange GLC_NCPL=\$ATM_NCPL

--- a/cime_config/testdefs/testmods_dirs/cam/outfrq3s_chemproc/shell_commands
+++ b/cime_config/testdefs/testmods_dirs/cam/outfrq3s_chemproc/shell_commands
@@ -1,1 +1,3 @@
 ./xmlchange --append CAM_CONFIG_OPTS="-usr_mech_infile \$TESTS_MODS_DIR/cam/outfrq3s_chemproc/test_mech.in"
+./xmlchange ROF_NCPL=\$ATM_NCPL
+./xmlchange GLC_NCPL=\$ATM_NCPL

--- a/cime_config/testdefs/testmods_dirs/cam/outfrq9s_apmee/shell_commands
+++ b/cime_config/testdefs/testmods_dirs/cam/outfrq9s_apmee/shell_commands
@@ -1,0 +1,2 @@
+./xmlchange ROF_NCPL=\$ATM_NCPL
+./xmlchange GLC_NCPL=\$ATM_NCPL

--- a/cime_config/testdefs/testmods_dirs/cam/outfrq9s_mee_fluxes/shell_commands
+++ b/cime_config/testdefs/testmods_dirs/cam/outfrq9s_mee_fluxes/shell_commands
@@ -1,2 +1,4 @@
 ./xmlchange RUN_STARTDATE=2015-01-01
 ./xmlchange CALENDAR=GREGORIAN
+./xmlchange ROF_NCPL=\$ATM_NCPL
+./xmlchange GLC_NCPL=\$ATM_NCPL


### PR DESCRIPTION
Match externals for cesm2_3_alpha11a, except for the externals which CAM has newer and the FMS external which is older

Closes #730 