### PR TITLE
cam6_3_133: Hybrid PGF option in the SE dycore for WACCM-x and other misc updates

### DIFF
--- a/bld/namelist_files/namelist_defaults_cam.xml
+++ b/bld/namelist_files/namelist_defaults_cam.xml
@@ -167,6 +167,7 @@
 <ncdata dyn="se"  hgrid="ne16np4"   nlev="126" waccmx="1" aquaplanet="1">atm/waccm/ic/waccmx_aqua_ne16np4_126L_c191108.nc</ncdata>
 <ncdata dyn="se"  hgrid="ne16np4"   nlev="126" waccmx="1" aquaplanet="1" ionosphere="none">atm/waccm/ic/waccmx4_neutral_aquap_ne16np4_126lev_c200827.nc</ncdata>
 <ncdata dyn="se"  hgrid="ne30np4"   nlev="130" waccmx="1"               >atm/waccm/ic/fx2000_phys-ionos-cpl_ne30_spinup01.cam.i.0002-01-01-00000_c201014.nc</ncdata>
+<ncdata dyn="se"  hgrid="ne30np4" npg="3" nlev="130" waccmx="1"         >atm/waccm/ic/waccmx_ne30pg3_c231005.nc</ncdata>
 
 <ncdata dyn="fv3"   hgrid="C24"  nlev="32"  aquaplanet="1"  ic_ymd="101" >atm/cam/inic/fv3/aqua_0006-01-01_C24_L32_c200625.nc</ncdata>
 <ncdata dyn="fv3"   hgrid="C48"  nlev="32"  aquaplanet="1"  ic_ymd="101" >atm/cam/inic/fv3/aqua_0006-01-01_C48_L32_c200625.nc</ncdata>
@@ -3016,7 +3017,7 @@
 <!-- ================================================================== -->
 
 <se_pgf_formulation>           1</se_pgf_formulation>
-<se_pgf_formulation waccmx="1">2</se_pgf_formulation>
+<se_pgf_formulation waccmx="1">3</se_pgf_formulation>
 <se_ftype> 2 </se_ftype>
 
 <se_large_Courant_incr        > .true.  </se_large_Courant_incr>

--- a/bld/namelist_files/namelist_definition.xml
+++ b/bld/namelist_files/namelist_definition.xml
@@ -7901,7 +7901,7 @@ If &lt; 0, se_sponge_del4_nu_fac is automatically set based on model top locatio
 Default: Set by build-namelist.
 </entry>
 
-<entry id="se_sponge_del4_nu_div_fac" type="integer" category="se"
+<entry id="se_sponge_del4_nu_div_fac" type="real" category="se"
        group="dyn_se_inparm" valid_values="" >
 Divergence damping hyperviscosity coefficient se_nu_div [m^4/s] for u,v is increased to
 se_nu_p*se_sponge_del4_nu_div_fac following a hyperbolic tangent function
@@ -7915,7 +7915,7 @@ If &lt; 0, se_sponge_del4_nu_div_fac is automatically set based on model top loc
 Default: Set by build-namelist.
 </entry>
 
-<entry id="se_sponge_del4_lev" type="real" category="se"
+<entry id="se_sponge_del4_lev" type="integer" category="se"
        group="dyn_se_inparm" valid_values="" >
 Level index around which increased del4 damping is centered.
 
@@ -8150,12 +8150,16 @@ Default: Set by build-namelist.
 </entry>
 
 <entry id="se_pgf_formulation" type="integer" category="se"
-       group="dyn_se_inparm" valid_values="1,2" >
+       group="dyn_se_inparm" valid_values="1,2,3" >
 
   1: Exner version of pressure gradient force (PGF)
   see Appendix A in https://agupubs.onlinelibrary.wiley.com/doi/epdf/10.1029/2022MS003192
 
   2: Traditional pressure gradient formulation (grad p)
+
+  3: Hybrid (formulation 1 where hybm>0 else formulation 2)
+     Use hybrid PGF option for WACCM-x to make WACCM-x consistent with PGF
+     used in CAM in the troposphere and traditional PGF formulation above
 
   Default: Set by build-namelist.
 </entry>

--- a/cime_config/config_pes.xml
+++ b/cime_config/config_pes.xml
@@ -293,6 +293,27 @@
 	</rootpe>
       </pes>
     </mach>
+    <mach name="derecho">
+      <pes pesize="any" compset="_CAM\d0%WX">
+	<comment>none</comment>
+	<ntasks>
+	  <ntasks_atm>-4</ntasks_atm>
+	  <ntasks_lnd>-4</ntasks_lnd>
+	  <ntasks_rof>-4</ntasks_rof>
+	  <ntasks_ice>-4</ntasks_ice>
+	  <ntasks_ocn>-4</ntasks_ocn>
+	  <ntasks_cpl>-4</ntasks_cpl>
+	</ntasks>
+	<nthrds>
+	  <nthrds_atm>1</nthrds_atm>
+	  <nthrds_lnd>1</nthrds_lnd>
+	  <nthrds_rof>1</nthrds_rof>
+	  <nthrds_ice>1</nthrds_ice>
+	  <nthrds_ocn>1</nthrds_ocn>
+	  <nthrds_cpl>1</nthrds_cpl>
+	</nthrds>
+      </pes>
+    </mach>
   </grid>
   <grid name="a%ne30" >
     <mach name="cheyenne">
@@ -328,6 +349,46 @@
 	  <rootpe_wav>0</rootpe_wav>
 	  <rootpe_cpl>0</rootpe_cpl>
 	</rootpe>
+      </pes>
+    </mach>
+    <mach name="derecho">
+      <pes pesize="any" compset="_CAM\d0%WX">
+	<comment>none</comment>
+	<ntasks>
+	  <ntasks_atm>-16</ntasks_atm>
+	  <ntasks_lnd>-16</ntasks_lnd>
+	  <ntasks_rof>-16</ntasks_rof>
+	  <ntasks_ice>-16</ntasks_ice>
+	  <ntasks_ocn>-16</ntasks_ocn>
+	  <ntasks_cpl>-16</ntasks_cpl>
+	</ntasks>
+	<nthrds>
+	  <nthrds_atm>1</nthrds_atm>
+	  <nthrds_lnd>1</nthrds_lnd>
+	  <nthrds_rof>1</nthrds_rof>
+	  <nthrds_ice>1</nthrds_ice>
+	  <nthrds_ocn>1</nthrds_ocn>
+	  <nthrds_cpl>1</nthrds_cpl>
+	</nthrds>
+      </pes>
+      <pes pesize="any" compset="_CAM%DEV%MT%CC">
+	<comment>none</comment>
+	<ntasks>
+	  <ntasks_atm>-8</ntasks_atm>
+	  <ntasks_lnd>-8</ntasks_lnd>
+	  <ntasks_rof>-8</ntasks_rof>
+	  <ntasks_ice>-8</ntasks_ice>
+	  <ntasks_ocn>-8</ntasks_ocn>
+	  <ntasks_cpl>-8</ntasks_cpl>
+	</ntasks>
+	<nthrds>
+	  <nthrds_atm>1</nthrds_atm>
+	  <nthrds_lnd>1</nthrds_lnd>
+	  <nthrds_rof>1</nthrds_rof>
+	  <nthrds_ice>1</nthrds_ice>
+	  <nthrds_ocn>1</nthrds_ocn>
+	  <nthrds_cpl>1</nthrds_cpl>
+	</nthrds>
       </pes>
     </mach>
   </grid>
@@ -1105,6 +1166,27 @@
 	</rootpe>
       </pes>
     </mach>
+    <mach name="derecho">
+      <pes pesize="any" compset="_CAM\d0%WX">
+	<comment>none</comment>
+	<ntasks>
+	  <ntasks_atm>-8</ntasks_atm>
+	  <ntasks_lnd>-8</ntasks_lnd>
+	  <ntasks_rof>-8</ntasks_rof>
+	  <ntasks_ice>-8</ntasks_ice>
+	  <ntasks_ocn>-8</ntasks_ocn>
+	  <ntasks_cpl>-8</ntasks_cpl>
+	</ntasks>
+	<nthrds>
+	  <nthrds_atm>1</nthrds_atm>
+	  <nthrds_lnd>1</nthrds_lnd>
+	  <nthrds_rof>1</nthrds_rof>
+	  <nthrds_ice>1</nthrds_ice>
+	  <nthrds_ocn>1</nthrds_ocn>
+	  <nthrds_cpl>1</nthrds_cpl>
+	</nthrds>
+      </pes>
+    </mach>
   </grid>
 
   <grid name="a%0.9x1.25">
@@ -1209,6 +1291,27 @@
 	  <rootpe_ocn>0</rootpe_ocn>
 	  <rootpe_cpl>0</rootpe_cpl>
 	</rootpe>
+      </pes>
+    </mach>
+    <mach name="derecho">
+      <pes pesize="any" compset="_(CAM50|CAM60)%(CC|CV|CF|WC)">
+	<comment>none</comment>
+	<ntasks>
+	  <ntasks_atm>-8</ntasks_atm>
+	  <ntasks_lnd>-8</ntasks_lnd>
+	  <ntasks_rof>-8</ntasks_rof>
+	  <ntasks_ice>-8</ntasks_ice>
+	  <ntasks_ocn>-8</ntasks_ocn>
+	  <ntasks_cpl>-8</ntasks_cpl>
+	</ntasks>
+	<nthrds>
+	  <nthrds_atm>1</nthrds_atm>
+	  <nthrds_lnd>1</nthrds_lnd>
+	  <nthrds_rof>1</nthrds_rof>
+	  <nthrds_ice>1</nthrds_ice>
+	  <nthrds_ocn>1</nthrds_ocn>
+	  <nthrds_cpl>1</nthrds_cpl>
+	</nthrds>
       </pes>
     </mach>
   </grid>

--- a/cime_config/testdefs/testlist_cam.xml
+++ b/cime_config/testdefs/testlist_cam.xml
@@ -1622,6 +1622,7 @@
   <test compset="FCnudged" grid="ne30_ne30_mg17" name="ERP_Ln9_Vnuopc" testmods="cam/outfrq9s">
     <machines>
       <machine name="cheyenne" compiler="intel" category="aux_cam"/>
+      <machine name="derecho" compiler="intel" category="aux_cam"/>
       <machine name="cheyenne" compiler="intel" category="camchem"/>
     </machines>
     <options>
@@ -1775,6 +1776,7 @@
   <test compset="FCts2SD" grid="f09_f09_mg17" name="SMS_D_Ln9_Vnuopc" testmods="cam/outfrq9s">
     <machines>
       <machine name="cheyenne" compiler="intel" category="camchem"/>
+      <machine name="derecho" compiler="intel" category="aux_cam"/>
       <machine name="cheyenne" compiler="intel" category="prealpha"/>
     </machines>
     <options>
@@ -1844,6 +1846,7 @@
     <machines>
       <machine name="cheyenne" compiler="intel" category="prebeta"/>
       <machine name="cheyenne" compiler="intel" category="camchem"/>
+      <machine name="derecho" compiler="intel" category="aux_cam"/>
     </machines>
   </test>
   <test compset="FCHIST" grid="f09_f09_mg17" name="SMS_D_Ln9_Vnuopc" testmods="cam/outfrq9s_ocnemis">
@@ -1864,6 +1867,16 @@
     <machines>
       <machine name="cheyenne" compiler="intel" category="aux_cam"/>
       <machine name="cheyenne" compiler="intel" category="camchem"/>
+    </machines>
+    <options>
+      <option name="wallclock">00:30:00</option>
+      <option name="comment">"Free running CAM-Chem on a reginally refined grid"</option>
+    </options>
+  </test>
+  <test compset="FCHIST" grid="ne0CONUSne30x8_ne0CONUSne30x8_mt12" name="SMS_D_Ln9_P1024x1" testmods="cam/outfrq9s">
+    <machines>
+      <machine name="derecho" compiler="intel" category="aux_cam"/>
+      <machine name="derecho" compiler="intel" category="camchem"/>
     </machines>
     <options>
       <option name="wallclock">00:30:00</option>
@@ -1913,6 +1926,7 @@
   <test compset="FCSD_HCO" grid="f09_f09_mg17" name="SMS_Lh12_Vnuopc" testmods="cam/outfrq3h" supported="false">
     <machines>
       <machine name="cheyenne" compiler="intel" category="aux_cam"/>
+      <machine name="derecho" compiler="intel" category="aux_cam"/>
       <machine name="cheyenne" compiler="intel" category="camchem_hco"/>
     </machines>
     <options>
@@ -1932,6 +1946,7 @@
   <test compset="FCSD_HCO" grid="f09_f09_mg17" name="ERP_Ln9_Vnuopc" testmods="cam/outfrq9s" supported="false">
     <machines>
       <machine name="cheyenne" compiler="intel" category="aux_cam"/>
+      <machine name="derecho" compiler="intel" category="aux_cam"/>
       <machine name="cheyenne" compiler="intel" category="camchem_hco"/>
     </machines>
     <options>
@@ -2159,6 +2174,7 @@
   <test compset="FCLTHIST" grid="ne30pg3_ne30pg3_mg17" name="SMS_D_Ln9_Vnuopc_P720x1" testmods="cam/outfrq9s">
     <machines>
       <machine name="cheyenne" compiler="intel" category="aux_cam"/>
+      <machine name="derecho" compiler="intel" category="aux_cam"/>
       <machine name="cheyenne" compiler="intel" category="camchem"/>
     </machines>
     <options>
@@ -2169,6 +2185,7 @@
   <test compset="FCMTHIST" grid="ne30pg3_ne30pg3_mg17" name="SMS_D_Ln9_Vnuopc" testmods="cam/outfrq9s">
     <machines>
       <machine name="cheyenne" compiler="intel" category="camchem"/>
+      <machine name="derecho" compiler="intel" category="aux_cam"/>
     </machines>
     <options>
       <option name="wallclock">00:40:00</option>
@@ -2296,6 +2313,7 @@
   <test compset="FWHIST" grid="f09_f09_mg17" name="ERP_Ld3_Vnuopc" testmods="cam/reduced_hist1d">
     <machines>
       <machine name="cheyenne" compiler="intel" category="aux_cam"/>
+      <machine name="derecho" compiler="intel" category="aux_cam"/>
     </machines>
     <options>
       <option name="wallclock">00:40:00</option>
@@ -2322,6 +2340,7 @@
     <machines>
       <machine name="cheyenne" compiler="intel" category="waccmx"/>
       <machine name="cheyenne" compiler="intel" category="aux_cam"/>
+      <machine name="derecho" compiler="intel" category="aux_cam"/>
     </machines>
     <options>
       <option name="wallclock">00:20:00</option>
@@ -2331,6 +2350,7 @@
     <machines>
       <machine name="cheyenne" compiler="intel" category="waccmx"/>
       <machine name="cheyenne" compiler="intel" category="aux_cam"/>
+      <machine name="derecho" compiler="intel" category="aux_cam"/>
     </machines>
     <options>
       <option name="wallclock">00:30:00</option>
@@ -2340,6 +2360,7 @@
     <machines>
       <machine name="cheyenne" compiler="intel" category="waccmx"/>
       <machine name="cheyenne" compiler="intel" category="aux_cam"/>
+      <machine name="derecho" compiler="intel" category="aux_cam"/>
     </machines>
     <options>
       <option name="wallclock">00:10:00</option>
@@ -2696,6 +2717,15 @@
     <machines>
       <machine name="cheyenne" compiler="intel" category="camchem"/>
       <machine name="cheyenne" compiler="intel" category="prealpha"/>
+    </machines>
+    <options>
+      <option name="wallclock">00:20:00</option>
+      <option name="comment" >CAMChem MAM4</option>
+    </options>
+  </test>
+  <test compset="FC2000climo" grid="f19_f19_mg17" name="SMS_D_Ln9" testmods="cam/outfrq9s_camchem_mam4">
+    <machines>
+      <machine name="derecho" compiler="intel" category="aux_cam"/>
     </machines>
     <options>
       <option name="wallclock">00:20:00</option>

--- a/cime_config/testdefs/testlist_cam.xml
+++ b/cime_config/testdefs/testlist_cam.xml
@@ -1622,7 +1622,6 @@
   <test compset="FCnudged" grid="ne30_ne30_mg17" name="ERP_Ln9_Vnuopc" testmods="cam/outfrq9s">
     <machines>
       <machine name="cheyenne" compiler="intel" category="aux_cam"/>
-      <machine name="derecho" compiler="intel" category="aux_cam"/>
       <machine name="cheyenne" compiler="intel" category="camchem"/>
     </machines>
     <options>
@@ -1776,7 +1775,6 @@
   <test compset="FCts2SD" grid="f09_f09_mg17" name="SMS_D_Ln9_Vnuopc" testmods="cam/outfrq9s">
     <machines>
       <machine name="cheyenne" compiler="intel" category="camchem"/>
-      <machine name="derecho" compiler="intel" category="aux_cam"/>
       <machine name="cheyenne" compiler="intel" category="prealpha"/>
     </machines>
     <options>
@@ -1846,7 +1844,6 @@
     <machines>
       <machine name="cheyenne" compiler="intel" category="prebeta"/>
       <machine name="cheyenne" compiler="intel" category="camchem"/>
-      <machine name="derecho" compiler="intel" category="aux_cam"/>
     </machines>
   </test>
   <test compset="FCHIST" grid="f09_f09_mg17" name="SMS_D_Ln9_Vnuopc" testmods="cam/outfrq9s_ocnemis">
@@ -1867,16 +1864,6 @@
     <machines>
       <machine name="cheyenne" compiler="intel" category="aux_cam"/>
       <machine name="cheyenne" compiler="intel" category="camchem"/>
-    </machines>
-    <options>
-      <option name="wallclock">00:30:00</option>
-      <option name="comment">"Free running CAM-Chem on a reginally refined grid"</option>
-    </options>
-  </test>
-  <test compset="FCHIST" grid="ne0CONUSne30x8_ne0CONUSne30x8_mt12" name="SMS_D_Ln9_P1024x1" testmods="cam/outfrq9s">
-    <machines>
-      <machine name="derecho" compiler="intel" category="aux_cam"/>
-      <machine name="derecho" compiler="intel" category="camchem"/>
     </machines>
     <options>
       <option name="wallclock">00:30:00</option>
@@ -1926,7 +1913,6 @@
   <test compset="FCSD_HCO" grid="f09_f09_mg17" name="SMS_Lh12_Vnuopc" testmods="cam/outfrq3h" supported="false">
     <machines>
       <machine name="cheyenne" compiler="intel" category="aux_cam"/>
-      <machine name="derecho" compiler="intel" category="aux_cam"/>
       <machine name="cheyenne" compiler="intel" category="camchem_hco"/>
     </machines>
     <options>
@@ -1946,7 +1932,6 @@
   <test compset="FCSD_HCO" grid="f09_f09_mg17" name="ERP_Ln9_Vnuopc" testmods="cam/outfrq9s" supported="false">
     <machines>
       <machine name="cheyenne" compiler="intel" category="aux_cam"/>
-      <machine name="derecho" compiler="intel" category="aux_cam"/>
       <machine name="cheyenne" compiler="intel" category="camchem_hco"/>
     </machines>
     <options>
@@ -2174,7 +2159,6 @@
   <test compset="FCLTHIST" grid="ne30pg3_ne30pg3_mg17" name="SMS_D_Ln9_Vnuopc_P720x1" testmods="cam/outfrq9s">
     <machines>
       <machine name="cheyenne" compiler="intel" category="aux_cam"/>
-      <machine name="derecho" compiler="intel" category="aux_cam"/>
       <machine name="cheyenne" compiler="intel" category="camchem"/>
     </machines>
     <options>
@@ -2185,7 +2169,6 @@
   <test compset="FCMTHIST" grid="ne30pg3_ne30pg3_mg17" name="SMS_D_Ln9_Vnuopc" testmods="cam/outfrq9s">
     <machines>
       <machine name="cheyenne" compiler="intel" category="camchem"/>
-      <machine name="derecho" compiler="intel" category="aux_cam"/>
     </machines>
     <options>
       <option name="wallclock">00:40:00</option>
@@ -2313,7 +2296,6 @@
   <test compset="FWHIST" grid="f09_f09_mg17" name="ERP_Ld3_Vnuopc" testmods="cam/reduced_hist1d">
     <machines>
       <machine name="cheyenne" compiler="intel" category="aux_cam"/>
-      <machine name="derecho" compiler="intel" category="aux_cam"/>
     </machines>
     <options>
       <option name="wallclock">00:40:00</option>
@@ -2340,7 +2322,6 @@
     <machines>
       <machine name="cheyenne" compiler="intel" category="waccmx"/>
       <machine name="cheyenne" compiler="intel" category="aux_cam"/>
-      <machine name="derecho" compiler="intel" category="aux_cam"/>
     </machines>
     <options>
       <option name="wallclock">00:20:00</option>
@@ -2350,7 +2331,6 @@
     <machines>
       <machine name="cheyenne" compiler="intel" category="waccmx"/>
       <machine name="cheyenne" compiler="intel" category="aux_cam"/>
-      <machine name="derecho" compiler="intel" category="aux_cam"/>
     </machines>
     <options>
       <option name="wallclock">00:30:00</option>
@@ -2360,7 +2340,6 @@
     <machines>
       <machine name="cheyenne" compiler="intel" category="waccmx"/>
       <machine name="cheyenne" compiler="intel" category="aux_cam"/>
-      <machine name="derecho" compiler="intel" category="aux_cam"/>
     </machines>
     <options>
       <option name="wallclock">00:10:00</option>
@@ -2717,15 +2696,6 @@
     <machines>
       <machine name="cheyenne" compiler="intel" category="camchem"/>
       <machine name="cheyenne" compiler="intel" category="prealpha"/>
-    </machines>
-    <options>
-      <option name="wallclock">00:20:00</option>
-      <option name="comment" >CAMChem MAM4</option>
-    </options>
-  </test>
-  <test compset="FC2000climo" grid="f19_f19_mg17" name="SMS_D_Ln9" testmods="cam/outfrq9s_camchem_mam4">
-    <machines>
-      <machine name="derecho" compiler="intel" category="aux_cam"/>
     </machines>
     <options>
       <option name="wallclock">00:20:00</option>

--- a/src/control/cam_history.F90
+++ b/src/control/cam_history.F90
@@ -1747,7 +1747,8 @@ CONTAINS
       ierr = pio_put_var(File, mdimname_desc, start, hist_coord_name(f))
     end do
 
-    deallocate(xyfill, allmdims)
+    deallocate(xyfill, allmdims, is_subcol, interp_output, restarthistory_tape)
+
     return
 
   end subroutine write_restart_history
@@ -5019,19 +5020,19 @@ end subroutine print_active_fldlst
     !
     type (dim_index_2d)     :: dimind    ! 2-D dimension index
     integer                 :: ie        ! dim3 index
-    integer                 :: count     ! tmp index 
+    integer                 :: count     ! tmp index
     integer                 :: i1        ! dim1 index
     integer                 :: j1        ! dim2 index
     integer                 :: fdims(3)  ! array shape
-    integer                 :: begdim1,enddim1,begdim2,enddim2,begdim3,enddim3        ! 
+    integer                 :: begdim1,enddim1,begdim2,enddim2,begdim3,enddim3        !
     real(r8)                :: globalsum(1) ! globalsum
     real(r8), allocatable   :: globalarr(:) ! globalarr values for this pe
-        
+
     call t_startf ('h_global')
 
     ! wbuf contains the area weighting for this field decomposition
     if (associated(tape(t)%hlist(f)%wbuf) ) then
-       
+
        begdim1    =  tape(t)%hlist(f)%field%begdim1
        enddim1    =  tape(t)%hlist(f)%field%enddim1
        fdims(1)   =  enddim1 - begdim1 + 1
@@ -5041,7 +5042,7 @@ end subroutine print_active_fldlst
        begdim3    =  tape(t)%hlist(f)%field%begdim3
        enddim3    =  tape(t)%hlist(f)%field%enddim3
        fdims(3)   =  enddim3 - begdim3 + 1
-       
+
        allocate(globalarr(fdims(1)*fdims(2)*fdims(3)))
        count=0
        globalarr=0._r8
@@ -5098,7 +5099,7 @@ end subroutine print_active_fldlst
 
     do c = begdim3, enddim3
       dimind = tape(t)%hlist(f)%field%get_dims(c)
-      if (trim(optype) == 'dif') then 
+      if (trim(optype) == 'dif') then
          tape(t)%hlist(f)%hbuf(dimind%beg1:dimind%end1,dimind%beg2:dimind%end2,c) = &
          tape(t)%hlist(f1)%hbuf(dimind%beg1:dimind%end1,dimind%beg2:dimind%end2,c) - &
          tape(t)%hlist(f2)%hbuf(dimind%beg1:dimind%end1,dimind%beg2:dimind%end2,c)
@@ -5592,7 +5593,7 @@ end subroutine print_active_fldlst
           if(.not. restart) then
              !$OMP PARALLEL DO PRIVATE (F)
              do f=1,nflds(t)
-                ! Normalize all non composed fields, composed fields are calculated next using the normalized components 
+                ! Normalize all non composed fields, composed fields are calculated next using the normalized components
                 if (tape(t)%hlist(f)%avgflag /= 'I'.and..not.tape(t)%hlist(f)%field%is_composed()) then
                    call h_normalize (f, t)
                 end if
@@ -5916,7 +5917,7 @@ end subroutine print_active_fldlst
 
     if (present(optype)) then
        ! make sure optype is "sum" or "dif"
-       if (.not.(trim(optype) == 'dif' .or. trim(optype) == 'sum')) then 
+       if (.not.(trim(optype) == 'dif' .or. trim(optype) == 'sum')) then
           write(errormsg, '(2a)')': Fatal : optype must be "sum" or "dif" not ',trim(optype)
           call endrun (trim(subname)//errormsg)
        end if

--- a/src/dynamics/se/dycore/global_norms_mod.F90
+++ b/src/dynamics/se/dycore/global_norms_mod.F90
@@ -737,9 +737,12 @@ contains
     !
     if (ptop>100.0_r8) then
       umax = 120.0_r8
-    else
+    else if (ptop>10.0_r8) then
       umax = 400.0_r8
+    else
+      umax = 800.0_r8
     end if
+
     ugw = 342.0_r8 !max gravity wave speed
 
     dt_max_adv             = S_rk/(umax*max_normDinv*lambda_max*ra)

--- a/src/dynamics/se/dycore/prim_advance_mod.F90
+++ b/src/dynamics/se/dycore/prim_advance_mod.F90
@@ -930,7 +930,7 @@ contains
             !OMP_COLLAPSE_SIMD
             !DIR_VECTOR_ALIGNED
             do j=1,np
-              do i=1,np                
+              do i=1,np
                 v1new=elem(ie)%state%v(i,j,1,k,nt)
                 v2new=elem(ie)%state%v(i,j,2,k,nt)
                 v1   =elem(ie)%state%v(i,j,1,k,nt)- vtens(i,j,1,k,ie)
@@ -1214,7 +1214,7 @@ contains
            pgf_term(:,:,1)  = density_inv(:,:)*grad_p_full(:,:,1,k)
            pgf_term(:,:,2)  = density_inv(:,:)*grad_p_full(:,:,2,k)
          else
-           call endrun('ERROR: bad choice of pgf_formulation (must be 1 or 2)')
+           call endrun('ERROR: bad choice of pgf_formulation (must be 1, 2, or 3)')
          end if
 
          do j=1,np
@@ -1524,12 +1524,12 @@ contains
              active_species_idx_dycore=thermodynamic_active_species_idx_dycore)
         ptop = hyai(1)*ps0
         do j=1,np
-          !get mixing ratio of thermodynamic active species only 
+          !get mixing ratio of thermodynamic active species only
           !(other tracers not used in get_hydrostatic_energy)
           do nq=1,thermodynamic_active_species_num
             m_cnst = thermodynamic_active_species_idx_dycore(nq)
             q(:,:,m_cnst) = elem(ie)%state%Qdp(:,j,:,m_cnst,tl_qdp)/&
-                 elem(ie)%state%dp3d(:,j,:,tl) 
+                 elem(ie)%state%dp3d(:,j,:,tl)
           end do
           call get_hydrostatic_energy(q, &
                .false., elem(ie)%state%dp3d(:,j,:,tl), cp(:,j,:), elem(ie)%state%v(:,j,1,:,tl), &

--- a/src/dynamics/se/dycore/prim_advance_mod.F90
+++ b/src/dynamics/se/dycore/prim_advance_mod.F90
@@ -1175,8 +1175,7 @@ contains
          ! vtemp = gradient_sphere(Ephi(:,:),deriv,elem(ie)%Dinv)
          call gradient_sphere(Ephi(:,:),deriv,elem(ie)%Dinv,vtemp)
          density_inv(:,:) = R_dry(:,:,k)*T_v(:,:,k)/p_full(:,:,k)
-
-         if (pgf_formulation==1) then
+         if (pgf_formulation==1.or.(pgf_formulation==3.and.hvcoord%hybm(k)>0._r8)) then
            if (dry_air_species_num==0) then
              exner(:,:)=(p_full(:,:,k)/hvcoord%ps0)**kappa(:,:,k,ie)
              theta_v(:,:)=T_v(:,:,k)/exner(:,:)
@@ -1211,7 +1210,7 @@ contains
              pgf_term(:,:,2)=pgf_term(:,:,2) + &
                   cpair*T0*(grad_logexner(:,:,2)-grad_exner(:,:,2)/exner(:,:))
            end if
-         elseif (pgf_formulation==2) then
+         elseif (pgf_formulation==2.or.pgf_formulation==3) then
            pgf_term(:,:,1)  = density_inv(:,:)*grad_p_full(:,:,1,k)
            pgf_term(:,:,2)  = density_inv(:,:)*grad_p_full(:,:,2,k)
          else

--- a/src/ionosphere/waccmx/edyn_init.F90
+++ b/src/ionosphere/waccmx/edyn_init.F90
@@ -62,6 +62,7 @@ contains
 
       call addfld ('PED_MAG'   ,(/ 'lev' /), 'I', 'S/m  ','Pedersen Conductivity'            ,gridname='gmag_grid')
       call addfld ('HAL_MAG'   ,(/ 'lev' /), 'I', 'S/m  ','Hall Conductivity'                ,gridname='gmag_grid')
+      call addfld ('PHIHM'     , horiz_only, 'I', 'VOLTS','High Latitude Electric Potential' ,gridname='gmag_grid')
       call addfld ('PHIM2D'    , horiz_only, 'I', 'VOLTS','PHIM2D: Electric Potential'       ,gridname='gmag_grid')
       call addfld ('ED1'       , horiz_only, 'I', 'V/m  ','ED1: Eastward Electric Field'     ,gridname='gmag_grid')
       call addfld ('ED2'       , horiz_only, 'I', 'V/m  ','ED2: Equatorward Electric Field'  ,gridname='gmag_grid')

--- a/src/ionosphere/waccmx/edynamo.F90
+++ b/src/ionosphere/waccmx/edynamo.F90
@@ -1231,6 +1231,7 @@ contains
     enddo
 
     do j=mlat0,mlat1
+      call outfld('PHIHM',phihm(mlon0:omlon1,j),omlon1-mlon0+1,j)
       call outfld('PHIM2D',phim2d(mlon0:omlon1,j),omlon1-mlon0+1,j)
     enddo
 

--- a/src/ionosphere/waccmx/ionosphere_interface.F90
+++ b/src/ionosphere/waccmx/ionosphere_interface.F90
@@ -14,7 +14,7 @@ module ionosphere_interface
    use physics_buffer,      only: pbuf_get_index
 
    use constituents,        only: cnst_get_ind, cnst_mw
-   use physconst,           only: gravit
+   use physconst,           only: gravit,rga
    use oplus,               only: oplus_init
    use edyn_init,           only: edynamo_init
    use pio,                 only: var_desc_t
@@ -740,11 +740,11 @@ module ionosphere_interface
                   ! Might need geometric height on midpoints for output
                   !------------------------------------------------------------
                   if (hist_fld_active('Z3GM')) then
-                     r8tmp = phys_state(lchnk)%zm(i, k)
+                     r8tmp = phys_state(lchnk)%zm(i, k) + phis(i)*rga
                      tempm(i, k) = r8tmp * (1._r8 + (r8tmp * rearth_inv))
                   end if
                   ! physics state fields on interfaces (but only to pver)
-                  zi_blck(k, j)    = phys_state(lchnk)%zi(i, k) + phis(i)/gravit
+                  zi_blck(k, j) = phys_state(lchnk)%zi(i, k) + phis(i)/gravit
                   !------------------------------------------------------------
                   ! Convert geopotential to geometric height at interfaces:
                   !------------------------------------------------------------

--- a/src/ionosphere/waccmx/ionosphere_interface.F90
+++ b/src/ionosphere/waccmx/ionosphere_interface.F90
@@ -14,7 +14,7 @@ module ionosphere_interface
    use physics_buffer,      only: pbuf_get_index
 
    use constituents,        only: cnst_get_ind, cnst_mw
-   use physconst,           only: gravit,rga
+   use physconst,           only: rga
    use oplus,               only: oplus_init
    use edyn_init,           only: edynamo_init
    use pio,                 only: var_desc_t
@@ -744,7 +744,7 @@ module ionosphere_interface
                      tempm(i, k) = r8tmp * (1._r8 + (r8tmp * rearth_inv))
                   end if
                   ! physics state fields on interfaces (but only to pver)
-                  zi_blck(k, j) = phys_state(lchnk)%zi(i, k) + phis(i)/gravit
+                  zi_blck(k, j) = phys_state(lchnk)%zi(i, k) + phis(i)*rga
                   !------------------------------------------------------------
                   ! Convert geopotential to geometric height at interfaces:
                   !------------------------------------------------------------

--- a/src/physics/cam/vertical_diffusion.F90
+++ b/src/physics/cam/vertical_diffusion.F90
@@ -287,7 +287,7 @@ subroutine vertical_diffusion_init(pbuf2d)
   integer        :: nbot_eddy   ! Bottom interface level to which eddy vertical diffusion is applied ( = pver )
   integer        :: k           ! Vertical loop index
 
-  real(r8), parameter :: ntop_eddy_pres = 1.e-5_r8 ! Pressure below which eddy diffusion is not done in WACCM-X. (Pa)
+  real(r8), parameter :: ntop_eddy_pres = 1.e-7_r8 ! Pressure below which eddy diffusion is not done in WACCM-X. (Pa)
 
   integer :: im, l, m, nmodes, nspec
 
@@ -1046,9 +1046,9 @@ subroutine vertical_diffusion_tend( &
       ! PBL diffusion will happen before coupling, so vertical_diffusion
       ! is only handling other things, e.g. some boundary conditions, tms,
       ! and molecular diffusion.
-      
+
       call virtem(ncol, th(:ncol,pver),state%q(:ncol,pver,1), thvs(:ncol))
-      
+
       call calc_ustar( ncol, state%t(:ncol,pver), state%pmid(:ncol,pver), &
            cam_in%wsx(:ncol), cam_in%wsy(:ncol), rrho(:ncol), ustar(:ncol))
       ! Use actual qflux, not lhf/latvap as was done previously


### PR DESCRIPTION
Introduce a hybrid PGF option in the SE dycore for WACCM-x to make WACCM-x consistent with PGF used in CAM in the troposphere and traditional PGF formulation above to solve stability issues with the SE dycore (fixes #896)

Set reasonable default PE layouts for WACCM(x) and CAMChem on derecho. This solves some of the regression test failures listed in #892

Implements PHIHM history field for waccmx -- High Latitude Electric Potential

Fixes #681 
