### PR TITLE
part of cam6_3_134: Rename SE dycore time_mod to dyn_time_mod

### DIFF
--- a/src/dynamics/se/dp_coupling.F90
+++ b/src/dynamics/se/dp_coupling.F90
@@ -54,7 +54,7 @@ subroutine d_p_coupling(phys_state, phys_tend,  pbuf2d, dyn_out)
    use phys_control,           only: use_gw_front, use_gw_front_igw
    use hycoef,                 only: hyai, ps0
    use fvm_mapping,            only: dyn2phys_vector, dyn2phys_all_vars
-   use dyn_time_mod,           only: timelevel_qdp
+   use se_dyn_time_mod,        only: timelevel_qdp
    use control_mod,            only: qsplit
    use test_fvm_mapping,       only: test_mapping_overwrite_dyn_state, test_mapping_output_phys_state
    use prim_advance_mod,       only: tot_energy_dyn

--- a/src/dynamics/se/dp_coupling.F90
+++ b/src/dynamics/se/dp_coupling.F90
@@ -54,7 +54,7 @@ subroutine d_p_coupling(phys_state, phys_tend,  pbuf2d, dyn_out)
    use phys_control,           only: use_gw_front, use_gw_front_igw
    use hycoef,                 only: hyai, ps0
    use fvm_mapping,            only: dyn2phys_vector, dyn2phys_all_vars
-   use time_mod,               only: timelevel_qdp
+   use dyn_time_mod,           only: timelevel_qdp
    use control_mod,            only: qsplit
    use test_fvm_mapping,       only: test_mapping_overwrite_dyn_state, test_mapping_output_phys_state
    use prim_advance_mod,       only: tot_energy_dyn

--- a/src/dynamics/se/dycore/dyn_time_mod.F90
+++ b/src/dynamics/se/dycore/dyn_time_mod.F90
@@ -1,4 +1,4 @@
-module time_mod
+module dyn_time_mod
   !------------------
   use shr_kind_mod,   only: r8=>shr_kind_r8
   !------------------
@@ -132,4 +132,4 @@ contains
 !$OMP BARRIER    
   end subroutine TimeLevel_update
 
-end module time_mod
+end module dyn_time_mod

--- a/src/dynamics/se/dycore/fvm_consistent_se_cslam.F90
+++ b/src/dynamics/se/dycore/fvm_consistent_se_cslam.F90
@@ -6,7 +6,7 @@ module fvm_consistent_se_cslam
   use cam_abortutils,         only: endrun
   use cam_logfile,            only: iulog
 
-  use dyn_time_mod,           only: timelevel_t
+  use se_dyn_time_mod,        only: timelevel_t
   use element_mod,            only: element_t
   use fvm_control_volume_mod, only: fvm_struct
   use hybrid_mod,             only: hybrid_t, config_thread_region, get_loop_ranges, threadOwnsVertLevel

--- a/src/dynamics/se/dycore/fvm_consistent_se_cslam.F90
+++ b/src/dynamics/se/dycore/fvm_consistent_se_cslam.F90
@@ -6,7 +6,7 @@ module fvm_consistent_se_cslam
   use cam_abortutils,         only: endrun
   use cam_logfile,            only: iulog
 
-  use time_mod,               only: timelevel_t
+  use dyn_time_mod,           only: timelevel_t
   use element_mod,            only: element_t
   use fvm_control_volume_mod, only: fvm_struct
   use hybrid_mod,             only: hybrid_t, config_thread_region, get_loop_ranges, threadOwnsVertLevel

--- a/src/dynamics/se/dycore/prim_advance_mod.F90
+++ b/src/dynamics/se/dycore/prim_advance_mod.F90
@@ -53,7 +53,7 @@ contains
     use element_mod,       only: element_t
     use hybvcoord_mod,     only: hvcoord_t
     use hybrid_mod,        only: hybrid_t
-    use dyn_time_mod,      only: TimeLevel_t,  timelevel_qdp, tevolve
+    use se_dyn_time_mod,   only: TimeLevel_t,  timelevel_qdp, tevolve
     use fvm_control_volume_mod, only: fvm_struct
     use cam_thermo,        only: get_kappa_dry
     use air_composition,   only: thermodynamic_active_species_num

--- a/src/dynamics/se/dycore/prim_advance_mod.F90
+++ b/src/dynamics/se/dycore/prim_advance_mod.F90
@@ -53,7 +53,7 @@ contains
     use element_mod,       only: element_t
     use hybvcoord_mod,     only: hvcoord_t
     use hybrid_mod,        only: hybrid_t
-    use time_mod,          only: TimeLevel_t,  timelevel_qdp, tevolve
+    use dyn_time_mod,      only: TimeLevel_t,  timelevel_qdp, tevolve
     use fvm_control_volume_mod, only: fvm_struct
     use cam_thermo,        only: get_kappa_dry
     use air_composition,   only: thermodynamic_active_species_num

--- a/src/dynamics/se/dycore/prim_advection_mod.F90
+++ b/src/dynamics/se/dycore/prim_advection_mod.F90
@@ -23,7 +23,7 @@ module prim_advection_mod
   use element_mod,            only: element_t
   use fvm_control_volume_mod, only: fvm_struct
   use hybvcoord_mod,          only: hvcoord_t
-  use time_mod,               only: TimeLevel_t, TimeLevel_Qdp
+  use dyn_time_mod,           only: TimeLevel_t, TimeLevel_Qdp
   use control_mod,            only: nu_q, nu_p, limiter_option, hypervis_subcycle_q, rsplit
   use edge_mod,               only: edgevpack, edgevunpack, initedgebuffer, initedgesbuffer
 

--- a/src/dynamics/se/dycore/prim_advection_mod.F90
+++ b/src/dynamics/se/dycore/prim_advection_mod.F90
@@ -23,7 +23,7 @@ module prim_advection_mod
   use element_mod,            only: element_t
   use fvm_control_volume_mod, only: fvm_struct
   use hybvcoord_mod,          only: hvcoord_t
-  use dyn_time_mod,           only: TimeLevel_t, TimeLevel_Qdp
+  use se_dyn_time_mod,        only: TimeLevel_t, TimeLevel_Qdp
   use control_mod,            only: nu_q, nu_p, limiter_option, hypervis_subcycle_q, rsplit
   use edge_mod,               only: edgevpack, edgevunpack, initedgebuffer, initedgesbuffer
 

--- a/src/dynamics/se/dycore/prim_driver_mod.F90
+++ b/src/dynamics/se/dycore/prim_driver_mod.F90
@@ -28,8 +28,8 @@ contains
     use dimensions_mod,         only: irecons_tracer, fvm_supercycling
     use dimensions_mod,         only: fv_nphys, nc
     use parallel_mod,           only: syncmp
-    use time_mod,               only: timelevel_t, tstep, phys_tscale, nsplit, TimeLevel_Qdp
-    use time_mod,               only: nsplit_baseline,rsplit_baseline
+    use dyn_time_mod,           only: timelevel_t, tstep, phys_tscale, nsplit, TimeLevel_Qdp
+    use dyn_time_mod,           only: nsplit_baseline,rsplit_baseline
     use prim_state_mod,         only: prim_printstate
     use control_mod,            only: runtype, topology, rsplit, qsplit, rk_stage_user,         &
                                       nu, nu_q, nu_div, hypervis_subcycle, hypervis_subcycle_q, &
@@ -218,7 +218,7 @@ contains
 !
 !
     use hybvcoord_mod, only : hvcoord_t
-    use time_mod,               only: TimeLevel_t, timelevel_update, timelevel_qdp, nsplit
+    use dyn_time_mod,           only: TimeLevel_t, timelevel_update, timelevel_qdp, nsplit
     use control_mod,            only: statefreq,qsplit, rsplit, variable_nsplit
     use prim_advance_mod,       only: applycamforcing
     use prim_advance_mod,       only: tot_energy_dyn,compute_omega
@@ -407,7 +407,7 @@ contains
     !       tl%n0    time t + dt_q
     !
     use hybvcoord_mod,          only: hvcoord_t
-    use time_mod,               only: TimeLevel_t, timelevel_update
+    use dyn_time_mod,           only: TimeLevel_t, timelevel_update
     use control_mod,            only: statefreq, qsplit, nu_p
     use thread_mod,             only: omp_get_thread_num
     use prim_advance_mod,       only: prim_advance_exp

--- a/src/dynamics/se/dycore/prim_driver_mod.F90
+++ b/src/dynamics/se/dycore/prim_driver_mod.F90
@@ -28,8 +28,8 @@ contains
     use dimensions_mod,         only: irecons_tracer, fvm_supercycling
     use dimensions_mod,         only: fv_nphys, nc
     use parallel_mod,           only: syncmp
-    use dyn_time_mod,           only: timelevel_t, tstep, phys_tscale, nsplit, TimeLevel_Qdp
-    use dyn_time_mod,           only: nsplit_baseline,rsplit_baseline
+    use se_dyn_time_mod,        only: timelevel_t, tstep, phys_tscale, nsplit, TimeLevel_Qdp
+    use se_dyn_time_mod,        only: nsplit_baseline,rsplit_baseline
     use prim_state_mod,         only: prim_printstate
     use control_mod,            only: runtype, topology, rsplit, qsplit, rk_stage_user,         &
                                       nu, nu_q, nu_div, hypervis_subcycle, hypervis_subcycle_q, &
@@ -218,7 +218,7 @@ contains
 !
 !
     use hybvcoord_mod, only : hvcoord_t
-    use dyn_time_mod,           only: TimeLevel_t, timelevel_update, timelevel_qdp, nsplit
+    use se_dyn_time_mod,        only: TimeLevel_t, timelevel_update, timelevel_qdp, nsplit
     use control_mod,            only: statefreq,qsplit, rsplit, variable_nsplit
     use prim_advance_mod,       only: applycamforcing
     use prim_advance_mod,       only: tot_energy_dyn,compute_omega
@@ -407,7 +407,7 @@ contains
     !       tl%n0    time t + dt_q
     !
     use hybvcoord_mod,          only: hvcoord_t
-    use dyn_time_mod,           only: TimeLevel_t, timelevel_update
+    use se_dyn_time_mod,        only: TimeLevel_t, timelevel_update
     use control_mod,            only: statefreq, qsplit, nu_p
     use thread_mod,             only: omp_get_thread_num
     use prim_advance_mod,       only: prim_advance_exp

--- a/src/dynamics/se/dycore/prim_init.F90
+++ b/src/dynamics/se/dycore/prim_init.F90
@@ -28,7 +28,7 @@ contains
     use element_mod,            only: element_t, allocate_element_desc
     use fvm_mod,                only: fvm_init1
     use mesh_mod,               only: MeshUseMeshFile
-    use time_mod,               only: timelevel_init, timelevel_t
+    use dyn_time_mod,           only: timelevel_init, timelevel_t
     use mass_matrix_mod,        only: mass_matrix
     use derivative_mod,         only: allocate_subcell_integration_matrix_cslam
     use derivative_mod,         only: allocate_subcell_integration_matrix_physgrid

--- a/src/dynamics/se/dycore/prim_init.F90
+++ b/src/dynamics/se/dycore/prim_init.F90
@@ -28,7 +28,7 @@ contains
     use element_mod,            only: element_t, allocate_element_desc
     use fvm_mod,                only: fvm_init1
     use mesh_mod,               only: MeshUseMeshFile
-    use dyn_time_mod,           only: timelevel_init, timelevel_t
+    use se_dyn_time_mod,        only: timelevel_init, timelevel_t
     use mass_matrix_mod,        only: mass_matrix
     use derivative_mod,         only: allocate_subcell_integration_matrix_cslam
     use derivative_mod,         only: allocate_subcell_integration_matrix_physgrid

--- a/src/dynamics/se/dycore/prim_state_mod.F90
+++ b/src/dynamics/se/dycore/prim_state_mod.F90
@@ -4,7 +4,7 @@ module prim_state_mod
   use dimensions_mod,   only: nlev, np, nc, qsize_d, ntrac_d
   use parallel_mod,     only: ordered
   use hybrid_mod,       only: hybrid_t
-  use time_mod,         only: timelevel_t, TimeLevel_Qdp, time_at
+  use dyn_time_mod,     only: timelevel_t, TimeLevel_Qdp, time_at
   use control_mod,      only: qsplit, statediag_numtrac
   use global_norms_mod, only: global_integrals_general
   use element_mod,      only: element_t
@@ -24,7 +24,7 @@ CONTAINS
     use air_composition,        only: thermodynamic_active_species_idx_dycore, dry_air_species_num
     use air_composition,        only: thermodynamic_active_species_num,thermodynamic_active_species_idx
     use cam_control_mod,        only: initial_run
-    use time_mod,               only: tstep
+    use dyn_time_mod,           only: tstep
     use control_mod,            only: rsplit, qsplit
     use perf_mod,       only: t_startf, t_stopf
     type (element_t),             intent(inout) :: elem(:)
@@ -345,10 +345,10 @@ CONTAINS
   subroutine adjust_nsplit(elem, tl,hybrid,nets,nete, fvm, omega_cn)
     use dimensions_mod,         only: ksponge_end
     use dimensions_mod,         only: fvm_supercycling, fvm_supercycling_jet
-    use time_mod,               only: tstep
+    use dyn_time_mod,           only: tstep
     use control_mod,            only: rsplit, qsplit
     use perf_mod,               only: t_startf, t_stopf
-    use time_mod,               only: nsplit, nsplit_baseline,rsplit_baseline
+    use dyn_time_mod,           only: nsplit, nsplit_baseline,rsplit_baseline
     use control_mod,            only: qsplit, rsplit
     use time_manager,           only: get_step_size
     use cam_abortutils,         only: endrun

--- a/src/dynamics/se/dycore/prim_state_mod.F90
+++ b/src/dynamics/se/dycore/prim_state_mod.F90
@@ -4,7 +4,7 @@ module prim_state_mod
   use dimensions_mod,   only: nlev, np, nc, qsize_d, ntrac_d
   use parallel_mod,     only: ordered
   use hybrid_mod,       only: hybrid_t
-  use dyn_time_mod,     only: timelevel_t, TimeLevel_Qdp, time_at
+  use se_dyn_time_mod,  only: timelevel_t, TimeLevel_Qdp, time_at
   use control_mod,      only: qsplit, statediag_numtrac
   use global_norms_mod, only: global_integrals_general
   use element_mod,      only: element_t
@@ -24,7 +24,7 @@ CONTAINS
     use air_composition,        only: thermodynamic_active_species_idx_dycore, dry_air_species_num
     use air_composition,        only: thermodynamic_active_species_num,thermodynamic_active_species_idx
     use cam_control_mod,        only: initial_run
-    use dyn_time_mod,           only: tstep
+    use se_dyn_time_mod,        only: tstep
     use control_mod,            only: rsplit, qsplit
     use perf_mod,       only: t_startf, t_stopf
     type (element_t),             intent(inout) :: elem(:)
@@ -345,10 +345,10 @@ CONTAINS
   subroutine adjust_nsplit(elem, tl,hybrid,nets,nete, fvm, omega_cn)
     use dimensions_mod,         only: ksponge_end
     use dimensions_mod,         only: fvm_supercycling, fvm_supercycling_jet
-    use dyn_time_mod,           only: tstep
+    use se_dyn_time_mod,        only: tstep
     use control_mod,            only: rsplit, qsplit
     use perf_mod,               only: t_startf, t_stopf
-    use dyn_time_mod,           only: nsplit, nsplit_baseline,rsplit_baseline
+    use se_dyn_time_mod,        only: nsplit, nsplit_baseline,rsplit_baseline
     use control_mod,            only: qsplit, rsplit
     use time_manager,           only: get_step_size
     use cam_abortutils,         only: endrun

--- a/src/dynamics/se/dycore/se_dyn_time_mod.F90
+++ b/src/dynamics/se/dycore/se_dyn_time_mod.F90
@@ -1,4 +1,4 @@
-module dyn_time_mod
+module se_dyn_time_mod
   !------------------
   use shr_kind_mod,   only: r8=>shr_kind_r8
   !------------------
@@ -132,4 +132,4 @@ contains
 !$OMP BARRIER    
   end subroutine TimeLevel_update
 
-end module dyn_time_mod
+end module se_dyn_time_mod

--- a/src/dynamics/se/dyn_comp.F90
+++ b/src/dynamics/se/dyn_comp.F90
@@ -42,7 +42,7 @@ use dimensions_mod,         only: nelemd, nlev, np, npsq, ntrac, nc, fv_nphys
 use dimensions_mod,         only: qsize, use_cslam
 use element_mod,            only: element_t, elem_state_t
 use fvm_control_volume_mod, only: fvm_struct
-use dyn_time_mod,           only: nsplit
+use se_dyn_time_mod,        only: nsplit
 use edge_mod,               only: initEdgeBuffer, edgeVpack, edgeVunpack, FreeEdgeBuffer
 use edgetype_mod,           only: EdgeBuffer_t
 use bndry_mod,              only: bndry_exchange
@@ -963,11 +963,11 @@ subroutine dyn_run(dyn_state)
    use air_composition,  only: thermodynamic_active_species_idx_dycore
    use prim_driver_mod,  only: prim_run_subcycle
    use dimensions_mod,   only: cnst_name_gll
-   use dyn_time_mod,     only: tstep, nsplit, timelevel_qdp
+   use se_dyn_time_mod,  only: tstep, nsplit, timelevel_qdp
    use hybrid_mod,       only: config_thread_region, get_loop_ranges
    use control_mod,      only: qsplit, rsplit, ftype_conserve
    use thread_mod,       only: horz_num_threads
-   use dyn_time_mod,     only: tevolve
+   use se_dyn_time_mod,  only: tevolve
 
    type(dyn_export_t), intent(inout) :: dyn_state
 

--- a/src/dynamics/se/dyn_comp.F90
+++ b/src/dynamics/se/dyn_comp.F90
@@ -42,7 +42,7 @@ use dimensions_mod,         only: nelemd, nlev, np, npsq, ntrac, nc, fv_nphys
 use dimensions_mod,         only: qsize, use_cslam
 use element_mod,            only: element_t, elem_state_t
 use fvm_control_volume_mod, only: fvm_struct
-use time_mod,               only: nsplit
+use dyn_time_mod,           only: nsplit
 use edge_mod,               only: initEdgeBuffer, edgeVpack, edgeVunpack, FreeEdgeBuffer
 use edgetype_mod,           only: EdgeBuffer_t
 use bndry_mod,              only: bndry_exchange
@@ -963,11 +963,11 @@ subroutine dyn_run(dyn_state)
    use air_composition,  only: thermodynamic_active_species_idx_dycore
    use prim_driver_mod,  only: prim_run_subcycle
    use dimensions_mod,   only: cnst_name_gll
-   use time_mod,         only: tstep, nsplit, timelevel_qdp
+   use dyn_time_mod,     only: tstep, nsplit, timelevel_qdp
    use hybrid_mod,       only: config_thread_region, get_loop_ranges
    use control_mod,      only: qsplit, rsplit, ftype_conserve
    use thread_mod,       only: horz_num_threads
-   use time_mod,         only: tevolve
+   use dyn_time_mod,     only: tevolve
 
    type(dyn_export_t), intent(inout) :: dyn_state
 

--- a/src/dynamics/se/dyn_grid.F90
+++ b/src/dynamics/se/dyn_grid.F90
@@ -48,7 +48,7 @@ use hybvcoord_mod,          only: hvcoord_t
 use prim_init,              only: prim_init1
 use edge_mod,               only: initEdgeBuffer
 use edgetype_mod,           only: EdgeBuffer_t
-use dyn_time_mod,           only: TimeLevel_t
+use se_dyn_time_mod,        only: TimeLevel_t
 use dof_mod,                only: UniqueCoords, UniquePoints
 
 implicit none
@@ -133,7 +133,7 @@ subroutine dyn_grid_init()
    use hybrid_mod,          only: hybrid_t, init_loop_ranges, &
                                   get_loop_ranges, config_thread_region
    use control_mod,         only: qsplit, rsplit
-   use dyn_time_mod,        only: tstep, nsplit
+   use se_dyn_time_mod,     only: tstep, nsplit
    use fvm_mod,             only: fvm_init2, fvm_init3, fvm_pg_init
    use dimensions_mod,      only: irecons_tracer
    use comp_gll_ctr_vol,    only: gll_grid_write

--- a/src/dynamics/se/dyn_grid.F90
+++ b/src/dynamics/se/dyn_grid.F90
@@ -48,7 +48,7 @@ use hybvcoord_mod,          only: hvcoord_t
 use prim_init,              only: prim_init1
 use edge_mod,               only: initEdgeBuffer
 use edgetype_mod,           only: EdgeBuffer_t
-use time_mod,               only: TimeLevel_t
+use dyn_time_mod,           only: TimeLevel_t
 use dof_mod,                only: UniqueCoords, UniquePoints
 
 implicit none
@@ -133,7 +133,7 @@ subroutine dyn_grid_init()
    use hybrid_mod,          only: hybrid_t, init_loop_ranges, &
                                   get_loop_ranges, config_thread_region
    use control_mod,         only: qsplit, rsplit
-   use time_mod,            only: tstep, nsplit
+   use dyn_time_mod,        only: tstep, nsplit
    use fvm_mod,             only: fvm_init2, fvm_init3, fvm_pg_init
    use dimensions_mod,      only: irecons_tracer
    use comp_gll_ctr_vol,    only: gll_grid_write

--- a/src/dynamics/se/restart_dynamics.F90
+++ b/src/dynamics/se/restart_dynamics.F90
@@ -46,7 +46,7 @@ use thread_mod,       only: horz_num_threads
 use dimensions_mod,   only: np, npsq, ne, nlev, qsize, nelemd, nc, ntrac, use_cslam
 use dof_mod,          only: UniquePoints
 use element_mod,      only: element_t
-use time_mod,         only: tstep, TimeLevel_Qdp
+use dyn_time_mod,     only: tstep, TimeLevel_Qdp
 
 use edge_mod,         only: initEdgeBuffer, edgeVpack, edgeVunpack, FreeEdgeBuffer
 use edgetype_mod,     only: EdgeBuffer_t

--- a/src/dynamics/se/restart_dynamics.F90
+++ b/src/dynamics/se/restart_dynamics.F90
@@ -46,7 +46,7 @@ use thread_mod,       only: horz_num_threads
 use dimensions_mod,   only: np, npsq, ne, nlev, qsize, nelemd, nc, ntrac, use_cslam
 use dof_mod,          only: UniquePoints
 use element_mod,      only: element_t
-use dyn_time_mod,     only: tstep, TimeLevel_Qdp
+use se_dyn_time_mod,  only: tstep, TimeLevel_Qdp
 
 use edge_mod,         only: initEdgeBuffer, edgeVpack, edgeVunpack, FreeEdgeBuffer
 use edgetype_mod,     only: EdgeBuffer_t

--- a/src/dynamics/se/stepon.F90
+++ b/src/dynamics/se/stepon.F90
@@ -99,7 +99,7 @@ subroutine stepon_run1( dtime_out, phys_state, phys_tend,               &
    use dp_coupling,    only: d_p_coupling
    use physics_buffer, only: physics_buffer_desc
 
-   use dyn_time_mod,   only: tstep                    ! dynamics timestep
+   use se_dyn_time_mod,only: tstep                    ! dynamics timestep
 
    real(r8),             intent(out)   :: dtime_out   ! Time-step
    type(physics_state),  intent(inout) :: phys_state(begchunk:endchunk)
@@ -152,7 +152,7 @@ subroutine stepon_run2(phys_state, phys_tend, dyn_in, dyn_out)
    use dp_coupling,            only: p_d_coupling
    use dyn_grid,               only: TimeLevel
 
-   use dyn_time_mod,           only: TimeLevel_Qdp
+   use se_dyn_time_mod,        only: TimeLevel_Qdp
    use control_mod,            only: qsplit
    use prim_advance_mod,       only: tot_energy_dyn
 
@@ -207,7 +207,7 @@ subroutine stepon_run3(dtime, cam_out, phys_state, dyn_in, dyn_out)
    use dyn_comp,       only: dyn_run
    use advect_tend,    only: compute_adv_tends_xyz
    use dyn_grid,       only: TimeLevel
-   use dyn_time_mod,   only: TimeLevel_Qdp
+   use se_dyn_time_mod,only: TimeLevel_Qdp
    use control_mod,    only: qsplit
    ! arguments
    real(r8),            intent(in)    :: dtime   ! Time-step
@@ -254,7 +254,7 @@ subroutine diag_dynvar_ic(elem, fvm)
    use cam_history,            only: write_inithist, outfld, hist_fld_active, fieldname_len
    use dyn_grid,               only: TimeLevel
 
-   use dyn_time_mod,           only: TimeLevel_Qdp   !  dynamics typestep
+   use se_dyn_time_mod,        only: TimeLevel_Qdp   !  dynamics typestep
    use control_mod,            only: qsplit
    use hybrid_mod,             only: config_thread_region, get_loop_ranges
    use hybrid_mod,             only: hybrid_t

--- a/src/dynamics/se/stepon.F90
+++ b/src/dynamics/se/stepon.F90
@@ -99,7 +99,7 @@ subroutine stepon_run1( dtime_out, phys_state, phys_tend,               &
    use dp_coupling,    only: d_p_coupling
    use physics_buffer, only: physics_buffer_desc
 
-   use time_mod,       only: tstep                    ! dynamics timestep
+   use dyn_time_mod,   only: tstep                    ! dynamics timestep
 
    real(r8),             intent(out)   :: dtime_out   ! Time-step
    type(physics_state),  intent(inout) :: phys_state(begchunk:endchunk)
@@ -152,7 +152,7 @@ subroutine stepon_run2(phys_state, phys_tend, dyn_in, dyn_out)
    use dp_coupling,            only: p_d_coupling
    use dyn_grid,               only: TimeLevel
 
-   use time_mod,               only: TimeLevel_Qdp
+   use dyn_time_mod,           only: TimeLevel_Qdp
    use control_mod,            only: qsplit
    use prim_advance_mod,       only: tot_energy_dyn
 
@@ -207,7 +207,7 @@ subroutine stepon_run3(dtime, cam_out, phys_state, dyn_in, dyn_out)
    use dyn_comp,       only: dyn_run
    use advect_tend,    only: compute_adv_tends_xyz
    use dyn_grid,       only: TimeLevel
-   use time_mod,       only: TimeLevel_Qdp
+   use dyn_time_mod,   only: TimeLevel_Qdp
    use control_mod,    only: qsplit
    ! arguments
    real(r8),            intent(in)    :: dtime   ! Time-step
@@ -254,7 +254,7 @@ subroutine diag_dynvar_ic(elem, fvm)
    use cam_history,            only: write_inithist, outfld, hist_fld_active, fieldname_len
    use dyn_grid,               only: TimeLevel
 
-   use time_mod,               only: TimeLevel_Qdp   !  dynamics typestep
+   use dyn_time_mod,           only: TimeLevel_Qdp   !  dynamics typestep
    use control_mod,            only: qsplit
    use hybrid_mod,             only: config_thread_region, get_loop_ranges
    use hybrid_mod,             only: hybrid_t


### PR DESCRIPTION
This commit renames time_mod in the SE dycore to dyn_time_mod in order to avoid naming conflicts with building with GEOS-Chem (with the SE dycore enabled).

All USE statements updated; zero differences in run output are expected.

This is being submitted as a separate PR than #484 as it is a zero-diff update of file names and might need discussion that is separate from the GEOS-Chem changes to CAM code.

On the GEOS-Chem side we intend to rename our utilities in the GEOS-Chem code with a prefix to avoid future instances of naming conflicts as well. This will be discussed by the GEOS-Chem support team. Copying @lizziel.

Thanks!