### PR TITLE
part of cam6_3_129: Update HEMCO-CESM external version to hemco-cesm1_2_1_hemco3_6_3_cesm

### DIFF
--- a/Externals_CAM.cfg
+++ b/Externals_CAM.cfg
@@ -78,7 +78,7 @@ required = True
 
 [hemco]
 local_path = src/hemco
-tag = hemco-cesm1_2_0_hemco3_6_2_cesm
+tag = hemco-cesm1_2_1_hemco3_6_3_cesm
 protocol = git
 repo_url = https://github.com/ESCOMP/HEMCO_CESM.git
 required = True


### PR DESCRIPTION
Derecho users have reported incompatibility with the nvhpc compiler by HEMCO source code due to an excessively long source line. Upstream HEMCO 3.6.3-cesm tag will fix this and is brought in by this PR through the HEMCO-CESM tag hemco-cesm1_2_1_hemco3_6_3_cesm.

No other changes including to known failures due to HEMCO are made in this release.

This is an expedited release of HEMCO solely to address the issue in https://github.com/ESCOMP/CAM/issues/871, as HEMCO 3.7.x with feature improvements is still pending release.

Thanks,
Haipeng

Closes #871