### PR TITLE
add pointers for intel performance, remove unused PI variable for nvhpc

### DIFF
--- a/src/control/cam_history.F90
+++ b/src/control/cam_history.F90
@@ -4992,7 +4992,6 @@ end subroutine print_active_fldlst
     use cam_history_support, only: dim_index_2d
     use shr_reprosum_mod,    only: shr_reprosum_calc
     use spmd_utils,          only: mpicom
-    use shr_const_mod,       only: PI => SHR_CONST_PI
     !
     !-----------------------------------------------------------------------
     !


### PR DESCRIPTION
This pull request is a fix for derecho performance as discussed in https://github.com/ESCOMP/CAM/discussions/827 
Testing was performed by creating a baseline using SMS_Ln9.ne30pg3_ne30pg3_mg17.FLTHIST_v0c.derecho_intel.cam-outfrq9s
and comparing unmodified fvm_consistent_se_cslam.F90 to the modified version.
Results were bfb.   A 20day PFS test with the same compset shows a speed up from 5.5 ypd to 17.4 ypd.

A PFS test was also conducted with the nvhpc/23.1 compiler, no notable change in performance.