### PR TITLE
cam6_3_102: Fix cam_dev TEM diags issue

### DIFF
--- a/cime_config/testdefs/testmods_dirs/cam/outfrq1d_14dec_ghg_cam_dev/user_nl_cam
+++ b/cime_config/testdefs/testmods_dirs/cam/outfrq1d_14dec_ghg_cam_dev/user_nl_cam
@@ -3,3 +3,7 @@ ndens=1,1,1,1,1,1,1,1,1,1
 nhtfrq=-24,-24,-24,-24,-24,-24,-24,-24,-24,-24
 tracer_cnst_specifier = 'O3','OH','NO3','HO2','HALONS'
 flbc_cycle_yr=1850
+phys_grid_ctem_nfreq=-6
+phys_grid_ctem_zm_nbas=16
+phys_grid_ctem_za_nlat=15
+fincl2 = 'THphys','VTHzaphys','WTHzaphys','UVzaphys','UWzaphys'

--- a/cime_config/testdefs/testmods_dirs/cam/outfrq1d_14dec_ghg_cam_dev/user_nl_cam
+++ b/cime_config/testdefs/testmods_dirs/cam/outfrq1d_14dec_ghg_cam_dev/user_nl_cam
@@ -6,4 +6,4 @@ flbc_cycle_yr=1850
 phys_grid_ctem_nfreq=-6
 phys_grid_ctem_zm_nbas=16
 phys_grid_ctem_za_nlat=15
-fincl2 = 'THphys','VTHzaphys','WTHzaphys','UVzaphys','UWzaphys'
+fincl2 = 'THphys','VTHzm','WTHzm','UVzm','UWzm','Uzm','Vzm','Wzm','THzm'

--- a/cime_config/testdefs/testmods_dirs/cam/outfrq1d_physgrid_tem_mpasa120_wcmsc/user_nl_cam
+++ b/cime_config/testdefs/testmods_dirs/cam/outfrq1d_physgrid_tem_mpasa120_wcmsc/user_nl_cam
@@ -17,7 +17,7 @@ phys_grid_ctem_za_nlat = 90
 fincl1 = ' '
 fexcl1 = ' '
 
-fincl2 = 'VTHzaphys','WTHzaphys','UVzaphys','UWzaphys'
+fincl2 = 'Uzm','Vzm','Wzm','THzm', 'VTHzm','WTHzm','UVzm','UWzm'
 
 mfilt=1,1,1,1,1,1,1,1,1,1
 ndens=1,1,1,1,1,1,1,1,1,1

--- a/cime_config/testdefs/testmods_dirs/cam/outfrq3s_physgrid_tem/user_nl_cam
+++ b/cime_config/testdefs/testmods_dirs/cam/outfrq3s_physgrid_tem/user_nl_cam
@@ -5,4 +5,4 @@ inithist='ENDOFRUN'
 phys_grid_ctem_nfreq=3
 phys_grid_ctem_zm_nbas=16
 phys_grid_ctem_za_nlat=15
-fincl3 = 'VTHzaphys','WTHzaphys','UVzaphys','UWzaphys'
+fincl3 = 'Uzm','Vzm','Wzm','THzm', 'VTHzm','WTHzm','UVzm','UWzm'

--- a/cime_config/testdefs/testmods_dirs/cam/outfrq9s_physgrid_tem_1deg/user_nl_cam
+++ b/cime_config/testdefs/testmods_dirs/cam/outfrq9s_physgrid_tem_1deg/user_nl_cam
@@ -5,4 +5,4 @@ inithist='ENDOFRUN'
 phys_grid_ctem_nfreq=-2
 phys_grid_ctem_zm_nbas=120
 phys_grid_ctem_za_nlat=90
-fincl3 = 'VTHzaphys','WTHzaphys','UVzaphys','UWzaphys'
+fincl3 = 'Uzm','Vzm','Wzm','THzm', 'VTHzm','WTHzm','UVzm','UWzm'

--- a/src/physics/cam/phys_grid_ctem.F90
+++ b/src/physics/cam/phys_grid_ctem.F90
@@ -207,10 +207,10 @@ contains
 
     if (.not.do_tem_diags) return
 
-    call addfld ('Uzm',  (/'lev'/), 'A','m s-1',  'Zonal-Mean zonal wind - defined on ilev', gridname='ctem_zavg_phys' )
-    call addfld ('Vzm',  (/'lev'/), 'A','m s-1',  'Zonal-Mean meridional wind - defined on ilev', gridname='ctem_zavg_phys' )
-    call addfld ('Wzm',  (/'lev'/), 'A','m s-1',  'Zonal-Mean vertical wind - defined on ilev', gridname='ctem_zavg_phys' )
-    call addfld ('THzm', (/'lev'/), 'A','K',      'Zonal-Mean potential temp - defined on ilev', gridname='ctem_zavg_phys' )
+    call addfld ('Uzm',  (/'lev'/), 'A','m s-1',  'Zonal-Mean zonal wind', gridname='ctem_zavg_phys' )
+    call addfld ('Vzm',  (/'lev'/), 'A','m s-1',  'Zonal-Mean meridional wind', gridname='ctem_zavg_phys' )
+    call addfld ('Wzm',  (/'lev'/), 'A','m s-1',  'Zonal-Mean vertical wind', gridname='ctem_zavg_phys' )
+    call addfld ('THzm', (/'lev'/), 'A','K',      'Zonal-Mean potential temp', gridname='ctem_zavg_phys' )
     call addfld ('VTHzm',(/'lev'/), 'A','K m s-1','Meridional Heat Flux:', gridname='ctem_zavg_phys')
     call addfld ('WTHzm',(/'lev'/), 'A','K m s-1','Vertical Heat Flux:', gridname='ctem_zavg_phys')
     call addfld ('UVzm', (/'lev'/), 'A','m2 s-2', 'Meridional Flux of Zonal Momentum', gridname='ctem_zavg_phys')

--- a/src/physics/cam/phys_grid_ctem.F90
+++ b/src/physics/cam/phys_grid_ctem.F90
@@ -140,7 +140,7 @@ contains
     real(r8), parameter :: latrad0 = -pi*0.5_r8
     real(r8), parameter :: fourpi = pi*4._r8
 
-    integer, parameter :: ctem_zavg_phys_decomp = 201 ! Must be unique within CAM
+    integer, parameter :: ctem_zavg_phys_decomp = 333 ! Must be unique within CAM
 
     if (.not.do_tem_diags) return
 
@@ -313,17 +313,22 @@ contains
     call ZAobj%binAvg(uvp, uvza)
     call ZAobj%binAvg(uwp, uwza)
     call ZAobj%binAvg(vthp, vthza)
-    call ZAobj%binAvg(uzm, uza)
-    call ZAobj%binAvg(vzm, vza)
-    call ZAobj%binAvg(wzm, wza)
-    call ZAobj%binAvg(thzm, thza)
-
-    call ZAobj%binAvg(uvp, uvza)
+    call ZAobj%binAvg(wthp, wthza)
 
     if (any(abs(uvza)>1.e20_r8)) call endrun(prefix//'bad values in uvza')
     if (any(abs(uwza)>1.e20_r8)) call endrun(prefix//'bad values in uwza')
     if (any(abs(vthza)>1.e20_r8)) call endrun(prefix//'bad values in vthza')
     if (any(abs(wthza)>1.e20_r8)) call endrun(prefix//'bad values in wthza')
+
+    call ZAobj%binAvg(uzm, uza)
+    call ZAobj%binAvg(vzm, vza)
+    call ZAobj%binAvg(wzm, wza)
+    call ZAobj%binAvg(thzm, thza)
+
+    if (any(abs(uza)>1.e20_r8)) call endrun(prefix//'bad values in uza')
+    if (any(abs(vza)>1.e20_r8)) call endrun(prefix//'bad values in vza')
+    if (any(abs(wza)>1.e20_r8)) call endrun(prefix//'bad values in wza')
+    if (any(abs(thza)>1.e20_r8)) call endrun(prefix//'bad values in thza')
 
     ! diagnostic output
     do j = 1,nzalat

--- a/src/physics/cam/phys_grid_ctem.F90
+++ b/src/physics/cam/phys_grid_ctem.F90
@@ -207,11 +207,15 @@ contains
 
     if (.not.do_tem_diags) return
 
-    call addfld ('VTHzaphys',(/'lev'/), 'A', 'K m s-1','Meridional Heat Flux:', gridname='ctem_zavg_phys')
-    call addfld ('WTHzaphys',(/'lev'/), 'A', 'K m s-1','Vertical Heat Flux:', gridname='ctem_zavg_phys')
-    call addfld ('UVzaphys', (/'lev'/), 'A', 'm2 s-2', 'Meridional Flux of Zonal Momentum', gridname='ctem_zavg_phys')
-    call addfld ('UWzaphys', (/'lev'/), 'A', 'm2 s-2', 'Vertical Flux of Zonal Momentum', gridname='ctem_zavg_phys')
-    call addfld ('THphys',   (/'lev'/), 'A', 'K',      'Potential temp', gridname='physgrid' )
+    call addfld ('Uzm',  (/'lev'/), 'A','m s-1',  'Zonal-Mean zonal wind - defined on ilev', gridname='ctem_zavg_phys' )
+    call addfld ('Vzm',  (/'lev'/), 'A','m s-1',  'Zonal-Mean meridional wind - defined on ilev', gridname='ctem_zavg_phys' )
+    call addfld ('Wzm',  (/'lev'/), 'A','m s-1',  'Zonal-Mean vertical wind - defined on ilev', gridname='ctem_zavg_phys' )
+    call addfld ('THzm', (/'lev'/), 'A','K',      'Zonal-Mean potential temp - defined on ilev', gridname='ctem_zavg_phys' )
+    call addfld ('VTHzm',(/'lev'/), 'A','K m s-1','Meridional Heat Flux:', gridname='ctem_zavg_phys')
+    call addfld ('WTHzm',(/'lev'/), 'A','K m s-1','Vertical Heat Flux:', gridname='ctem_zavg_phys')
+    call addfld ('UVzm', (/'lev'/), 'A','m2 s-2', 'Meridional Flux of Zonal Momentum', gridname='ctem_zavg_phys')
+    call addfld ('UWzm', (/'lev'/), 'A','m2 s-2', 'Vertical Flux of Zonal Momentum', gridname='ctem_zavg_phys')
+    call addfld ('THphys',(/'lev'/), 'A', 'K',    'Potential temp', gridname='physgrid' )
 
   end subroutine phys_grid_ctem_init
 
@@ -250,6 +254,11 @@ contains
     real(r8) :: uwza(nzalat,pver)
     real(r8) :: vthza(nzalat,pver)
     real(r8) :: wthza(nzalat,pver)
+
+    real(r8) :: uza(nzalat,pver)
+    real(r8) :: vza(nzalat,pver)
+    real(r8) :: wza(nzalat,pver)
+    real(r8) :: thza(nzalat,pver)
 
     real(r8) :: sheight(pcols,pver) ! pressure scale height (m)
 
@@ -304,7 +313,12 @@ contains
     call ZAobj%binAvg(uvp, uvza)
     call ZAobj%binAvg(uwp, uwza)
     call ZAobj%binAvg(vthp, vthza)
-    call ZAobj%binAvg(wthp, wthza)
+    call ZAobj%binAvg(uzm, uza)
+    call ZAobj%binAvg(vzm, vza)
+    call ZAobj%binAvg(wzm, wza)
+    call ZAobj%binAvg(thzm, thza)
+
+    call ZAobj%binAvg(uvp, uvza)
 
     if (any(abs(uvza)>1.e20_r8)) call endrun(prefix//'bad values in uvza')
     if (any(abs(uwza)>1.e20_r8)) call endrun(prefix//'bad values in uwza')
@@ -313,10 +327,14 @@ contains
 
     ! diagnostic output
     do j = 1,nzalat
-       call outfld('UVzaphys',uvza(j,:),1,j)
-       call outfld('UWzaphys',uwza(j,:),1,j)
-       call outfld('VTHzaphys',vthza(j,:),1,j)
-       call outfld('WTHzaphys',wthza(j,:),1,j)
+       call outfld('Uzm',uza(j,:),1,j)
+       call outfld('Vzm',vza(j,:),1,j)
+       call outfld('Wzm',wza(j,:),1,j)
+       call outfld('THzm',thza(j,:),1,j)
+       call outfld('UVzm',uvza(j,:),1,j)
+       call outfld('UWzm',uwza(j,:),1,j)
+       call outfld('VTHzm',vthza(j,:),1,j)
+       call outfld('WTHzm',wthza(j,:),1,j)
     end do
 
   contains

--- a/src/physics/cam_dev/physpkg.F90
+++ b/src/physics/cam_dev/physpkg.F90
@@ -749,6 +749,7 @@ contains
     use nudging,            only: Nudge_Model, nudging_init
     use cam_snapshot,       only: cam_snapshot_init
     use cam_history,        only: addfld, register_vector_field, add_default
+    use phys_grid_ctem,     only: phys_grid_ctem_init
 
     ! Input/output arguments
     type(physics_state), pointer       :: phys_state(:)
@@ -927,6 +928,9 @@ contains
 
     ! Initialize qneg3 and qneg4
     call qneg_init()
+
+    ! Initialize phys TEM diagnostics
+    call phys_grid_ctem_init()
 
     ! Initialize the snapshot capability
     call cam_snapshot_init(cam_in, cam_out, pbuf2d, begchunk)
@@ -1248,6 +1252,8 @@ contains
     use carma_intr,     only: carma_final
     use wv_saturation,  only: wv_sat_final
     use microp_aero,    only: microp_aero_final
+    use phys_grid_ctem, only: phys_grid_ctem_final
+    use nudging,        only: Nudge_Model, nudging_final
 
     !-----------------------------------------------------------------------
     !
@@ -1270,6 +1276,8 @@ contains
     call carma_final
     call wv_sat_final
     call microp_aero_final()
+    call phys_grid_ctem_final()
+    if(Nudge_Model) call nudging_final()
 
   end subroutine phys_final
 
@@ -2828,6 +2836,7 @@ subroutine phys_timestep_init(phys_state, cam_in, cam_out, pbuf2d)
   use iop_forcing,         only: scam_use_iop_srf
   use nudging,             only: Nudge_Model, nudging_timestep_init
   use waccmx_phys_intr,    only: waccmx_phys_ion_elec_temp_timestep_init
+  use phys_grid_ctem,      only: phys_grid_ctem_diags
 
   implicit none
 
@@ -2894,6 +2903,9 @@ subroutine phys_timestep_init(phys_state, cam_in, cam_out, pbuf2d)
   ! Update Nudging values, if needed
   !----------------------------------
   if(Nudge_Model) call nudging_timestep_init(phys_state)
+
+  ! Update TEM diagnostics
+  call phys_grid_ctem_diags(phys_state)
 
 end subroutine phys_timestep_init
 


### PR DESCRIPTION
fixes #769 

Also :
 - adopts the `zm` naming convention for the zonal mean outputs.  
 - add 'Uzm','Vzm','Wzm','THzm' output fields