### PR TITLE
improves history write performance;

### DIFF
--- a/src/control/cam_history.F90
+++ b/src/control/cam_history.F90
@@ -2818,7 +2818,18 @@ fincls: do while (f < pflds .and. fincl(f,t) /= ' ')
       do f=nflds(t)-1,1,-1
         do ff=1,f
 
-          if (tape(t)%hlist(ff)%field%name > tape(t)%hlist(ff+1)%field%name) then
+          if (tape(t)%hlist(ff)%field%numlev > tape(t)%hlist(ff+1)%field%numlev) then
+            tmp = tape(t)%hlist(ff)
+            tape(t)%hlist(ff  ) = tape(t)%hlist(ff+1)
+            tape(t)%hlist(ff+1) = tmp
+          end if
+
+        end do
+
+        do ff=1,f
+
+           if ((tape(t)%hlist(ff)%field%numlev == tape(t)%hlist(ff+1)%field%numlev) .and. &
+                (tape(t)%hlist(ff)%field%name > tape(t)%hlist(ff+1)%field%name)) then
 
             tmp = tape(t)%hlist(ff)
             tape(t)%hlist(ff  ) = tape(t)%hlist(ff+1)


### PR DESCRIPTION
Fixes issue #876 Significantly improves cam history write time.
Testing - 
I ran test PFS_P2160.ne30pg3_ne30pg3_mg17.FLTHIST_v0d.derecho_intel with 
user_nl_cam
`! Users should add all user specific namelist changes below in the form of 
! namelist_var = new_namelist_value 
mfilt=1,1,1,1,1,1
ndens=1,1,1,1,1,1
nhtfrq=-6,-6,-6,-6,-6,-6
`
And Environment variable:
`
MPICH_MPIIO_HINTS=*.nc:romio_cb_read=enable:romio_cb_write=enable:striping_factor=48:striping_unit=4194304
`

This resulted in:

Model Cost:            5659.69   pe-hrs/simulated_year 
Model Throughput:         9.23   simulated_years/day 
cam_run4_wrapup                                               2160   2160   961      70.6861     70.6560     384     70.8260     1885 

Using the original cam_history.F90:
Model Cost:            6360.07   pe-hrs/simulated_year 
Model Throughput:         8.21   simulated_years/day
 cam_run4_wrapup                                               2160   2160   961      108.8453    108.8224    1       108.8620    1921 
