### PR TITLE
part of cam6_3_129: Add derecho support to test_driver.

### DIFF
--- a/test/system/test_driver.sh
+++ b/test/system/test_driver.sh
@@ -321,7 +321,7 @@ cat > ${submit_script_cime} << EOF
 #PBS -N cime-tests
 #PBS -q $CAM_BATCHQ
 #PBS -A $CAM_ACCOUNT
-#PBS -l walltime=4:00:00
+#PBS -l walltime=$wallclock_limit
 #PBS -l select=1:ncpus=128:mpiprocs=128
 #PBS -j oe
 

--- a/test/system/test_driver.sh
+++ b/test/system/test_driver.sh
@@ -310,7 +310,7 @@ EOF
     # Check for CESM baseline directory
     if [ -n "${BL_TESTDIR}" ] && [ ! -d "${BL_TESTDIR}" ]; then
         echo "CESM_BASELINE ${BL_TESTDIR} not found.  Check BL_TESTDIR for correct tag name."
-        exit
+        exit 3
     fi
 
 #-------------------------------------------

--- a/test/system/test_driver.sh
+++ b/test/system/test_driver.sh
@@ -264,7 +264,7 @@ cat > ${submit_script_cime} << EOF
 #PBS -N cime-tests
 #PBS -q $CAM_BATCHQ
 #PBS -A $CAM_ACCOUNT
-#PBS -l walltime=4:00:00
+#PBS -l walltime=$wallclock_limit
 #PBS -l select=1:ncpus=36:mpiprocs=36
 #PBS -j oe
 #PBS -l inception=login
@@ -488,7 +488,7 @@ cat > ${submit_script_cime} << EOF
 #PBS -N cime-tests
 #PBS -q $CAM_BATCHQ
 #PBS -A $CAM_ACCOUNT
-#PBS -l walltime=2:00:00
+#PBS -l walltime=$wallclock_limit
 #PBS -l select=1:ncpus=36:mpiprocs=36:mem=300GB
 #PBS -j oe
 #PBS -V


### PR DESCRIPTION
I added support for running tests on derecho.  I set up the derecho tests to use the cheyenne test lists.  Once the transition to derecho is finished we can rename the cheyenne tests to derecho, and update test_driver.sh

I noticed that CAM_RESTART_TASKS and CAM_RESTART_THREADS aren't being used on cheyenne or derecho.  But I didn't want to remove them in case they are used.  There's still issues with with the PE layouts on derecho so several of the tests are failing.

Addresses: #875 

Here's a list of the aux_cam tests that were failing for me.


   `FAIL ERP_Ld3_Vnuopc.f09_f09_mg17.FWHIST.derecho_intel.cam-reduced_hist1d RUN time=2423
    FAIL ERP_Lh12_Vnuopc.f19_f19_mg17.FW4madSD.derecho_intel.cam-outfrq3h COMPARE_base_rest
    FAIL ERP_Ln9_P24x3_Vnuopc.f45_f45_mg37.QPWmaC6.derecho_intel.cam-outfrq9s_mee_fluxes COMPARE_base_rest
    FAIL ERP_Ln9_Vnuopc.C96_C96_mg17.F2000climo.derecho_intel.cam-outfrq9s_mg3 SHAREDLIB_BUILD failed to initialize
    FAIL ERP_Ln9_Vnuopc.f09_f09_mg17.F1850.derecho_intel.cam-outfrq9s COMPARE_base_rest
    FAIL ERP_Ln9_Vnuopc.f09_f09_mg17.F2000climo.derecho_intel.cam-outfrq9s COMPARE_base_rest
    FAIL ERP_Ln9_Vnuopc.f09_f09_mg17.F2000dev.derecho_intel.cam-outfrq9s_mg3 COMPARE_base_rest
    FAIL ERP_Ln9_Vnuopc.f09_f09_mg17.F2010climo.derecho_intel.cam-outfrq9s COMPARE_base_rest
    FAIL ERP_Ln9_Vnuopc.f09_f09_mg17.FCSD_HCO.derecho_intel.cam-outfrq9s RUN time=1217
    FAIL ERP_Ln9_Vnuopc.f09_f09_mg17.FHIST_BDRD.derecho_intel.cam-outfrq9s COMPARE_base_rest
    FAIL ERP_Ln9_Vnuopc.f19_f19_mg17.FWsc1850.derecho_intel.cam-outfrq9s COMPARE_base_rest
    FAIL ERP_Ln9_Vnuopc.ne30_ne30_mg17.FCnudged.derecho_intel.cam-outfrq9s COMPARE_base_rest
    FAIL ERP_Ln9_Vnuopc.ne30pg3_ne30pg3_mg17.FW2000climo.derecho_intel.cam-outfrq9s_wcm_ne30 RUN time=310
    FAIL ERS_Ld3_Vnuopc.f10_f10_mg37.F1850.derecho_intel.cam-outfrq1d_14dec_ghg_cam_dev RUN time=20
    FAIL ERS_Ln9_Vnuopc.f09_f09_mg17.FX2000.derecho_intel.cam-outfrq9s RUN time=1662
    FAIL ERS_Ln9_Vnuopc.ne0TESTONLYne5x4_ne0TESTONLYne5x4_mg37.FADIAB.derecho_intel.cam-outfrq3s_refined COMPARE_base_rest
    FAIL SMS_D_Ln9_Vnuopc.ne16_ne16_mg17.FX2000.derecho_intel.cam-outfrq9s RUN time=1223
    FAIL SMS_D_Ln9_Vnuopc_P720x1.ne0ARCTICne30x4_ne0ARCTICne30x4_mt12.FHIST.derecho_intel.cam-outfrq9s RUN time=31
    FAIL SMS_D_Ln9_Vnuopc_P720x1.ne0CONUSne30x8_ne0CONUSne30x8_mt12.FCHIST.derecho_intel.cam-outfrq9s RUN time=32
    FAIL SMS_Lh12_Vnuopc.f09_f09_mg17.FCSD_HCO.derecho_intel.cam-outfrq3h RUN time=1224
    FAIL SMS_Lm13_Vnuopc.f10_f10_mg37.F2000climo.derecho_intel.cam-outfrq1m RUN time=22`
