### PR TITLE
cam6_3_110: Resolve miscellaneous issues.

### DIFF
--- a/bld/namelist_files/namelist_definition.xml
+++ b/bld/namelist_files/namelist_definition.xml
@@ -1906,27 +1906,27 @@ if .true. then output CLUBBs radiative history statistics
 Default: false
 </entry>
 
-<entry id="clubb_vars_zt" type="char*16(10000)"  category="history"
+<entry id="clubb_vars_zt" type="char*35(10000)"  category="history"
        group="clubb_stats_nl" valid_values="" >
 Same as {{ hilight }}fincl1{{ closehilight }}, but for CLUBB statistics on zt grid.
 </entry>
 
-<entry id="clubb_vars_zm" type="char*16(10000)"  category="history"
+<entry id="clubb_vars_zm" type="char*35(10000)"  category="history"
        group="clubb_stats_nl" valid_values="" >
 Same as {{ hilight }}fincl1{{ closehilight }}, but for CLUBB statistics on zm grid.
 </entry>
 
-<entry id="clubb_vars_rad_zt" type="char*16(10000)"  category="history"
+<entry id="clubb_vars_rad_zt" type="char*35(10000)"  category="history"
        group="clubb_stats_nl" valid_values="" >
 Same as {{ hilight }}fincl1{{ closehilight }}, but for CLUBB statistics on radiation zt grid.
 </entry>
 
-<entry id="clubb_vars_rad_zm" type="char*16(10000)"  category="history"
+<entry id="clubb_vars_rad_zm" type="char*35(10000)"  category="history"
        group="clubb_stats_nl" valid_values="" >
 Same as {{ hilight }}fincl1{{ closehilight }}, but for CLUBB statistics on radiation zm grid.
 </entry>
 
-<entry id="clubb_vars_sfc" type="char*16(10000)"  category="history"
+<entry id="clubb_vars_sfc" type="char*35(10000)"  category="history"
        group="clubb_stats_nl" valid_values="" >
 Same as {{ hilight }}fincl1{{ closehilight }}, but for CLUBB statistics on surface.
 </entry>

--- a/cime_config/config_compsets.xml
+++ b/cime_config/config_compsets.xml
@@ -62,13 +62,13 @@
   </compset>
 
   <compset>
-    <alias>FLTHIST_v0b</alias>
+    <alias>FLTHIST_v0c</alias>
     <lname>HIST_CAM%DEV%LT%GHGMAM4_CLM51%SP_CICE%PRES_DOCN%DOM_MOSART_SGLC_SWAV</lname>
   </compset>
 
   <compset>
-    <alias>FMTHIST_v0b</alias>
-    <lname>HIST_CAM%DEV%MT_CLM51%SP_CICE%PRES_DOCN%DOM_MOSART_SGLC_SWAV</lname>
+    <alias>FMTHIST_v0c</alias>
+    <lname>HIST_CAM%DEV%MT%GHGMAM4_CLM51%SP_CICE%PRES_DOCN%DOM_MOSART_SGLC_SWAV</lname>
   </compset>
 
   <compset>

--- a/cime_config/config_compsets.xml
+++ b/cime_config/config_compsets.xml
@@ -572,51 +572,6 @@
      </values>
     </entry>
 
- <!-- comment out RUN_TYPE until refcases are reintroduced for the next release -->
-
- <!--    <entry id="RUN_TYPE"> -->
- <!--      <values match="first"> -->
- <!--	<value grid="a%0.9x1.25_l%0.9x1.25_oi%0.9x1.25_r%r05_g%gland4_w%null_m%gx1v7"	compset="HIST_CAM60_CLM50%BGC-CROP_CICE%PRES_DOCN%DOM_MOSART_CISM2%NOEVOLVE_SWAV"	 >hybrid</value> -->
- <!--	<value grid="a%0.9x1.25_l%0.9x1.25_oi%0.9x1.25_r%r05_g%gland4_w%null_m%gx1v7"	compset="2000_CAM60_CLM50%BGC-CROP_CICE%PRES_DOCN%DOM_MOSART_CISM2%NOEVOLVE_SWAV"	 >hybrid</value> -->
- <!--	<value grid="a%0.9x1.25_l%0.9x1.25_oi%0.9_1.25_r%r05_m%gx1v6"   compset="2000_CAM60_CLM50%BGC-CROP_CICE%PRES_DOCN%DOM_MOSART_CISM2%NOEVOLVE_SWAV">hybrid</value> -->
-
- <!--	<value grid="a%0.9x1.25_l%0.9x1.25_oi%0.9_1.25_r%r05_m%gx1v7"   compset="2000_CAM60_CLM50%BGC-CROP_CICE%PRES_DOCN%DOM_MOSART_CISM2%NOEVOLVE_SWAV">hybrid</value> -->
- <!--	<value grid="a%0.9x1.25_l%0.9x1.25_oi%0.9x1.25_r%r05_g%gland4_w%null_m%gx1v7" compset="HIST_CAM60%WC.*_CLM50%BGC-CROP_CICE%PRES_DOCN%DOM_MOSART_CISM2%NOEVOLVE_SWAV">hybrid</value> -->
- <!--      </values> -->
- <!--    </entry> -->
-
- <!-- comment out RUN_REFCASE until refcases are reintroduced for the next release -->
- <!--   <entry id="RUN_REFCASE"> -->
- <!--     <values match="first"> -->
-<!--	<value grid="a%0.9x1.25_l%0.9x1.25_oi%0.9x1.25_r%r05_g%gland4_w%null_m%gx1v7"	compset="2000_CAM60_CLM50%BGC-CROP_CICE%PRES_DOCN%DOM_MOSART_CISM2%NOEVOLVE_SWAV"	 >b.e20.BHIST.f09_g17.20thC.297_01_v2</value> -->
-<!--	<value grid="a%0.9x1.25_l%0.9x1.25_oi%0.9x1.25_r%r05_g%gland4_w%null_m%gx1v7"	compset="HIST_CAM60_CLM50%BGC-CROP_CICE%PRES_DOCN%DOM_MOSART_CISM2%NOEVOLVE_SWAV"	 >b.e20.BHIST.f09_g17.20thC.297_01_v2</value> -->
-<!--	<value grid="a%0.9x1.25_l%0.9x1.25_oi%0.9_1.25_r%r05_m%gx1v6"   compset="2000_CAM60_CLM50%BGC-CROP_CICE%PRES_DOCN%DOM_MOSART_CISM2%NOEVOLVE_SWAV">b.e20.B1850.f09_g16.pi_control.all.123</value> -->
-
-<!--	<value grid="a%0.9x1.25_l%0.9x1.25_oi%0.9_1.25_r%r05_m%gx1v7"   compset="2000_CAM60_CLM50%BGC-CROP_CICE%PRES_DOCN%DOM_MOSART_CISM2%NOEVOLVE_SWAV">b.e20.B1850.f09_g16.pi_control.all.123</value> -->
-<!--        <value grid="a%0.9x1.25_l%0.9x1.25_oi%0.9x1.25_r%r05_g%gland4_w%null_m%gx1v7" compset="HIST_CAM60%WC.*_CLM50%BGC-CROP_CICE%PRES_DOCN%DOM_MOSART_CISM2%NOEVOLVE_SWAV">b.e21.BWHIST.f09_g17.CMIP6-historical-WACCM.001</value> -->
-<!--      </values> -->
-<!--    </entry> -->
-
- <!-- comment out RUN_REFDATE until refcases are reintroduced for the next release -->
-<!--    <entry id="RUN_REFDATE"> -->
-<!--      <values match="first"> -->
-<!--	<value grid="a%0.9x1.25_l%0.9x1.25_oi%0.9x1.25_r%r05_g%gland4_w%null_m%gx1v7"	compset="HIST_CAM60_CLM50%BGC-CROP_CICE%PRES_DOCN%DOM_MOSART_CISM2%NOEVOLVE_SWAV"   >1979-01-01</value> -->
-<!--	<value grid="a%0.9x1.25_l%0.9x1.25_oi%0.9x1.25_r%r05_g%gland4_w%null_m%gx1v7"	compset="2000_CAM60_CLM50%BGC-CROP_CICE%PRES_DOCN%DOM_MOSART_CISM2%NOEVOLVE_SWAV"   >2000-01-01</value> -->
-<!--	<value grid="a%0.9x1.25_l%0.9x1.25_oi%0.9_1.25_r%r05_m%gx1v6"   compset="2000_CAM60_CLM50%BGC-CROP_CICE%PRES_DOCN%DOM_MOSART_CISM2%NOEVOLVE_SWAV">0010-01-01</value> -->
-<!--	<value grid="a%0.9x1.25_l%0.9x1.25_oi%0.9_1.25_r%r05_m%gx1v7"   compset="2000_CAM60_CLM50%BGC-CROP_CICE%PRES_DOCN%DOM_MOSART_CISM2%NOEVOLVE_SWAV">0010-01-01</value> -->
-<!--        <value grid="a%0.9x1.25_l%0.9x1.25_oi%0.9x1.25_r%r05_g%gland4_w%null_m%gx1v7" compset="HIST_CAM60%WC.*_CLM50%BGC-CROP_CICE%PRES_DOCN%DOM_MOSART_CISM2%NOEVOLVE_SWAV">1950-01-01</value> -->
-<!--      </values> -->
-<!--    </entry> -->
-
- <!-- comment out RUN_REFDIR until refcases are reintroduced for the next release -->
- <!--   <entry id="RUN_REFDIR"> -->
-<!--      <values match="first"> -->
-<!--	<value grid="a%0.9x1.25_l%0.9x1.25_oi%0.9x1.25_r%r05_g%gland4_w%null_m%gx1v7"	compset="HIST_CAM60_CLM50%BGC-CROP_CICE%PRES_DOCN%DOM_MOSART_CISM2%NOEVOLVE_SWAV"   >cesm2_init</value> -->
-<!--	<value grid="a%0.9x1.25_l%0.9x1.25_oi%0.9x1.25_r%r05_g%gland4_w%null_m%gx1v7"	compset="2000_CAM60_CLM50%BGC-CROP_CICE%PRES_DOCN%DOM_MOSART_CISM2%NOEVOLVE_SWAV"   >cesm2_init</value> -->
-<!--	<value grid="a%0.9x1.25_l%0.9x1.25_oi%0.9x1.25_r%r05_g%gland4_w%null_m%gx1v7" compset="HIST_CAM60%WC.*_CLM50%BGC-CROP_CICE%PRES_DOCN%DOM_MOSART_CISM2%NOEVOLVE_SWAV">cesm2_init</value> -->
-<!--     </values> -->
-<!--    </entry> -->
-
     <entry id="NTHRDS_ATM">
       <values match="first">
         <value compset="SPCAMS">1</value>

--- a/src/control/cam_history.F90
+++ b/src/control/cam_history.F90
@@ -2521,9 +2521,10 @@ CONTAINS
     ! To avoid duplicating long fincl lists in use case files to provide both FV and non-FV
     ! versions this short list of fields is checked for and removed from fincl lists when
     ! the dycore is not FV.
-    integer, parameter :: n_fv_only = 2
+    integer, parameter :: n_fv_only = 10
     character(len=6) :: fv_only_flds(n_fv_only) = &
-       [ 'TH    ', 'MSKtem' ]
+       [ 'VTHzm ', 'WTHzm ', 'UVzm  ', 'UWzm  ', 'Uzm   ', 'Vzm   ', 'Wzm   ', &
+         'THzm  ', 'TH    ', 'MSKtem' ]
 
     integer :: n_vec_comp, add_fincl_idx
     integer, parameter :: nvecmax = 50 ! max number of vector components in a fincl list

--- a/src/control/cam_history.F90
+++ b/src/control/cam_history.F90
@@ -2269,10 +2269,9 @@ CONTAINS
     ! To avoid duplicating long fincl lists in use case files to provide both FV and non-FV
     ! versions this short list of fields is checked for and removed from fincl lists when
     ! the dycore is not FV.
-    integer, parameter :: n_fv_only = 10
+    integer, parameter :: n_fv_only = 2
     character(len=6) :: fv_only_flds(n_fv_only) = &
-       [ 'VTHzm ', 'WTHzm ', 'UVzm  ', 'UWzm  ', 'Uzm   ', 'Vzm   ', 'Wzm   ', &
-         'THzm  ', 'TH    ', 'MSKtem' ]
+       [ 'TH    ', 'MSKtem' ]
 
     integer :: n_vec_comp, add_fincl_idx
     integer, parameter :: nvecmax = 50 ! max number of vector components in a fincl list

--- a/src/physics/cam/cam_diagnostics.F90
+++ b/src/physics/cam/cam_diagnostics.F90
@@ -276,8 +276,8 @@ contains
 
     call addfld ('UU',         (/ 'lev' /), 'A', 'm2/s2',     'Zonal velocity squared' )
     call addfld ('WSPEED',     (/ 'lev' /), 'X', 'm/s',       'Horizontal total wind speed maximum' )
-    call addfld ('WSPDSRFMX',  horiz_only,  'X', 'm/s',       'Horizontal total wind speed maximum at the surface' )
-    call addfld ('WSPDSRFAV',  horiz_only,  'A', 'm/s',       'Horizontal total wind speed average at the surface' )
+    call addfld ('WSPDSRFMX',  horiz_only,  'X', 'm/s',       'Horizontal total wind speed maximum at surface layer midpoint' )
+    call addfld ('WSPDSRFAV',  horiz_only,  'A', 'm/s',       'Horizontal total wind speed average at surface layer midpoint' )
 
     call addfld ('OMEGA',      (/ 'lev' /), 'A', 'Pa/s',      'Vertical velocity (pressure)')
     call addfld ('OMEGAT',     (/ 'lev' /), 'A', 'K Pa/s  ',  'Vertical heat flux' )

--- a/src/physics/cam/clubb_intr.F90
+++ b/src/physics/cam/clubb_intr.F90
@@ -17,23 +17,24 @@ module clubb_intr
   !                                                                                                      ! 
   !----------------------------------------------------------------------------------------------------- !
 
-  use shr_kind_mod,     only: r8=>shr_kind_r8                                                                  
-  use ppgrid,           only: pver, pverp, pcols, begchunk, endchunk
-  use phys_control,     only: phys_getopts
-  use physconst,        only: cpair, gravit, rga, latvap, latice, zvir, rh2o, karman
-  use air_composition,  only: rairv, cpairv
+  use shr_kind_mod,        only: r8=>shr_kind_r8                                                                  
+  use ppgrid,              only: pver, pverp, pcols, begchunk, endchunk
+  use phys_control,        only: phys_getopts
+  use physconst,           only: cpair, gravit, rga, latvap, latice, zvir, rh2o, karman
+  use air_composition,     only: rairv, cpairv
+  use cam_history_support, only: max_fieldname_len
 
-  use spmd_utils,       only: masterproc 
-  use constituents,     only: pcnst, cnst_add
-  use pbl_utils,        only: calc_ustar, calc_obklen
-  use ref_pres,         only: top_lev => trop_cloud_top_lev  
-  use zm_conv_intr,     only: zmconv_microp
+  use spmd_utils,          only: masterproc 
+  use constituents,        only: pcnst, cnst_add
+  use pbl_utils,           only: calc_ustar, calc_obklen
+  use ref_pres,            only: top_lev => trop_cloud_top_lev  
+  use zm_conv_intr,        only: zmconv_microp
 #ifdef CLUBB_SGS
-  use clubb_api_module, only: pdf_parameter, implicit_coefs_terms
-  use clubb_api_module, only: clubb_config_flags_type, grid, stats, nu_vertical_res_dep
-  use clubb_api_module, only: nparams
-  use clubb_mf,         only: do_clubb_mf, do_clubb_mf_diag
-  use cloud_fraction,   only: dp1, dp2
+  use clubb_api_module,    only: pdf_parameter, implicit_coefs_terms
+  use clubb_api_module,    only: clubb_config_flags_type, grid, stats, nu_vertical_res_dep
+  use clubb_api_module,    only: nparams
+  use clubb_mf,            only: do_clubb_mf, do_clubb_mf_diag
+  use cloud_fraction,      only: dp1, dp2
 #endif
 
   implicit none
@@ -4305,7 +4306,7 @@ end subroutine clubb_init_cnst
    
         temp1 = trim(stats_zt(1)%file%grid_avg_var(j)%name)
         sub   = temp1
-        if (len(temp1) >  16) sub = temp1(1:16)
+        if (len(temp1) >  max_fieldname_len) sub = temp1(1:max_fieldname_len)
  
         call outfld(trim(sub), out_zt(:,:,j), pcols, lchnk )
       enddo
@@ -4314,7 +4315,7 @@ end subroutine clubb_init_cnst
    
         temp1 = trim(stats_zm(1)%file%grid_avg_var(j)%name)
         sub   = temp1
-        if (len(temp1) > 16) sub = temp1(1:16)
+        if (len(temp1) > max_fieldname_len) sub = temp1(1:max_fieldname_len)
    
         call outfld(trim(sub),out_zm(:,:,j), pcols, lchnk)
       enddo
@@ -5020,7 +5021,7 @@ end function diag_ustar
       
         temp1 = trim(stats_zt%file%grid_avg_var(i)%name)
         sub   = temp1
-        if (len(temp1) > 16) sub = temp1(1:16)
+        if (len(temp1) > max_fieldname_len) sub = temp1(1:max_fieldname_len)
        
           call addfld(trim(sub),(/ 'ilev' /),&
                'A',trim(stats_zt%file%grid_avg_var(i)%units),trim(stats_zt%file%grid_avg_var(i)%description))
@@ -5030,7 +5031,7 @@ end function diag_ustar
       
         temp1 = trim(stats_zm%file%grid_avg_var(i)%name)
         sub   = temp1
-        if (len(temp1) > 16) sub = temp1(1:16)
+        if (len(temp1) > max_fieldname_len) sub = temp1(1:max_fieldname_len)
       
          call addfld(trim(sub),(/ 'ilev' /),&
               'A',trim(stats_zm%file%grid_avg_var(i)%units),trim(stats_zm%file%grid_avg_var(i)%description))

--- a/test/system/archive_baseline.sh
+++ b/test/system/archive_baseline.sh
@@ -122,7 +122,7 @@ if [ -n "$CESM_TESTDIR" ]; then
       cp -r $CESM_TESTDIR/baselines/. $root_baselinedir/$cam_tag
     else
       echo "Using bless_test_results to archive baselines."
-      ../../cime/scripts/Tools/bless_test_results -p -t '' -c '' -r $CESM_TESTDIR --baseline-root $root_baselinedir -b $cam_tag -f -s
+      ../../cime/CIME/Tools/bless_test_results -p -t '' -c '' -r $CESM_TESTDIR --baseline-root $root_baselinedir -b $cam_tag -f -s
     fi
 
     echo " "


### PR DESCRIPTION
Resolve issues:

. Issue #371 - Grid matches in refcases will need to change from gland4 to gris4 if they are re-enabled
    - Resolved by removing entries for old refcases.

. Issue #741 - Updates to address CLUBB variable-name length limit.
    - Use cam_history_support::max_fieldname_len to replace hardcoded 16.
    - PR #743 will be resolved by this PR.

. Issue #608 - Fix path for buildlib/buildnml
    - Fix one wrong occurance of the old path 'cime/scripts/Tools'.  Don't see any problem with paths for buildlib/buildnml.

. Issue #749 - Correct description of low-level wind output
    - fix description as suggested

. resolves #371
. resolves #741
. resolves #743
. resolves #608
. resolves #749
. resolves #803 
