### PR TITLE
cam6_3_129:  Update externals to match cesm2_3_alpha16d and bring in test_driver which supports derecho

### DIFF
--- a/Externals.cfg
+++ b/Externals.cfg
@@ -1,5 +1,5 @@
 [ccs_config]
-tag = ccs_config_cesm0.0.73
+tag = ccs_config_cesm0.0.78
 protocol = git
 repo_url = https://github.com/ESMCI/ccs_config_cesm
 local_path = ccs_config
@@ -13,7 +13,7 @@ local_path = components/cice5
 required = True
 
 [cice6]
-tag = cesm_cice6_4_1_8
+tag = cesm_cice6_4_1_10
 protocol = git
 repo_url = https://github.com/ESCOMP/CESM_CICE
 local_path = components/cice
@@ -21,14 +21,14 @@ externals = Externals.cfg
 required = True
 
 [cmeps]
-tag = cmeps0.14.34
+tag = cmeps0.14.39
 protocol = git
 repo_url = https://github.com/ESCOMP/CMEPS.git
 local_path = components/cmeps
 required = True
 
 [cdeps]
-tag = cdeps1.0.14
+tag = cdeps1.0.21
 protocol = git
 repo_url = https://github.com/ESCOMP/CDEPS.git
 local_path = components/cdeps
@@ -36,7 +36,7 @@ externals =  Externals_CDEPS.cfg
 required = True
 
 [cpl7]
-tag = cpl77.0.5
+tag = cpl77.0.6
 protocol = git
 repo_url = https://github.com/ESCOMP/CESM_CPL7andDataComps
 local_path = components/cpl7
@@ -57,21 +57,21 @@ local_path = libraries/mct
 required = True
 
 [parallelio]
-tag = pio2_5_10
+tag = pio2_6_2
 protocol = git
 repo_url = https://github.com/NCAR/ParallelIO
 local_path = libraries/parallelio
 required = True
 
 [cime]
-tag = cime6.0.125
+tag = cime6.0.156
 protocol = git
 repo_url = https://github.com/ESMCI/cime
 local_path = cime
 required = True
 
 [cism]
-tag = cismwrap_2_1_95
+tag = cismwrap_2_1_96
 protocol = git
 repo_url = https://github.com/ESCOMP/CISM-wrapper
 local_path = components/cism
@@ -79,7 +79,7 @@ externals = Externals_CISM.cfg
 required = True
 
 [clm]
-tag = ctsm5.1.dev124
+tag = ctsm5.1.dev139
 protocol = git
 repo_url = https://github.com/ESCOMP/CTSM
 local_path = components/clm

--- a/Externals_CAM.cfg
+++ b/Externals_CAM.cfg
@@ -78,7 +78,7 @@ required = True
 
 [hemco]
 local_path = src/hemco
-tag = hemco-cesm1_2_0_hemco3_6_3_cesm
+tag = hemco-cesm1_2_1_hemco3_6_3_cesm
 protocol = git
 repo_url = https://github.com/ESCOMP/HEMCO_CESM.git
 required = True

--- a/Externals_CAM.cfg
+++ b/Externals_CAM.cfg
@@ -78,7 +78,7 @@ required = True
 
 [hemco]
 local_path = src/hemco
-tag = hemco-cesm1_2_0_hemco3_6_2_cesm
+tag = hemco-cesm1_2_0_hemco3_6_3_cesm
 protocol = git
 repo_url = https://github.com/ESCOMP/HEMCO_CESM.git
 required = True

--- a/cime_config/buildlib
+++ b/cime_config/buildlib
@@ -87,7 +87,7 @@ def _build_cam(caseroot, libroot, bldroot):
             shutil.move(filedst_tmp, filedst)
 
         # -------------------------------------------------------
-        # fms is needd by fv3 and should have been built by the framework
+        # fms is needed by fv3 and should have been built by the framework
         # -------------------------------------------------------
         libfms = os.path.join(fmsbuilddir, "libfms.a")
         expect(os.path.isfile(libfms),

--- a/cime_config/buildlib
+++ b/cime_config/buildlib
@@ -91,7 +91,7 @@ def _build_cam(caseroot, libroot, bldroot):
         # -------------------------------------------------------
         libfms = os.path.join(fmsbuilddir, "libfms.a")
         expect(os.path.isfile(libfms),
-           " Missing config_cache.xml - cannot run build-namelist")
+           "err: Missing the FMS library libfms.a - cannot complete CAM build")
         shutil.copy(libfms, libroot)
 
         # -------------------------------------------------------

--- a/cime_config/buildlib
+++ b/cime_config/buildlib
@@ -89,10 +89,11 @@ def _build_cam(caseroot, libroot, bldroot):
         # -------------------------------------------------------
         # fms is needed by fv3 and should have been built by the framework
         # -------------------------------------------------------
-        libfms = os.path.join(fmsbuilddir, "libfms.a")
-        expect(os.path.isfile(libfms),
-           "err: Missing the FMS library libfms.a - cannot complete CAM build")
-        shutil.copy(libfms, libroot)
+        if cam_dycore == "fv3":
+            libfms = os.path.join(fmsbuilddir, "libfms.a")
+            expect(os.path.isfile(libfms),
+               "err: Missing the FMS library libfms.a - cannot complete CAM build")
+            shutil.copy(libfms, libroot)
 
         # -------------------------------------------------------
         # build the library

--- a/cime_config/buildlib
+++ b/cime_config/buildlib
@@ -3,10 +3,11 @@
 """
 create the cam library
 """
-#pylint: disable=multiple-imports, wrong-import-position, wildcard-import
-#pylint: disable=unused-wildcard-import, bad-whitespace, too-many-locals
-#pylint: disable=invalid-name
+# pylint: disable=multiple-imports, wrong-import-position, wildcard-import
+# pylint: disable=unused-wildcard-import, bad-whitespace, too-many-locals
+# pylint: disable=invalid-name
 import sys, os, filecmp, shutil, imp
+
 
 _CIMEROOT = os.environ.get("CIMEROOT")
 if _CIMEROOT is None:
@@ -17,51 +18,27 @@ sys.path.append(_LIBDIR)
 
 from standard_script_setup import *
 from CIME.case import Case
-from CIME.utils import run_cmd, expect
+from CIME.utils import run_sub_or_cmd, expect, run_cmd
 from CIME.buildlib import parse_input
 from CIME.build import get_standard_makefile_args
 
 logger = logging.getLogger(__name__)
 
 ###############################################################################
-def _build_fms(caseroot, libroot, bldroot):
-###############################################################################
-
-    with Case(caseroot) as case:
-
-        # Only need FMS for fv3 dycore
-        cam_dycore = case.get_value("CAM_DYCORE")
-        if cam_dycore == 'fv3':
-            # Check to see if some other component built it already
-            if not os.path.exists(os.path.join(libroot,"libfms.a")):
-                # first check for the external FMS library and build it
-                srcroot = case.get_value("SRCROOT")
-                fmsbuildlib = os.path.join(srcroot,"libraries","FMS","buildlib")
-                fmsbuilddir = os.path.join(case.get_value("EXEROOT"),"FMS")
-                expect(os.path.exists(fmsbuildlib), "FMS external not found")
-                stat, _, err = run_cmd("{} {} {} {}".format(fmsbuildlib, case.get_value("EXEROOT"), fmsbuilddir, caseroot), verbose=True)
-                expect(stat==0, "FMS build Failed {}".format(err))
-                
-                libfms = os.path.join(bldroot,"FMS","libfms.a")
-                if os.path.exists(libfms):
-                    shutil.copy(libfms, libroot)
-
-###############################################################################
 def _build_cam(caseroot, libroot, bldroot):
-###############################################################################
+    ###############################################################################
 
     with Case(caseroot, read_only=False) as case:
 
         srcroot = case.get_value("SRCROOT")
-        #-------------------------------------------------------
+        # -------------------------------------------------------
         # Call cam's buildcpp
-        #-------------------------------------------------------
+        # -------------------------------------------------------
         testpath = os.path.join(srcroot, "components", "cam")
         if os.path.exists(testpath):
             srcroot = testpath
 
-        cmd = os.path.join(os.path.join(srcroot,
-                                        "cime_config", "buildcpp"))
+        cmd = os.path.join(os.path.join(srcroot, "cime_config", "buildcpp"))
         logger.info("     ...calling cam buildcpp to set build time options")
         try:
             mod = imp.load_source("buildcpp", cmd)
@@ -76,16 +53,32 @@ def _build_cam(caseroot, libroot, bldroot):
         gmake_j = case.get_value("GMAKE_J")
         gmake = case.get_value("GMAKE")
         mach = case.get_value("MACH")
+        user_incldir = None
+        cam_dycore = case.get_value("CAM_DYCORE")
+        if cam_dycore == "fv3":
+            slr = os.path.abspath(case.get_value("SHAREDLIBROOT"))
+            compiler = case.get_value("COMPILER")
+            mpilib = case.get_value("MPILIB")
+            debug = "debug" if case.get_value("DEBUG") else "nodebug"
+            threaded = "threads" if case.get_value("BUILD_THREADED") else "nothreads"
+            comp_interface = case.get_value("COMP_INTERFACE")
+            fmsbuilddir = os.path.join(
+                slr, compiler, mpilib, debug, threaded, comp_interface)
+            user_incldir = '"-I{} -I{} -I{}"'.format(
+                os.path.join(srcroot, "libraries", "FMS", "src", "include"),
+                os.path.join(srcroot, "libraries", "FMS", "src", "mpp", "include"),
+                fmsbuilddir,
+            )
 
-        #-------------------------------------------------------
+        # -------------------------------------------------------
         # Filepath is created in caseroot/camconf by the call
         # to buildcpp - this needs to be copied to bldroot
-        #-------------------------------------------------------
+        # -------------------------------------------------------
         filesrc = os.path.join(caseroot, "Buildconf", "camconf", "Filepath")
         filedst = os.path.join(bldroot, "Filepath_tmp")
         shutil.copy(filesrc, filedst)
 
-        filedst     = os.path.join(bldroot, "Filepath")
+        filedst = os.path.join(bldroot, "Filepath")
         filedst_tmp = os.path.join(bldroot, "Filepath_tmp")
         if os.path.isfile(filedst):
             if not filecmp.cmp(filedst_tmp, filedst):
@@ -93,27 +86,41 @@ def _build_cam(caseroot, libroot, bldroot):
         else:
             shutil.move(filedst_tmp, filedst)
 
-        #-------------------------------------------------------
+        # -------------------------------------------------------
+        # fms is needd by fv3 and should have been built by the framework
+        # -------------------------------------------------------
+        libfms = os.path.join(fmsbuilddir, "libfms.a")
+        expect(os.path.isfile(libfms),
+           " Missing config_cache.xml - cannot run build-namelist")
+        shutil.copy(libfms, libroot)
+
+        # -------------------------------------------------------
         # build the library
-        #-------------------------------------------------------
-        complib  = os.path.join(libroot, "libatm.a")
+        # -------------------------------------------------------
+        complib = os.path.join(libroot, "libatm.a")
         makefile = os.path.join(casetools, "Makefile")
 
-        cmd = "{} complib -j {} COMP_NAME=cam COMPLIB={} -f {} {} " \
-            .format(gmake, gmake_j, complib, makefile, get_standard_makefile_args(case))
+        cmd = "{} complib -j {} COMP_NAME=cam COMPLIB={} -f {} {} ".format(
+            gmake, gmake_j, complib, makefile, get_standard_makefile_args(case)
+        )
         if cam_cppdefs:
             cmd += " USER_CPPDEFS='{}'".format(cam_cppdefs)
+
+        if user_incldir:
+            cmd += " USER_INCLDIR={}".format(user_incldir)
 
         rc, out, err = run_cmd(cmd)
         logger.info("%s: \n\n output:\n %s \n\n err:\n\n%s\n", cmd, out, err)
         expect(rc == 0, "Command %s failed with rc=%s" % (cmd, rc))
 
+
 ###############################################################################
+
 
 def _main_func():
     caseroot, libroot, bldroot = parse_input(sys.argv)
-    _build_fms(caseroot, libroot, bldroot)
     _build_cam(caseroot, libroot, bldroot)
+
 
 ###############################################################################
 

--- a/test/system/test_driver.sh
+++ b/test/system/test_driver.sh
@@ -619,7 +619,7 @@ if [ "${cesm_test_suite}" != "none" -a -n "${cesm_test_mach}" ]; then
           testargs="${testargs} --queue ${CAM_BATCHQ} --test-root ${cesm_testdir} --output-root ${cesm_testdir}"
           ;;
         # derecho
-        derc* | dec* )
+        derec* | dec* )
           testargs="${testargs} --queue ${CAM_BATCHQ} --test-root ${cesm_testdir} --output-root ${cesm_testdir}"
           ;;
         # casper

--- a/test/system/test_driver.sh
+++ b/test/system/test_driver.sh
@@ -525,7 +525,7 @@ if [ -n "${CAM_FC}" ]; then
 fi
 
 if [ "${cesm_test_suite}" != "none" -a -n "${cesm_test_mach}" ]; then
-  if [ "${hostname:0:5}" != "izumi" ]; then
+  if [ "${hostname:0:5}" != "izumi" ] && [ "${hostname:0:7}" != "derecho" ]; then
     module load python
   fi
 
@@ -704,7 +704,6 @@ if [ "${cesm_test_suite}" != "none" -a -n "${cesm_test_mach}" ]; then
 
     if [ "${hostname:0:2}" == "de" ]; then
       echo "cd ${script_dir}" >> ${submit_script_cime}
-      echo "module load python" >> ${submit_script_cime}
       echo './create_test' ${testargs} >> ${submit_script_cime}
       chmod u+x ${submit_script_cime}
       qsub ${submit_script_cime}


### PR DESCRIPTION
Closes #879 (test_driver.sh supports derecho)
Closes #886 (fix line too long in HEMCO external)

Updates externals to match cesm2_3_alpha16d (except ccs_config is newer)

Limited review as reviews were performed in #884 before it was broken into a more limited PR