### PR TITLE
part of cam6_3_130: Changes to archive_baselines to store derecho baselines

### DIFF
--- a/test/system/archive_baseline.sh
+++ b/test/system/archive_baseline.sh
@@ -103,6 +103,16 @@ case $hostname in
     baselinedir="/glade/p/cesm/amwg/cesm_baselines/$cam_tag"
   ;;
 
+  de*)
+    echo "server: derecho"
+    if [ -z "$CAM_FC" ]; then
+      CAM_FC="INTEL"
+    fi
+    test_file_list="tests_pretag_derecho"
+    cam_tag=$1
+    baselinedir="/glade/p/cesm/amwg/derecho_baselines/$cam_tag"
+  ;;
+
   * ) echo "ERROR: machine $hostname not currently supported"; exit 1 ;;
 esac
 


### PR DESCRIPTION
Tested with baselines generated with cam6_3_129 and appears to have worked properly.

Closes #893
