### PR TITLE
WACCMX-FV bug fix:convert wet species to dry before calling cam_thermo_dry_air_update

### DIFF
--- a/bld/namelist_files/namelist_definition.xml
+++ b/bld/namelist_files/namelist_definition.xml
@@ -7901,7 +7901,7 @@ If &lt; 0, se_sponge_del4_nu_fac is automatically set based on model top locatio
 Default: Set by build-namelist.
 </entry>
 
-<entry id="se_sponge_del4_nu_div_fac" type="integer" category="se"
+<entry id="se_sponge_del4_nu_div_fac" type="real" category="se"
        group="dyn_se_inparm" valid_values="" >
 Divergence damping hyperviscosity coefficient se_nu_div [m^4/s] for u,v is increased to
 se_nu_p*se_sponge_del4_nu_div_fac following a hyperbolic tangent function
@@ -7915,7 +7915,7 @@ If &lt; 0, se_sponge_del4_nu_div_fac is automatically set based on model top loc
 Default: Set by build-namelist.
 </entry>
 
-<entry id="se_sponge_del4_lev" type="real" category="se"
+<entry id="se_sponge_del4_lev" type="integer" category="se"
        group="dyn_se_inparm" valid_values="" >
 Level index around which increased del4 damping is centered.
 

--- a/src/dynamics/fv/dp_coupling.F90
+++ b/src/dynamics/fv/dp_coupling.F90
@@ -571,7 +571,12 @@ chnk_loop2 : &
              end if
           end do
        end do
-
+       !
+       ! Convert dry type constituents from moist to dry mixing ratio
+       ! (note: cam_thermo_dry_air_update assumes dry unless optianal conversion factor provided)
+       !
+       call set_state_pdry(phys_state(lchnk))    ! First get dry pressure to use for this timestepxxx
+       call set_wet_to_dry(phys_state(lchnk))    ! Dynamics had moist, physics wants dry. xxx
        if (dry_air_species_num>0) then
 !------------------------------------------------------------
 ! Apply limiters to mixing ratios of major species
@@ -607,11 +612,6 @@ chnk_loop2 : &
           end do
        end do
 
-!
-! Convert dry type constituents from moist to dry mixing ratio
-!
-       call set_state_pdry(phys_state(lchnk))    ! First get dry pressure to use for this timestep
-       call set_wet_to_dry(phys_state(lchnk))    ! Dynamics had moist, physics wants dry.
 !
 ! Ensure tracers are all positive
 !

--- a/src/dynamics/fv/dp_coupling.F90
+++ b/src/dynamics/fv/dp_coupling.F90
@@ -575,8 +575,8 @@ chnk_loop2 : &
        ! Convert dry type constituents from moist to dry mixing ratio
        ! (note: cam_thermo_dry_air_update assumes dry unless optianal conversion factor provided)
        !
-       call set_state_pdry(phys_state(lchnk))    ! First get dry pressure to use for this timestepxxx
-       call set_wet_to_dry(phys_state(lchnk))    ! Dynamics had moist, physics wants dry. xxx
+       call set_state_pdry(phys_state(lchnk))    ! First get dry pressure to use for this timestep
+       call set_wet_to_dry(phys_state(lchnk))    ! Dynamics had moist, physics wants dry
        if (dry_air_species_num>0) then
 !------------------------------------------------------------
 ! Apply limiters to mixing ratios of major species

--- a/src/dynamics/fv/dp_coupling.F90
+++ b/src/dynamics/fv/dp_coupling.F90
@@ -573,7 +573,7 @@ chnk_loop2 : &
        end do
        !
        ! Convert dry type constituents from moist to dry mixing ratio
-       ! (note: cam_thermo_dry_air_update assumes dry unless optianal conversion factor provided)
+       ! (note: cam_thermo_dry_air_update assumes dry unless optional conversion factor provided)
        !
        call set_state_pdry(phys_state(lchnk))    ! First get dry pressure to use for this timestep
        call set_wet_to_dry(phys_state(lchnk))    ! Dynamics had moist, physics wants dry

--- a/test/system/archive_baseline.sh
+++ b/test/system/archive_baseline.sh
@@ -103,6 +103,16 @@ case $hostname in
     baselinedir="/glade/p/cesm/amwg/cesm_baselines/$cam_tag"
   ;;
 
+  de*)
+    echo "server: derecho"
+    if [ -z "$CAM_FC" ]; then
+      CAM_FC="INTEL"
+    fi
+    test_file_list="tests_pretag_derecho"
+    cam_tag=$1
+    baselinedir="/glade/p/cesm/amwg/derecho_baselines/$cam_tag"
+  ;;
+
   * ) echo "ERROR: machine $hostname not currently supported"; exit 1 ;;
 esac
 


### PR DESCRIPTION
This PR corrects a bug introduced in cam6_3_109.  Physics requires constituents mixing ratios to be dry but was using constituent thermodynamic properties based on the wet mixing ratio returned by dynamics.  To fix this bug, the routine called to convert mixing ratios from wet to dry was moved further up in d_p_coupling so that it is called before the thermodynamic properties are calculated for physics. 

An additional fix to close issue #690 was added to correct namelist default types which are used to control the effect of the SE sponge layer. se_sponge_del4_nu_div_fac has been redefined from and integer to a real type as it controls real valued coefficient.  se_sponge_del4_lev was defined as a real but identifies a specific integer model level and has been redefined from a real to integer type.

closes #885
closes #690 
closes #893 