### PR TITLE
part of cam_cesm_2_2_rel_09: corrrection for zonal mean history output

### DIFF
--- a/bld/build-namelist
+++ b/bld/build-namelist
@@ -4051,13 +4051,21 @@ sub fv_decomp_set{
     my $nlev = $cfg->get('nlev');
     my ($ny, $nz);
 
+    my $waccmx = $cfg->get('waccmx');
+    my $nmaglat = 97;
+    my $nmaglon = 80;
+    my $nlatitudes = $nlat;
+    if ($waccmx and $nlat>$nmaglat) {
+	$nlatitudes = $nmaglat; # magnetic grid resolution
+    }
+
     # die if bad input
     if ($ntasks < 1) {
         die "$ProgName - ERROR: fv_decomp_set: bad input: ntasks=$ntasks.\n" .
             "  -ntask argument to build-namelist is wrong.";
     }
 
-    NZ: for ($nz = 1; $nz <= $nlev; ++$nz) {
+    NZLOOP: for ($nz = 1; $nz <= $nlev; ++$nz) {
 
         # test that $nz divides $ntasks
         if ($ntasks%$nz == 0) {
@@ -4066,7 +4074,7 @@ sub fv_decomp_set{
 
             # test that y subdomains contain at least 3 latitudes
             # if so then done
-            if (3*$ny <= $nlat) {last NZ;}
+            if (3*$ny <= $nlatitudes) {last NZLOOP;}
         }
     }
 
@@ -4074,6 +4082,10 @@ sub fv_decomp_set{
     if ($nz > $nlev  or  $ny*$nz != $ntasks) {
         die "$ProgName - ERROR: fv_decomp_set failed to find a decomposition.\n" .
             "  npr_yz needs to be set by the user.";
+    }
+    if ($waccmx and $nmaglon/$nz < 4) {
+	die "$ProgName - ERROR: fv_decomp_set failed to find a decomposition.\n"
+	 . "  Too many MPI tasks to properly decompose WACCMX magnetic grid.";
     }
 
     return "$ny,$nz,$nz,$ny";

--- a/cime_config/config_pes.xml
+++ b/cime_config/config_pes.xml
@@ -7,67 +7,67 @@
       <pes pesize="any" compset="CAM[45]0%SCAM">
 	<comment>none</comment>
 	<ntasks>
-	  <ntasks_atm>1</ntasks_atm> 
-	  <ntasks_lnd>1</ntasks_lnd>           
-	  <ntasks_rof>1</ntasks_rof> 
-	  <ntasks_ice>1</ntasks_ice> 
-	  <ntasks_ocn>1</ntasks_ocn> 
-	  <ntasks_glc>1</ntasks_glc> 
-	  <ntasks_wav>1</ntasks_wav> 
-	  <ntasks_cpl>1</ntasks_cpl> 
+	  <ntasks_atm>1</ntasks_atm>
+	  <ntasks_lnd>1</ntasks_lnd>
+	  <ntasks_rof>1</ntasks_rof>
+	  <ntasks_ice>1</ntasks_ice>
+	  <ntasks_ocn>1</ntasks_ocn>
+	  <ntasks_glc>1</ntasks_glc>
+	  <ntasks_wav>1</ntasks_wav>
+	  <ntasks_cpl>1</ntasks_cpl>
 	</ntasks>
 	<nthrds>
-	  <nthrds_atm>1</nthrds_atm>                   
-	  <nthrds_lnd>1</nthrds_lnd> 
-	  <nthrds_rof>1</nthrds_rof> 
-	  <nthrds_ice>1</nthrds_ice> 
-	  <nthrds_ocn>1</nthrds_ocn> 
-	  <nthrds_glc>1</nthrds_glc> 
-	  <nthrds_wav>1</nthrds_wav> 
-	  <nthrds_cpl>1</nthrds_cpl> 
+	  <nthrds_atm>1</nthrds_atm>
+	  <nthrds_lnd>1</nthrds_lnd>
+	  <nthrds_rof>1</nthrds_rof>
+	  <nthrds_ice>1</nthrds_ice>
+	  <nthrds_ocn>1</nthrds_ocn>
+	  <nthrds_glc>1</nthrds_glc>
+	  <nthrds_wav>1</nthrds_wav>
+	  <nthrds_cpl>1</nthrds_cpl>
 	</nthrds>
 	<rootpe>
-	  <rootpe_atm>0</rootpe_atm> 
-	  <rootpe_lnd>0</rootpe_lnd> 
-	  <rootpe_rof>0</rootpe_rof> 
-	  <rootpe_ice>0</rootpe_ice>    
-	  <rootpe_ocn>0</rootpe_ocn>   
-	  <rootpe_glc>0</rootpe_glc> 
-	  <rootpe_wav>0</rootpe_wav> 
-	  <rootpe_cpl>0</rootpe_cpl>                         
+	  <rootpe_atm>0</rootpe_atm>
+	  <rootpe_lnd>0</rootpe_lnd>
+	  <rootpe_rof>0</rootpe_rof>
+	  <rootpe_ice>0</rootpe_ice>
+	  <rootpe_ocn>0</rootpe_ocn>
+	  <rootpe_glc>0</rootpe_glc>
+	  <rootpe_wav>0</rootpe_wav>
+	  <rootpe_cpl>0</rootpe_cpl>
 	</rootpe>
       </pes>
       <pes pesize="any" compset="any">
 	<comment>none</comment>
 	<ntasks>
-	  <ntasks_atm>-1</ntasks_atm> 
-	  <ntasks_lnd>-1</ntasks_lnd>           
-	  <ntasks_rof>-1</ntasks_rof> 
-	  <ntasks_ice>-1</ntasks_ice> 
-	  <ntasks_ocn>-1</ntasks_ocn> 
-	  <ntasks_glc>-1</ntasks_glc> 
-	  <ntasks_wav>-1</ntasks_wav> 
-	  <ntasks_cpl>-1</ntasks_cpl> 
+	  <ntasks_atm>-1</ntasks_atm>
+	  <ntasks_lnd>-1</ntasks_lnd>
+	  <ntasks_rof>-1</ntasks_rof>
+	  <ntasks_ice>-1</ntasks_ice>
+	  <ntasks_ocn>-1</ntasks_ocn>
+	  <ntasks_glc>-1</ntasks_glc>
+	  <ntasks_wav>-1</ntasks_wav>
+	  <ntasks_cpl>-1</ntasks_cpl>
 	</ntasks>
 	<nthrds>
-	  <nthrds_atm>1</nthrds_atm>                   
-	  <nthrds_lnd>1</nthrds_lnd> 
-	  <nthrds_rof>1</nthrds_rof> 
-	  <nthrds_ice>1</nthrds_ice> 
-	  <nthrds_ocn>1</nthrds_ocn> 
-	  <nthrds_glc>1</nthrds_glc> 
-	  <nthrds_wav>1</nthrds_wav> 
-	  <nthrds_cpl>1</nthrds_cpl> 
+	  <nthrds_atm>1</nthrds_atm>
+	  <nthrds_lnd>1</nthrds_lnd>
+	  <nthrds_rof>1</nthrds_rof>
+	  <nthrds_ice>1</nthrds_ice>
+	  <nthrds_ocn>1</nthrds_ocn>
+	  <nthrds_glc>1</nthrds_glc>
+	  <nthrds_wav>1</nthrds_wav>
+	  <nthrds_cpl>1</nthrds_cpl>
 	</nthrds>
 	<rootpe>
-	  <rootpe_atm>0</rootpe_atm> 
-	  <rootpe_lnd>0</rootpe_lnd> 
-	  <rootpe_rof>0</rootpe_rof> 
-	  <rootpe_ice>0</rootpe_ice>    
-	  <rootpe_ocn>0</rootpe_ocn>   
-	  <rootpe_glc>0</rootpe_glc> 
-	  <rootpe_wav>0</rootpe_wav> 
-	  <rootpe_cpl>0</rootpe_cpl>                         
+	  <rootpe_atm>0</rootpe_atm>
+	  <rootpe_lnd>0</rootpe_lnd>
+	  <rootpe_rof>0</rootpe_rof>
+	  <rootpe_ice>0</rootpe_ice>
+	  <rootpe_ocn>0</rootpe_ocn>
+	  <rootpe_glc>0</rootpe_glc>
+	  <rootpe_wav>0</rootpe_wav>
+	  <rootpe_cpl>0</rootpe_cpl>
 	</rootpe>
       </pes>
     </mach>
@@ -77,34 +77,34 @@
       <pes pesize="any" compset="any">
 	<comment>none</comment>
 	<ntasks>
-	  <ntasks_atm>-4</ntasks_atm> 
-	  <ntasks_lnd>-4</ntasks_lnd>           
-	  <ntasks_rof>-4</ntasks_rof> 
-	  <ntasks_ice>-4</ntasks_ice> 
-	  <ntasks_ocn>-4</ntasks_ocn> 
-	  <ntasks_glc>-4</ntasks_glc> 
-	  <ntasks_wav>-4</ntasks_wav> 
-	  <ntasks_cpl>-4</ntasks_cpl> 
+	  <ntasks_atm>-4</ntasks_atm>
+	  <ntasks_lnd>-4</ntasks_lnd>
+	  <ntasks_rof>-4</ntasks_rof>
+	  <ntasks_ice>-4</ntasks_ice>
+	  <ntasks_ocn>-4</ntasks_ocn>
+	  <ntasks_glc>-4</ntasks_glc>
+	  <ntasks_wav>-4</ntasks_wav>
+	  <ntasks_cpl>-4</ntasks_cpl>
 	</ntasks>
 	<nthrds>
-	  <nthrds_atm>1</nthrds_atm>                   
-	  <nthrds_lnd>1</nthrds_lnd> 
-	  <nthrds_rof>1</nthrds_rof> 
-	  <nthrds_ice>1</nthrds_ice> 
-	  <nthrds_ocn>1</nthrds_ocn> 
-	  <nthrds_glc>1</nthrds_glc> 
-	  <nthrds_wav>1</nthrds_wav> 
-	  <nthrds_cpl>1</nthrds_cpl> 
+	  <nthrds_atm>1</nthrds_atm>
+	  <nthrds_lnd>1</nthrds_lnd>
+	  <nthrds_rof>1</nthrds_rof>
+	  <nthrds_ice>1</nthrds_ice>
+	  <nthrds_ocn>1</nthrds_ocn>
+	  <nthrds_glc>1</nthrds_glc>
+	  <nthrds_wav>1</nthrds_wav>
+	  <nthrds_cpl>1</nthrds_cpl>
 	</nthrds>
 	<rootpe>
-	  <rootpe_atm>0</rootpe_atm> 
-	  <rootpe_lnd>0</rootpe_lnd> 
-	  <rootpe_rof>0</rootpe_rof> 
-	  <rootpe_ice>0</rootpe_ice>    
-	  <rootpe_ocn>0</rootpe_ocn>   
-	  <rootpe_glc>0</rootpe_glc> 
-	  <rootpe_wav>0</rootpe_wav> 
-	  <rootpe_cpl>0</rootpe_cpl>                         
+	  <rootpe_atm>0</rootpe_atm>
+	  <rootpe_lnd>0</rootpe_lnd>
+	  <rootpe_rof>0</rootpe_rof>
+	  <rootpe_ice>0</rootpe_ice>
+	  <rootpe_ocn>0</rootpe_ocn>
+	  <rootpe_glc>0</rootpe_glc>
+	  <rootpe_wav>0</rootpe_wav>
+	  <rootpe_cpl>0</rootpe_cpl>
 	</rootpe>
       </pes>
     </mach>
@@ -114,34 +114,34 @@
       <pes pesize="any" compset="any">
 	<comment>none</comment>
 	<ntasks>
-	  <ntasks_atm>-4</ntasks_atm> 
-	  <ntasks_lnd>-4</ntasks_lnd>           
-	  <ntasks_rof>-4</ntasks_rof> 
-	  <ntasks_ice>-4</ntasks_ice> 
-	  <ntasks_ocn>-4</ntasks_ocn> 
-	  <ntasks_glc>-4</ntasks_glc> 
-	  <ntasks_wav>-4</ntasks_wav> 
-	  <ntasks_cpl>-4</ntasks_cpl> 
+	  <ntasks_atm>-4</ntasks_atm>
+	  <ntasks_lnd>-4</ntasks_lnd>
+	  <ntasks_rof>-4</ntasks_rof>
+	  <ntasks_ice>-4</ntasks_ice>
+	  <ntasks_ocn>-4</ntasks_ocn>
+	  <ntasks_glc>-4</ntasks_glc>
+	  <ntasks_wav>-4</ntasks_wav>
+	  <ntasks_cpl>-4</ntasks_cpl>
 	</ntasks>
 	<nthrds>
-	  <nthrds_atm>2</nthrds_atm>                   
-	  <nthrds_lnd>2</nthrds_lnd> 
-	  <nthrds_rof>2</nthrds_rof> 
-	  <nthrds_ice>2</nthrds_ice> 
-	  <nthrds_ocn>2</nthrds_ocn> 
-	  <nthrds_glc>2</nthrds_glc> 
-	  <nthrds_wav>2</nthrds_wav> 
-	  <nthrds_cpl>2</nthrds_cpl> 
+	  <nthrds_atm>2</nthrds_atm>
+	  <nthrds_lnd>2</nthrds_lnd>
+	  <nthrds_rof>2</nthrds_rof>
+	  <nthrds_ice>2</nthrds_ice>
+	  <nthrds_ocn>2</nthrds_ocn>
+	  <nthrds_glc>2</nthrds_glc>
+	  <nthrds_wav>2</nthrds_wav>
+	  <nthrds_cpl>2</nthrds_cpl>
 	</nthrds>
 	<rootpe>
-	  <rootpe_atm>0</rootpe_atm> 
-	  <rootpe_lnd>0</rootpe_lnd> 
-	  <rootpe_rof>0</rootpe_rof> 
-	  <rootpe_ice>0</rootpe_ice>    
-	  <rootpe_ocn>0</rootpe_ocn>   
-	  <rootpe_glc>0</rootpe_glc> 
-	  <rootpe_wav>0</rootpe_wav> 
-	  <rootpe_cpl>0</rootpe_cpl>                         
+	  <rootpe_atm>0</rootpe_atm>
+	  <rootpe_lnd>0</rootpe_lnd>
+	  <rootpe_rof>0</rootpe_rof>
+	  <rootpe_ice>0</rootpe_ice>
+	  <rootpe_ocn>0</rootpe_ocn>
+	  <rootpe_glc>0</rootpe_glc>
+	  <rootpe_wav>0</rootpe_wav>
+	  <rootpe_cpl>0</rootpe_cpl>
 	</rootpe>
       </pes>
     </mach>
@@ -151,34 +151,34 @@
       <pes pesize="any" compset="any">
 	<comment>none</comment>
 	<ntasks>
-	  <ntasks_atm>-40</ntasks_atm> 
-	  <ntasks_lnd>-40</ntasks_lnd>           
-	  <ntasks_rof>-40</ntasks_rof> 
-	  <ntasks_ice>-40</ntasks_ice> 
-	  <ntasks_ocn>-40</ntasks_ocn> 
-	  <ntasks_glc>-40</ntasks_glc> 
-	  <ntasks_wav>-40</ntasks_wav> 
-	  <ntasks_cpl>-40</ntasks_cpl> 
+	  <ntasks_atm>-40</ntasks_atm>
+	  <ntasks_lnd>-40</ntasks_lnd>
+	  <ntasks_rof>-40</ntasks_rof>
+	  <ntasks_ice>-40</ntasks_ice>
+	  <ntasks_ocn>-40</ntasks_ocn>
+	  <ntasks_glc>-40</ntasks_glc>
+	  <ntasks_wav>-40</ntasks_wav>
+	  <ntasks_cpl>-40</ntasks_cpl>
 	</ntasks>
 	<nthrds>
-	  <nthrds_atm>1</nthrds_atm> 
-	  <nthrds_lnd>1</nthrds_lnd> 
-	  <nthrds_rof>1</nthrds_rof> 
-	  <nthrds_ice>1</nthrds_ice> 
-	  <nthrds_ocn>1</nthrds_ocn> 
-	  <nthrds_glc>1</nthrds_glc> 
-	  <nthrds_wav>1</nthrds_wav> 
-	  <nthrds_cpl>1</nthrds_cpl> 
+	  <nthrds_atm>1</nthrds_atm>
+	  <nthrds_lnd>1</nthrds_lnd>
+	  <nthrds_rof>1</nthrds_rof>
+	  <nthrds_ice>1</nthrds_ice>
+	  <nthrds_ocn>1</nthrds_ocn>
+	  <nthrds_glc>1</nthrds_glc>
+	  <nthrds_wav>1</nthrds_wav>
+	  <nthrds_cpl>1</nthrds_cpl>
 	</nthrds>
 	<rootpe>
-	  <rootpe_atm>0</rootpe_atm> 
-	  <rootpe_lnd>0</rootpe_lnd> 
-	  <rootpe_rof>0</rootpe_rof> 
-	  <rootpe_ice>0</rootpe_ice>    
-	  <rootpe_ocn>0</rootpe_ocn>   
-	  <rootpe_glc>0</rootpe_glc> 
-	  <rootpe_wav>0</rootpe_wav> 
-	  <rootpe_cpl>0</rootpe_cpl>                         
+	  <rootpe_atm>0</rootpe_atm>
+	  <rootpe_lnd>0</rootpe_lnd>
+	  <rootpe_rof>0</rootpe_rof>
+	  <rootpe_ice>0</rootpe_ice>
+	  <rootpe_ocn>0</rootpe_ocn>
+	  <rootpe_glc>0</rootpe_glc>
+	  <rootpe_wav>0</rootpe_wav>
+	  <rootpe_cpl>0</rootpe_cpl>
 	</rootpe>
       </pes>
     </mach>
@@ -188,34 +188,34 @@
       <pes pesize="any" compset="any">
 	<comment>none</comment>
 	<ntasks>
-	  <ntasks_atm>2048</ntasks_atm> 
-	  <ntasks_lnd>2048</ntasks_lnd>           
-	  <ntasks_rof>2048</ntasks_rof> 
-	  <ntasks_ice>2048</ntasks_ice> 
-	  <ntasks_ocn>2048</ntasks_ocn> 
-	  <ntasks_glc>2048</ntasks_glc> 
-	  <ntasks_wav>2048</ntasks_wav> 
-	  <ntasks_cpl>2048</ntasks_cpl> 
+	  <ntasks_atm>2048</ntasks_atm>
+	  <ntasks_lnd>2048</ntasks_lnd>
+	  <ntasks_rof>2048</ntasks_rof>
+	  <ntasks_ice>2048</ntasks_ice>
+	  <ntasks_ocn>2048</ntasks_ocn>
+	  <ntasks_glc>2048</ntasks_glc>
+	  <ntasks_wav>2048</ntasks_wav>
+	  <ntasks_cpl>2048</ntasks_cpl>
 	</ntasks>
 	<nthrds>
-	  <nthrds_atm>8</nthrds_atm> 
-	  <nthrds_lnd>8</nthrds_lnd> 
-	  <nthrds_rof>8</nthrds_rof> 
-	  <nthrds_ice>8</nthrds_ice> 
-	  <nthrds_ocn>8</nthrds_ocn> 
-	  <nthrds_glc>8</nthrds_glc> 
-	  <nthrds_wav>8</nthrds_wav> 
-	  <nthrds_cpl>8</nthrds_cpl> 
+	  <nthrds_atm>8</nthrds_atm>
+	  <nthrds_lnd>8</nthrds_lnd>
+	  <nthrds_rof>8</nthrds_rof>
+	  <nthrds_ice>8</nthrds_ice>
+	  <nthrds_ocn>8</nthrds_ocn>
+	  <nthrds_glc>8</nthrds_glc>
+	  <nthrds_wav>8</nthrds_wav>
+	  <nthrds_cpl>8</nthrds_cpl>
 	</nthrds>
 	<rootpe>
-	  <rootpe_atm>0</rootpe_atm> 
-	  <rootpe_lnd>0</rootpe_lnd> 
-	  <rootpe_rof>0</rootpe_rof> 
-	  <rootpe_ice>0</rootpe_ice>    
-	  <rootpe_ocn>0</rootpe_ocn>   
-	  <rootpe_glc>0</rootpe_glc> 
-	  <rootpe_wav>0</rootpe_wav> 
-	  <rootpe_cpl>0</rootpe_cpl>                         
+	  <rootpe_atm>0</rootpe_atm>
+	  <rootpe_lnd>0</rootpe_lnd>
+	  <rootpe_rof>0</rootpe_rof>
+	  <rootpe_ice>0</rootpe_ice>
+	  <rootpe_ocn>0</rootpe_ocn>
+	  <rootpe_glc>0</rootpe_glc>
+	  <rootpe_wav>0</rootpe_wav>
+	  <rootpe_cpl>0</rootpe_cpl>
 	</rootpe>
       </pes>
     </mach>
@@ -260,36 +260,36 @@
   <grid name="a%ne120">
     <mach name="any">
       <pes pesize="any" compset="any">
-	<comment>none</comment> 
+	<comment>none</comment>
 	<ntasks>
-	  <ntasks_atm>-16</ntasks_atm> 
-	  <ntasks_lnd>-16</ntasks_lnd>           
-	  <ntasks_rof>-16</ntasks_rof> 
-	  <ntasks_ice>-16</ntasks_ice> 
-	  <ntasks_ocn>-16</ntasks_ocn> 
-	  <ntasks_glc>-16</ntasks_glc> 
-	  <ntasks_wav>-16</ntasks_wav> 
-	  <ntasks_cpl>-16</ntasks_cpl> 
+	  <ntasks_atm>-16</ntasks_atm>
+	  <ntasks_lnd>-16</ntasks_lnd>
+	  <ntasks_rof>-16</ntasks_rof>
+	  <ntasks_ice>-16</ntasks_ice>
+	  <ntasks_ocn>-16</ntasks_ocn>
+	  <ntasks_glc>-16</ntasks_glc>
+	  <ntasks_wav>-16</ntasks_wav>
+	  <ntasks_cpl>-16</ntasks_cpl>
 	</ntasks>
 	<nthrds>
-	  <nthrds_atm>1</nthrds_atm>                   
-	  <nthrds_lnd>1</nthrds_lnd> 
-	  <nthrds_rof>1</nthrds_rof> 
-	  <nthrds_ice>1</nthrds_ice> 
-	  <nthrds_ocn>1</nthrds_ocn> 
-	  <nthrds_glc>1</nthrds_glc> 
-	  <nthrds_wav>1</nthrds_wav> 
-	  <nthrds_cpl>1</nthrds_cpl> 
+	  <nthrds_atm>1</nthrds_atm>
+	  <nthrds_lnd>1</nthrds_lnd>
+	  <nthrds_rof>1</nthrds_rof>
+	  <nthrds_ice>1</nthrds_ice>
+	  <nthrds_ocn>1</nthrds_ocn>
+	  <nthrds_glc>1</nthrds_glc>
+	  <nthrds_wav>1</nthrds_wav>
+	  <nthrds_cpl>1</nthrds_cpl>
 	</nthrds>
 	<rootpe>
-	  <rootpe_atm>0</rootpe_atm> 
-	  <rootpe_lnd>0</rootpe_lnd> 
-	  <rootpe_rof>0</rootpe_rof> 
-	  <rootpe_ice>0</rootpe_ice>    
-	  <rootpe_ocn>0</rootpe_ocn>   
-	  <rootpe_glc>0</rootpe_glc> 
-	  <rootpe_wav>0</rootpe_wav> 
-	  <rootpe_cpl>0</rootpe_cpl>                         
+	  <rootpe_atm>0</rootpe_atm>
+	  <rootpe_lnd>0</rootpe_lnd>
+	  <rootpe_rof>0</rootpe_rof>
+	  <rootpe_ice>0</rootpe_ice>
+	  <rootpe_ocn>0</rootpe_ocn>
+	  <rootpe_glc>0</rootpe_glc>
+	  <rootpe_wav>0</rootpe_wav>
+	  <rootpe_cpl>0</rootpe_cpl>
 	</rootpe>
       </pes>
     </mach>
@@ -299,34 +299,34 @@
       <pes pesize="any" compset="any">
 	<comment>none</comment>
 	<ntasks>
-	  <ntasks_atm>4800</ntasks_atm> 
-	  <ntasks_lnd>4800</ntasks_lnd>           
-	  <ntasks_rof>4800</ntasks_rof> 
-	  <ntasks_ice>4800</ntasks_ice> 
-	  <ntasks_ocn>4800</ntasks_ocn> 
-	  <ntasks_glc>4800</ntasks_glc> 
-	  <ntasks_wav>4800</ntasks_wav> 
-	  <ntasks_cpl>4800</ntasks_cpl> 
+	  <ntasks_atm>4800</ntasks_atm>
+	  <ntasks_lnd>4800</ntasks_lnd>
+	  <ntasks_rof>4800</ntasks_rof>
+	  <ntasks_ice>4800</ntasks_ice>
+	  <ntasks_ocn>4800</ntasks_ocn>
+	  <ntasks_glc>4800</ntasks_glc>
+	  <ntasks_wav>4800</ntasks_wav>
+	  <ntasks_cpl>4800</ntasks_cpl>
 	</ntasks>
 	<nthrds>
-	  <nthrds_atm>4</nthrds_atm>   	  
-	  <nthrds_lnd>4</nthrds_lnd> 
-	  <nthrds_rof>4</nthrds_rof> 
-	  <nthrds_ice>4</nthrds_ice> 
-	  <nthrds_ocn>4</nthrds_ocn> 
-	  <nthrds_glc>4</nthrds_glc> 
-	  <nthrds_wav>4</nthrds_wav> 
-	  <nthrds_cpl>4</nthrds_cpl> 
+	  <nthrds_atm>4</nthrds_atm>
+	  <nthrds_lnd>4</nthrds_lnd>
+	  <nthrds_rof>4</nthrds_rof>
+	  <nthrds_ice>4</nthrds_ice>
+	  <nthrds_ocn>4</nthrds_ocn>
+	  <nthrds_glc>4</nthrds_glc>
+	  <nthrds_wav>4</nthrds_wav>
+	  <nthrds_cpl>4</nthrds_cpl>
 	</nthrds>
 	<rootpe>
-	  <rootpe_atm>0</rootpe_atm> 
-	  <rootpe_lnd>0</rootpe_lnd> 
-	  <rootpe_rof>0</rootpe_rof> 
-	  <rootpe_ice>0</rootpe_ice>    
-	  <rootpe_ocn>0</rootpe_ocn>   
-	  <rootpe_glc>0</rootpe_glc> 
-	  <rootpe_wav>0</rootpe_wav> 
-	  <rootpe_cpl>0</rootpe_cpl>                         
+	  <rootpe_atm>0</rootpe_atm>
+	  <rootpe_lnd>0</rootpe_lnd>
+	  <rootpe_rof>0</rootpe_rof>
+	  <rootpe_ice>0</rootpe_ice>
+	  <rootpe_ocn>0</rootpe_ocn>
+	  <rootpe_glc>0</rootpe_glc>
+	  <rootpe_wav>0</rootpe_wav>
+	  <rootpe_cpl>0</rootpe_cpl>
 	</rootpe>
       </pes>
     </mach>
@@ -336,34 +336,34 @@
       <pes pesize="any" compset="any">
 	<comment>none</comment>
 	<ntasks>
-	  <ntasks_atm>16384</ntasks_atm> 
-	  <ntasks_lnd>16384</ntasks_lnd>           
-	  <ntasks_rof>16384</ntasks_rof> 
-	  <ntasks_ice>16384</ntasks_ice> 
-	  <ntasks_ocn>16384</ntasks_ocn> 
-	  <ntasks_glc>16384</ntasks_glc> 
-	  <ntasks_wav>16384</ntasks_wav> 
-	  <ntasks_cpl>16384</ntasks_cpl> 
+	  <ntasks_atm>16384</ntasks_atm>
+	  <ntasks_lnd>16384</ntasks_lnd>
+	  <ntasks_rof>16384</ntasks_rof>
+	  <ntasks_ice>16384</ntasks_ice>
+	  <ntasks_ocn>16384</ntasks_ocn>
+	  <ntasks_glc>16384</ntasks_glc>
+	  <ntasks_wav>16384</ntasks_wav>
+	  <ntasks_cpl>16384</ntasks_cpl>
 	</ntasks>
 	<nthrds>
-	  <nthrds_atm>8</nthrds_atm> 
-	  <nthrds_lnd>8</nthrds_lnd> 
-	  <nthrds_rof>8</nthrds_rof> 
-	  <nthrds_ice>8</nthrds_ice> 
-	  <nthrds_ocn>8</nthrds_ocn> 
-	  <nthrds_glc>8</nthrds_glc> 
-	  <nthrds_wav>8</nthrds_wav> 
-	  <nthrds_cpl>8</nthrds_cpl> 
+	  <nthrds_atm>8</nthrds_atm>
+	  <nthrds_lnd>8</nthrds_lnd>
+	  <nthrds_rof>8</nthrds_rof>
+	  <nthrds_ice>8</nthrds_ice>
+	  <nthrds_ocn>8</nthrds_ocn>
+	  <nthrds_glc>8</nthrds_glc>
+	  <nthrds_wav>8</nthrds_wav>
+	  <nthrds_cpl>8</nthrds_cpl>
 	</nthrds>
 	<rootpe>
-	  <rootpe_atm>0</rootpe_atm> 
-	  <rootpe_lnd>0</rootpe_lnd> 
-	  <rootpe_rof>0</rootpe_rof> 
-	  <rootpe_ice>0</rootpe_ice>    
-	  <rootpe_ocn>0</rootpe_ocn>   
-	  <rootpe_glc>0</rootpe_glc> 
-	  <rootpe_wav>0</rootpe_wav> 
-	  <rootpe_cpl>0</rootpe_cpl>                         
+	  <rootpe_atm>0</rootpe_atm>
+	  <rootpe_lnd>0</rootpe_lnd>
+	  <rootpe_rof>0</rootpe_rof>
+	  <rootpe_ice>0</rootpe_ice>
+	  <rootpe_ocn>0</rootpe_ocn>
+	  <rootpe_glc>0</rootpe_glc>
+	  <rootpe_wav>0</rootpe_wav>
+	  <rootpe_cpl>0</rootpe_cpl>
 	</rootpe>
       </pes>
     </mach>
@@ -373,34 +373,34 @@
       <pes pesize="any" compset="any">
 	<comment>none</comment>
 	<ntasks>
-	  <ntasks_atm>8192</ntasks_atm> 
-	  <ntasks_lnd>8192</ntasks_lnd>           
-	  <ntasks_rof>8192</ntasks_rof> 
-	  <ntasks_ice>8192</ntasks_ice> 
-	  <ntasks_ocn>8192</ntasks_ocn> 
-	  <ntasks_glc>8192</ntasks_glc> 
-	  <ntasks_wav>8192</ntasks_wav> 
-	  <ntasks_cpl>8192</ntasks_cpl> 
+	  <ntasks_atm>8192</ntasks_atm>
+	  <ntasks_lnd>8192</ntasks_lnd>
+	  <ntasks_rof>8192</ntasks_rof>
+	  <ntasks_ice>8192</ntasks_ice>
+	  <ntasks_ocn>8192</ntasks_ocn>
+	  <ntasks_glc>8192</ntasks_glc>
+	  <ntasks_wav>8192</ntasks_wav>
+	  <ntasks_cpl>8192</ntasks_cpl>
 	</ntasks>
 	<nthrds>
-	  <nthrds_atm>2</nthrds_atm> 
-	  <nthrds_lnd>2</nthrds_lnd> 
-	  <nthrds_rof>2</nthrds_rof> 
-	  <nthrds_ice>2</nthrds_ice> 
-	  <nthrds_ocn>2</nthrds_ocn> 
-	  <nthrds_glc>2</nthrds_glc> 
-	  <nthrds_wav>2</nthrds_wav> 
-	  <nthrds_cpl>2</nthrds_cpl> 
+	  <nthrds_atm>2</nthrds_atm>
+	  <nthrds_lnd>2</nthrds_lnd>
+	  <nthrds_rof>2</nthrds_rof>
+	  <nthrds_ice>2</nthrds_ice>
+	  <nthrds_ocn>2</nthrds_ocn>
+	  <nthrds_glc>2</nthrds_glc>
+	  <nthrds_wav>2</nthrds_wav>
+	  <nthrds_cpl>2</nthrds_cpl>
 	</nthrds>
 	<rootpe>
-	  <rootpe_atm>0</rootpe_atm> 
-	  <rootpe_lnd>0</rootpe_lnd> 
-	  <rootpe_rof>0</rootpe_rof> 
-	  <rootpe_ice>0</rootpe_ice>    
-	  <rootpe_ocn>0</rootpe_ocn>   
-	  <rootpe_glc>0</rootpe_glc> 
-	  <rootpe_wav>0</rootpe_wav> 
-	  <rootpe_cpl>0</rootpe_cpl>                         
+	  <rootpe_atm>0</rootpe_atm>
+	  <rootpe_lnd>0</rootpe_lnd>
+	  <rootpe_rof>0</rootpe_rof>
+	  <rootpe_ice>0</rootpe_ice>
+	  <rootpe_ocn>0</rootpe_ocn>
+	  <rootpe_glc>0</rootpe_glc>
+	  <rootpe_wav>0</rootpe_wav>
+	  <rootpe_cpl>0</rootpe_cpl>
 	</rootpe>
       </pes>
     </mach>
@@ -410,34 +410,34 @@
       <pes pesize="any" compset="any">
 	<comment>none</comment>
 	<ntasks>
-	  <ntasks_atm>-32</ntasks_atm> 
-	  <ntasks_lnd>-32</ntasks_lnd>           
-	  <ntasks_rof>-32</ntasks_rof> 
-	  <ntasks_ice>-32</ntasks_ice> 
-	  <ntasks_ocn>-32</ntasks_ocn> 
-	  <ntasks_glc>-32</ntasks_glc> 
-	  <ntasks_wav>-32</ntasks_wav> 
-	  <ntasks_cpl>-32</ntasks_cpl> 
+	  <ntasks_atm>-32</ntasks_atm>
+	  <ntasks_lnd>-32</ntasks_lnd>
+	  <ntasks_rof>-32</ntasks_rof>
+	  <ntasks_ice>-32</ntasks_ice>
+	  <ntasks_ocn>-32</ntasks_ocn>
+	  <ntasks_glc>-32</ntasks_glc>
+	  <ntasks_wav>-32</ntasks_wav>
+	  <ntasks_cpl>-32</ntasks_cpl>
 	</ntasks>
 	<nthrds>
-	  <nthrds_atm>1</nthrds_atm>                   
-	  <nthrds_lnd>1</nthrds_lnd> 
-	  <nthrds_rof>1</nthrds_rof> 
-	  <nthrds_ice>1</nthrds_ice> 
-	  <nthrds_ocn>1</nthrds_ocn> 
-	  <nthrds_glc>1</nthrds_glc> 
-	  <nthrds_wav>1</nthrds_wav> 
-	  <nthrds_cpl>1</nthrds_cpl> 
+	  <nthrds_atm>1</nthrds_atm>
+	  <nthrds_lnd>1</nthrds_lnd>
+	  <nthrds_rof>1</nthrds_rof>
+	  <nthrds_ice>1</nthrds_ice>
+	  <nthrds_ocn>1</nthrds_ocn>
+	  <nthrds_glc>1</nthrds_glc>
+	  <nthrds_wav>1</nthrds_wav>
+	  <nthrds_cpl>1</nthrds_cpl>
 	</nthrds>
 	<rootpe>
-	  <rootpe_atm>0</rootpe_atm> 
-	  <rootpe_lnd>0</rootpe_lnd> 
-	  <rootpe_rof>0</rootpe_rof> 
-	  <rootpe_ice>0</rootpe_ice>    
-	  <rootpe_ocn>0</rootpe_ocn>   
-	  <rootpe_glc>0</rootpe_glc> 
-	  <rootpe_wav>0</rootpe_wav> 
-	  <rootpe_cpl>0</rootpe_cpl>                         
+	  <rootpe_atm>0</rootpe_atm>
+	  <rootpe_lnd>0</rootpe_lnd>
+	  <rootpe_rof>0</rootpe_rof>
+	  <rootpe_ice>0</rootpe_ice>
+	  <rootpe_ocn>0</rootpe_ocn>
+	  <rootpe_glc>0</rootpe_glc>
+	  <rootpe_wav>0</rootpe_wav>
+	  <rootpe_cpl>0</rootpe_cpl>
 	</rootpe>
       </pes>
     </mach>
@@ -447,34 +447,34 @@
       <pes pesize="any" compset="any">
 	<comment>none</comment>
 	<ntasks>
-	  <ntasks_atm>64</ntasks_atm> 
-	  <ntasks_lnd>64</ntasks_lnd>           
-	  <ntasks_rof>64</ntasks_rof> 
-	  <ntasks_ice>64</ntasks_ice> 
-	  <ntasks_ocn>64</ntasks_ocn> 
-	  <ntasks_glc>64</ntasks_glc> 
-	  <ntasks_wav>64</ntasks_wav> 
-	  <ntasks_cpl>64</ntasks_cpl> 
+	  <ntasks_atm>64</ntasks_atm>
+	  <ntasks_lnd>64</ntasks_lnd>
+	  <ntasks_rof>64</ntasks_rof>
+	  <ntasks_ice>64</ntasks_ice>
+	  <ntasks_ocn>64</ntasks_ocn>
+	  <ntasks_glc>64</ntasks_glc>
+	  <ntasks_wav>64</ntasks_wav>
+	  <ntasks_cpl>64</ntasks_cpl>
 	</ntasks>
 	<nthrds>
 	  <nthrds_atm>1</nthrds_atm>
-	  <nthrds_lnd>1</nthrds_lnd> 
-	  <nthrds_rof>1</nthrds_rof> 
-	  <nthrds_ice>1</nthrds_ice> 
-	  <nthrds_ocn>1</nthrds_ocn> 
-	  <nthrds_glc>1</nthrds_glc> 
-	  <nthrds_wav>1</nthrds_wav> 
-	  <nthrds_cpl>1</nthrds_cpl> 
+	  <nthrds_lnd>1</nthrds_lnd>
+	  <nthrds_rof>1</nthrds_rof>
+	  <nthrds_ice>1</nthrds_ice>
+	  <nthrds_ocn>1</nthrds_ocn>
+	  <nthrds_glc>1</nthrds_glc>
+	  <nthrds_wav>1</nthrds_wav>
+	  <nthrds_cpl>1</nthrds_cpl>
 	</nthrds>
 	<rootpe>
-	  <rootpe_atm>0</rootpe_atm> 
-	  <rootpe_lnd>0</rootpe_lnd> 
-	  <rootpe_rof>0</rootpe_rof> 
-	  <rootpe_ice>0</rootpe_ice>    
-	  <rootpe_ocn>0</rootpe_ocn>   
-	  <rootpe_glc>0</rootpe_glc> 
-	  <rootpe_wav>0</rootpe_wav> 
-	  <rootpe_cpl>0</rootpe_cpl>                         
+	  <rootpe_atm>0</rootpe_atm>
+	  <rootpe_lnd>0</rootpe_lnd>
+	  <rootpe_rof>0</rootpe_rof>
+	  <rootpe_ice>0</rootpe_ice>
+	  <rootpe_ocn>0</rootpe_ocn>
+	  <rootpe_glc>0</rootpe_glc>
+	  <rootpe_wav>0</rootpe_wav>
+	  <rootpe_cpl>0</rootpe_cpl>
 	</rootpe>
       </pes>
     </mach>
@@ -484,34 +484,34 @@
       <pes pesize='any' compset='any'>
 	<comment>none</comment>
 	<ntasks>
-	  <ntasks_atm>-2</ntasks_atm> 
-	  <ntasks_lnd>-2</ntasks_lnd>           
-	  <ntasks_rof>-2</ntasks_rof> 
-	  <ntasks_ice>-2</ntasks_ice> 
-	  <ntasks_ocn>-2</ntasks_ocn> 
-	  <ntasks_glc>-2</ntasks_glc> 
-	  <ntasks_wav>-2</ntasks_wav> 
-	  <ntasks_cpl>-2</ntasks_cpl> 
+	  <ntasks_atm>-2</ntasks_atm>
+	  <ntasks_lnd>-2</ntasks_lnd>
+	  <ntasks_rof>-2</ntasks_rof>
+	  <ntasks_ice>-2</ntasks_ice>
+	  <ntasks_ocn>-2</ntasks_ocn>
+	  <ntasks_glc>-2</ntasks_glc>
+	  <ntasks_wav>-2</ntasks_wav>
+	  <ntasks_cpl>-2</ntasks_cpl>
 	</ntasks>
 	<nthrds>
-	  <nthrds_atm>1</nthrds_atm>                   
-	  <nthrds_lnd>1</nthrds_lnd> 
-	  <nthrds_rof>1</nthrds_rof> 
-	  <nthrds_ice>1</nthrds_ice> 
-	  <nthrds_ocn>1</nthrds_ocn> 
-	  <nthrds_glc>1</nthrds_glc> 
-	  <nthrds_wav>1</nthrds_wav> 
-	  <nthrds_cpl>1</nthrds_cpl> 
+	  <nthrds_atm>1</nthrds_atm>
+	  <nthrds_lnd>1</nthrds_lnd>
+	  <nthrds_rof>1</nthrds_rof>
+	  <nthrds_ice>1</nthrds_ice>
+	  <nthrds_ocn>1</nthrds_ocn>
+	  <nthrds_glc>1</nthrds_glc>
+	  <nthrds_wav>1</nthrds_wav>
+	  <nthrds_cpl>1</nthrds_cpl>
 	</nthrds>
 	<rootpe>
-	  <rootpe_atm>0</rootpe_atm> 
-	  <rootpe_lnd>0</rootpe_lnd> 
-	  <rootpe_rof>0</rootpe_rof> 
-	  <rootpe_ice>0</rootpe_ice>    
-	  <rootpe_ocn>0</rootpe_ocn>   
-	  <rootpe_glc>0</rootpe_glc> 
-	  <rootpe_wav>0</rootpe_wav> 
-	  <rootpe_cpl>0</rootpe_cpl>                         
+	  <rootpe_atm>0</rootpe_atm>
+	  <rootpe_lnd>0</rootpe_lnd>
+	  <rootpe_rof>0</rootpe_rof>
+	  <rootpe_ice>0</rootpe_ice>
+	  <rootpe_ocn>0</rootpe_ocn>
+	  <rootpe_glc>0</rootpe_glc>
+	  <rootpe_wav>0</rootpe_wav>
+	  <rootpe_cpl>0</rootpe_cpl>
 	</rootpe>
       </pes>
     </mach>
@@ -521,34 +521,34 @@
       <pes pesize="any" compset="any">
 	<comment>none</comment>
 	<ntasks>
-	  <ntasks_atm>224</ntasks_atm> 
-	  <ntasks_lnd>224</ntasks_lnd>           
-	  <ntasks_rof>224</ntasks_rof> 
-	  <ntasks_ice>224</ntasks_ice> 
-	  <ntasks_ocn>224</ntasks_ocn> 
-	  <ntasks_glc>224</ntasks_glc> 
-	  <ntasks_wav>224</ntasks_wav> 
-	  <ntasks_cpl>224</ntasks_cpl> 
+	  <ntasks_atm>224</ntasks_atm>
+	  <ntasks_lnd>224</ntasks_lnd>
+	  <ntasks_rof>224</ntasks_rof>
+	  <ntasks_ice>224</ntasks_ice>
+	  <ntasks_ocn>224</ntasks_ocn>
+	  <ntasks_glc>224</ntasks_glc>
+	  <ntasks_wav>224</ntasks_wav>
+	  <ntasks_cpl>224</ntasks_cpl>
 	</ntasks>
 	<nthrds>
-	  <nthrds_atm>1</nthrds_atm> 
-	  <nthrds_lnd>1</nthrds_lnd> 
-	  <nthrds_rof>1</nthrds_rof> 
-	  <nthrds_ice>1</nthrds_ice> 
-	  <nthrds_ocn>1</nthrds_ocn> 
-	  <nthrds_glc>1</nthrds_glc> 
-	  <nthrds_wav>1</nthrds_wav> 
-	  <nthrds_cpl>1</nthrds_cpl> 
+	  <nthrds_atm>1</nthrds_atm>
+	  <nthrds_lnd>1</nthrds_lnd>
+	  <nthrds_rof>1</nthrds_rof>
+	  <nthrds_ice>1</nthrds_ice>
+	  <nthrds_ocn>1</nthrds_ocn>
+	  <nthrds_glc>1</nthrds_glc>
+	  <nthrds_wav>1</nthrds_wav>
+	  <nthrds_cpl>1</nthrds_cpl>
 	</nthrds>
 	<rootpe>
-	  <rootpe_atm>0</rootpe_atm> 
-	  <rootpe_lnd>0</rootpe_lnd> 
-	  <rootpe_rof>0</rootpe_rof> 
-	  <rootpe_ice>0</rootpe_ice>    
-	  <rootpe_ocn>0</rootpe_ocn>   
-	  <rootpe_glc>0</rootpe_glc> 
-	  <rootpe_wav>0</rootpe_wav> 
-	  <rootpe_cpl>0</rootpe_cpl>                         
+	  <rootpe_atm>0</rootpe_atm>
+	  <rootpe_lnd>0</rootpe_lnd>
+	  <rootpe_rof>0</rootpe_rof>
+	  <rootpe_ice>0</rootpe_ice>
+	  <rootpe_ocn>0</rootpe_ocn>
+	  <rootpe_glc>0</rootpe_glc>
+	  <rootpe_wav>0</rootpe_wav>
+	  <rootpe_cpl>0</rootpe_cpl>
 	</rootpe>
       </pes>
     </mach>
@@ -558,34 +558,34 @@
       <pes pesize="any" compset="any">
 	<comment>none</comment>
 	<ntasks>
-	  <ntasks_atm>192</ntasks_atm> 
-	  <ntasks_lnd>192</ntasks_lnd>           
-	  <ntasks_rof>192</ntasks_rof> 
-	  <ntasks_ice>192</ntasks_ice> 
-	  <ntasks_ocn>192</ntasks_ocn> 
-	  <ntasks_glc>192</ntasks_glc> 
-	  <ntasks_wav>192</ntasks_wav> 
-	  <ntasks_cpl>192</ntasks_cpl> 
+	  <ntasks_atm>192</ntasks_atm>
+	  <ntasks_lnd>192</ntasks_lnd>
+	  <ntasks_rof>192</ntasks_rof>
+	  <ntasks_ice>192</ntasks_ice>
+	  <ntasks_ocn>192</ntasks_ocn>
+	  <ntasks_glc>192</ntasks_glc>
+	  <ntasks_wav>192</ntasks_wav>
+	  <ntasks_cpl>192</ntasks_cpl>
 	</ntasks>
 	<nthrds>
-	  <nthrds_atm>1</nthrds_atm> 
-	  <nthrds_lnd>1</nthrds_lnd> 
-	  <nthrds_rof>1</nthrds_rof> 
-	  <nthrds_ice>1</nthrds_ice> 
-	  <nthrds_ocn>1</nthrds_ocn> 
-	  <nthrds_glc>1</nthrds_glc> 
-	  <nthrds_wav>1</nthrds_wav> 
-	  <nthrds_cpl>1</nthrds_cpl> 
+	  <nthrds_atm>1</nthrds_atm>
+	  <nthrds_lnd>1</nthrds_lnd>
+	  <nthrds_rof>1</nthrds_rof>
+	  <nthrds_ice>1</nthrds_ice>
+	  <nthrds_ocn>1</nthrds_ocn>
+	  <nthrds_glc>1</nthrds_glc>
+	  <nthrds_wav>1</nthrds_wav>
+	  <nthrds_cpl>1</nthrds_cpl>
 	</nthrds>
 	<rootpe>
-	  <rootpe_atm>0</rootpe_atm> 
-	  <rootpe_lnd>0</rootpe_lnd> 
-	  <rootpe_rof>0</rootpe_rof> 
-	  <rootpe_ice>0</rootpe_ice>    
-	  <rootpe_ocn>0</rootpe_ocn>   
-	  <rootpe_glc>0</rootpe_glc> 
-	  <rootpe_wav>0</rootpe_wav> 
-	  <rootpe_cpl>0</rootpe_cpl>                         
+	  <rootpe_atm>0</rootpe_atm>
+	  <rootpe_lnd>0</rootpe_lnd>
+	  <rootpe_rof>0</rootpe_rof>
+	  <rootpe_ice>0</rootpe_ice>
+	  <rootpe_ocn>0</rootpe_ocn>
+	  <rootpe_glc>0</rootpe_glc>
+	  <rootpe_wav>0</rootpe_wav>
+	  <rootpe_cpl>0</rootpe_cpl>
 	</rootpe>
       </pes>
     </mach>
@@ -595,34 +595,34 @@
       <pes pesize="any" compset="any">
 	<comment>none</comment>
 	<ntasks>
-	  <ntasks_atm>192</ntasks_atm> 
-	  <ntasks_lnd>192</ntasks_lnd>           
-	  <ntasks_rof>192</ntasks_rof> 
-	  <ntasks_ice>192</ntasks_ice> 
-	  <ntasks_ocn>192</ntasks_ocn> 
-	  <ntasks_glc>192</ntasks_glc> 
-	  <ntasks_wav>192</ntasks_wav> 
-	  <ntasks_cpl>192</ntasks_cpl> 
+	  <ntasks_atm>192</ntasks_atm>
+	  <ntasks_lnd>192</ntasks_lnd>
+	  <ntasks_rof>192</ntasks_rof>
+	  <ntasks_ice>192</ntasks_ice>
+	  <ntasks_ocn>192</ntasks_ocn>
+	  <ntasks_glc>192</ntasks_glc>
+	  <ntasks_wav>192</ntasks_wav>
+	  <ntasks_cpl>192</ntasks_cpl>
 	</ntasks>
 	<nthrds>
-	  <nthrds_atm>1</nthrds_atm> 
-	  <nthrds_lnd>1</nthrds_lnd> 
-	  <nthrds_rof>1</nthrds_rof> 
-	  <nthrds_ice>1</nthrds_ice> 
-	  <nthrds_ocn>1</nthrds_ocn> 
-	  <nthrds_glc>1</nthrds_glc> 
-	  <nthrds_wav>1</nthrds_wav> 
-	  <nthrds_cpl>1</nthrds_cpl> 
+	  <nthrds_atm>1</nthrds_atm>
+	  <nthrds_lnd>1</nthrds_lnd>
+	  <nthrds_rof>1</nthrds_rof>
+	  <nthrds_ice>1</nthrds_ice>
+	  <nthrds_ocn>1</nthrds_ocn>
+	  <nthrds_glc>1</nthrds_glc>
+	  <nthrds_wav>1</nthrds_wav>
+	  <nthrds_cpl>1</nthrds_cpl>
 	</nthrds>
 	<rootpe>
-	  <rootpe_atm>0</rootpe_atm> 
-	  <rootpe_lnd>0</rootpe_lnd> 
-	  <rootpe_rof>0</rootpe_rof> 
-	  <rootpe_ice>0</rootpe_ice>    
-	  <rootpe_ocn>0</rootpe_ocn>   
-	  <rootpe_glc>0</rootpe_glc> 
-	  <rootpe_wav>0</rootpe_wav> 
-	  <rootpe_cpl>0</rootpe_cpl>                         
+	  <rootpe_atm>0</rootpe_atm>
+	  <rootpe_lnd>0</rootpe_lnd>
+	  <rootpe_rof>0</rootpe_rof>
+	  <rootpe_ice>0</rootpe_ice>
+	  <rootpe_ocn>0</rootpe_ocn>
+	  <rootpe_glc>0</rootpe_glc>
+	  <rootpe_wav>0</rootpe_wav>
+	  <rootpe_cpl>0</rootpe_cpl>
 	</rootpe>
       </pes>
     </mach>
@@ -632,34 +632,34 @@
       <pes pesize="any" compset="any">
 	<comment>none</comment>
 	<ntasks>
-	  <ntasks_atm>240</ntasks_atm> 
-	  <ntasks_lnd>240</ntasks_lnd>           
-	  <ntasks_rof>240</ntasks_rof> 
-	  <ntasks_ice>240</ntasks_ice> 
-	  <ntasks_ocn>240</ntasks_ocn> 
-	  <ntasks_glc>240</ntasks_glc> 
-	  <ntasks_wav>240</ntasks_wav> 
-	  <ntasks_cpl>240</ntasks_cpl> 
+	  <ntasks_atm>240</ntasks_atm>
+	  <ntasks_lnd>240</ntasks_lnd>
+	  <ntasks_rof>240</ntasks_rof>
+	  <ntasks_ice>240</ntasks_ice>
+	  <ntasks_ocn>240</ntasks_ocn>
+	  <ntasks_glc>240</ntasks_glc>
+	  <ntasks_wav>240</ntasks_wav>
+	  <ntasks_cpl>240</ntasks_cpl>
 	</ntasks>
 	<nthrds>
-	  <nthrds_atm>1</nthrds_atm> 
-	  <nthrds_lnd>1</nthrds_lnd> 
-	  <nthrds_rof>1</nthrds_rof> 
-	  <nthrds_ice>1</nthrds_ice> 
-	  <nthrds_ocn>1</nthrds_ocn> 
-	  <nthrds_glc>1</nthrds_glc> 
-	  <nthrds_wav>1</nthrds_wav> 
-	  <nthrds_cpl>1</nthrds_cpl> 
+	  <nthrds_atm>1</nthrds_atm>
+	  <nthrds_lnd>1</nthrds_lnd>
+	  <nthrds_rof>1</nthrds_rof>
+	  <nthrds_ice>1</nthrds_ice>
+	  <nthrds_ocn>1</nthrds_ocn>
+	  <nthrds_glc>1</nthrds_glc>
+	  <nthrds_wav>1</nthrds_wav>
+	  <nthrds_cpl>1</nthrds_cpl>
 	</nthrds>
 	<rootpe>
-	  <rootpe_atm>0</rootpe_atm> 
-	  <rootpe_lnd>0</rootpe_lnd> 
-	  <rootpe_rof>0</rootpe_rof> 
-	  <rootpe_ice>0</rootpe_ice>    
-	  <rootpe_ocn>0</rootpe_ocn>   
-	  <rootpe_glc>0</rootpe_glc> 
-	  <rootpe_wav>0</rootpe_wav> 
-	  <rootpe_cpl>0</rootpe_cpl>                         
+	  <rootpe_atm>0</rootpe_atm>
+	  <rootpe_lnd>0</rootpe_lnd>
+	  <rootpe_rof>0</rootpe_rof>
+	  <rootpe_ice>0</rootpe_ice>
+	  <rootpe_ocn>0</rootpe_ocn>
+	  <rootpe_glc>0</rootpe_glc>
+	  <rootpe_wav>0</rootpe_wav>
+	  <rootpe_cpl>0</rootpe_cpl>
 	</rootpe>
       </pes>
     </mach>
@@ -674,10 +674,10 @@
           <ntasks_lnd>360</ntasks_lnd>
           <ntasks_rof>360</ntasks_rof>
           <ntasks_ice>360</ntasks_ice>
-          <ntasks_ocn>360</ntasks_ocn> 
-          <ntasks_glc>360</ntasks_glc> 
-          <ntasks_wav>360</ntasks_wav> 
-          <ntasks_cpl>360</ntasks_cpl> 
+          <ntasks_ocn>360</ntasks_ocn>
+          <ntasks_glc>360</ntasks_glc>
+          <ntasks_wav>360</ntasks_wav>
+          <ntasks_cpl>360</ntasks_cpl>
         </ntasks>
         <nthrds>
           <nthrds_atm>3</nthrds_atm>
@@ -771,40 +771,75 @@
 	</rootpe>
       </pes>
     </mach>
+    <mach name="derecho">
+      <pes pesize="any" compset="_CAM\d0%(CC|CV|CF|WC|WX)">
+	<comment>none</comment>
+	<ntasks>
+	  <ntasks_atm>-4</ntasks_atm>
+	  <ntasks_lnd>-4</ntasks_lnd>
+	  <ntasks_rof>-4</ntasks_rof>
+	  <ntasks_ice>-4</ntasks_ice>
+	  <ntasks_ocn>-4</ntasks_ocn>
+	  <ntasks_glc>-4</ntasks_glc>
+	  <ntasks_wav>-4</ntasks_wav>
+	  <ntasks_cpl>-4</ntasks_cpl>
+	</ntasks>
+	<nthrds>
+	  <nthrds_atm>1</nthrds_atm>
+	  <nthrds_lnd>1</nthrds_lnd>
+	  <nthrds_rof>1</nthrds_rof>
+	  <nthrds_ice>1</nthrds_ice>
+	  <nthrds_ocn>1</nthrds_ocn>
+	  <nthrds_glc>1</nthrds_glc>
+	  <nthrds_wav>1</nthrds_wav>
+	  <nthrds_cpl>1</nthrds_cpl>
+	</nthrds>
+	<rootpe>
+	  <rootpe_atm>0</rootpe_atm>
+	  <rootpe_lnd>0</rootpe_lnd>
+	  <rootpe_rof>0</rootpe_rof>
+	  <rootpe_ice>0</rootpe_ice>
+	  <rootpe_ocn>0</rootpe_ocn>
+	  <rootpe_glc>0</rootpe_glc>
+	  <rootpe_wav>0</rootpe_wav>
+	  <rootpe_cpl>0</rootpe_cpl>
+	</rootpe>
+      </pes>
+    </mach>
     <mach name="hobart|izumi">
       <pes pesize="any" compset="CAM\d+%W">
 	<comment>none</comment>
 	<ntasks>
-	  <ntasks_atm>192</ntasks_atm> 
-	  <ntasks_lnd>192</ntasks_lnd>           
-	  <ntasks_rof>192</ntasks_rof> 
-	  <ntasks_ice>192</ntasks_ice> 
-	  <ntasks_ocn>192</ntasks_ocn> 
-	  <ntasks_glc>192</ntasks_glc> 
-	  <ntasks_wav>192</ntasks_wav> 
-	  <ntasks_cpl>192</ntasks_cpl> 
+	  <ntasks_atm>192</ntasks_atm>
+	  <ntasks_lnd>192</ntasks_lnd>
+	  <ntasks_rof>192</ntasks_rof>
+	  <ntasks_ice>192</ntasks_ice>
+	  <ntasks_ocn>192</ntasks_ocn>
+	  <ntasks_glc>192</ntasks_glc>
+	  <ntasks_wav>192</ntasks_wav>
+	  <ntasks_cpl>192</ntasks_cpl>
 	</ntasks>
 	<nthrds>
-	  <nthrds_atm>1</nthrds_atm> 
-	  <nthrds_lnd>1</nthrds_lnd> 
-	  <nthrds_rof>1</nthrds_rof> 
-	  <nthrds_ice>1</nthrds_ice> 
-	  <nthrds_ocn>1</nthrds_ocn> 
-	  <nthrds_glc>1</nthrds_glc> 
-	  <nthrds_wav>1</nthrds_wav> 
-	  <nthrds_cpl>1</nthrds_cpl> 
+	  <nthrds_atm>1</nthrds_atm>
+	  <nthrds_lnd>1</nthrds_lnd>
+	  <nthrds_rof>1</nthrds_rof>
+	  <nthrds_ice>1</nthrds_ice>
+	  <nthrds_ocn>1</nthrds_ocn>
+	  <nthrds_glc>1</nthrds_glc>
+	  <nthrds_wav>1</nthrds_wav>
+	  <nthrds_cpl>1</nthrds_cpl>
 	</nthrds>
 	<rootpe>
-	  <rootpe_atm>0</rootpe_atm> 
-	  <rootpe_lnd>0</rootpe_lnd> 
-	  <rootpe_rof>0</rootpe_rof> 
-	  <rootpe_ice>0</rootpe_ice>    
-	  <rootpe_ocn>0</rootpe_ocn>   
-	  <rootpe_glc>0</rootpe_glc> 
-	  <rootpe_wav>0</rootpe_wav> 
-	  <rootpe_cpl>0</rootpe_cpl>                         
+	  <rootpe_atm>0</rootpe_atm>
+	  <rootpe_lnd>0</rootpe_lnd>
+	  <rootpe_rof>0</rootpe_rof>
+	  <rootpe_ice>0</rootpe_ice>
+	  <rootpe_ocn>0</rootpe_ocn>
+	  <rootpe_glc>0</rootpe_glc>
+	  <rootpe_wav>0</rootpe_wav>
+	  <rootpe_cpl>0</rootpe_cpl>
 	</rootpe>
-      </pes>    
+      </pes>
     </mach>
   </grid>
   <grid name="a%0.9x1.25">
@@ -843,6 +878,74 @@
 	</rootpe>
       </pes>
     </mach>
+    <mach name="derecho">
+      <pes pesize="any" compset="_CAM\d0%(CC|CV|CF|WC)">
+	<comment>none</comment>
+	<ntasks>
+	  <ntasks_atm>-8</ntasks_atm>
+	  <ntasks_lnd>-8</ntasks_lnd>
+	  <ntasks_rof>-8</ntasks_rof>
+	  <ntasks_ice>-8</ntasks_ice>
+	  <ntasks_ocn>-8</ntasks_ocn>
+	  <ntasks_glc>-8</ntasks_glc>
+	  <ntasks_wav>-8</ntasks_wav>
+	  <ntasks_cpl>-8</ntasks_cpl>
+	</ntasks>
+	<nthrds>
+	  <nthrds_atm>1</nthrds_atm>
+	  <nthrds_lnd>1</nthrds_lnd>
+	  <nthrds_rof>1</nthrds_rof>
+	  <nthrds_ice>1</nthrds_ice>
+	  <nthrds_ocn>1</nthrds_ocn>
+	  <nthrds_glc>1</nthrds_glc>
+	  <nthrds_wav>1</nthrds_wav>
+	  <nthrds_cpl>1</nthrds_cpl>
+	</nthrds>
+	<rootpe>
+	  <rootpe_atm>0</rootpe_atm>
+	  <rootpe_lnd>0</rootpe_lnd>
+	  <rootpe_rof>0</rootpe_rof>
+	  <rootpe_ice>0</rootpe_ice>
+	  <rootpe_ocn>0</rootpe_ocn>
+	  <rootpe_glc>0</rootpe_glc>
+	  <rootpe_wav>0</rootpe_wav>
+	  <rootpe_cpl>0</rootpe_cpl>
+	</rootpe>
+      </pes>
+      <pes pesize="any" compset="_CAM\d0%WX">
+	<comment>none</comment>
+	<ntasks>
+	  <ntasks_atm>-4</ntasks_atm>
+	  <ntasks_lnd>-4</ntasks_lnd>
+	  <ntasks_rof>-4</ntasks_rof>
+	  <ntasks_ice>-4</ntasks_ice>
+	  <ntasks_ocn>-4</ntasks_ocn>
+	  <ntasks_glc>-4</ntasks_glc>
+	  <ntasks_wav>-4</ntasks_wav>
+	  <ntasks_cpl>-4</ntasks_cpl>
+	</ntasks>
+	<nthrds>
+	  <nthrds_atm>1</nthrds_atm>
+	  <nthrds_lnd>1</nthrds_lnd>
+	  <nthrds_rof>1</nthrds_rof>
+	  <nthrds_ice>1</nthrds_ice>
+	  <nthrds_ocn>1</nthrds_ocn>
+	  <nthrds_glc>1</nthrds_glc>
+	  <nthrds_wav>1</nthrds_wav>
+	  <nthrds_cpl>1</nthrds_cpl>
+	</nthrds>
+	<rootpe>
+	  <rootpe_atm>0</rootpe_atm>
+	  <rootpe_lnd>0</rootpe_lnd>
+	  <rootpe_rof>0</rootpe_rof>
+	  <rootpe_ice>0</rootpe_ice>
+	  <rootpe_ocn>0</rootpe_ocn>
+	  <rootpe_glc>0</rootpe_glc>
+	  <rootpe_wav>0</rootpe_wav>
+	  <rootpe_cpl>0</rootpe_cpl>
+	</rootpe>
+      </pes>
+    </mach>
   </grid>
 
   <grid name="a%0.9x1.25">
@@ -850,34 +953,34 @@
       <pes pesize="any" compset="any">
 	<comment>none</comment>
 	<ntasks>
-	  <ntasks_atm>-4</ntasks_atm> 
-	  <ntasks_lnd>-4</ntasks_lnd>           
-	  <ntasks_rof>-4</ntasks_rof> 
-	  <ntasks_ice>-4</ntasks_ice> 
-	  <ntasks_ocn>-4</ntasks_ocn> 
-	  <ntasks_glc>-4</ntasks_glc> 
-	  <ntasks_wav>-4</ntasks_wav> 
-	  <ntasks_cpl>-4</ntasks_cpl> 
+	  <ntasks_atm>-4</ntasks_atm>
+	  <ntasks_lnd>-4</ntasks_lnd>
+	  <ntasks_rof>-4</ntasks_rof>
+	  <ntasks_ice>-4</ntasks_ice>
+	  <ntasks_ocn>-4</ntasks_ocn>
+	  <ntasks_glc>-4</ntasks_glc>
+	  <ntasks_wav>-4</ntasks_wav>
+	  <ntasks_cpl>-4</ntasks_cpl>
 	</ntasks>
 	<nthrds>
-	  <nthrds_atm>1</nthrds_atm>                   
-	  <nthrds_lnd>1</nthrds_lnd> 
-	  <nthrds_rof>1</nthrds_rof> 
-	  <nthrds_ice>1</nthrds_ice> 
-	  <nthrds_ocn>1</nthrds_ocn> 
-	  <nthrds_glc>1</nthrds_glc> 
-	  <nthrds_wav>1</nthrds_wav> 
-	  <nthrds_cpl>1</nthrds_cpl> 
+	  <nthrds_atm>1</nthrds_atm>
+	  <nthrds_lnd>1</nthrds_lnd>
+	  <nthrds_rof>1</nthrds_rof>
+	  <nthrds_ice>1</nthrds_ice>
+	  <nthrds_ocn>1</nthrds_ocn>
+	  <nthrds_glc>1</nthrds_glc>
+	  <nthrds_wav>1</nthrds_wav>
+	  <nthrds_cpl>1</nthrds_cpl>
 	</nthrds>
 	<rootpe>
-	  <rootpe_atm>0</rootpe_atm> 
-	  <rootpe_lnd>0</rootpe_lnd> 
-	  <rootpe_rof>0</rootpe_rof> 
-	  <rootpe_ice>0</rootpe_ice>    
-	  <rootpe_ocn>0</rootpe_ocn>   
-	  <rootpe_glc>0</rootpe_glc> 
-	  <rootpe_wav>0</rootpe_wav> 
-	  <rootpe_cpl>0</rootpe_cpl>                         
+	  <rootpe_atm>0</rootpe_atm>
+	  <rootpe_lnd>0</rootpe_lnd>
+	  <rootpe_rof>0</rootpe_rof>
+	  <rootpe_ice>0</rootpe_ice>
+	  <rootpe_ocn>0</rootpe_ocn>
+	  <rootpe_glc>0</rootpe_glc>
+	  <rootpe_wav>0</rootpe_wav>
+	  <rootpe_cpl>0</rootpe_cpl>
 	</rootpe>
       </pes>
     </mach>
@@ -887,34 +990,34 @@
       <pes pesize="any" compset="any">
 	<comment>none</comment>
 	<ntasks>
-	  <ntasks_atm>-208</ntasks_atm> 
-	  <ntasks_lnd>-208</ntasks_lnd>           
-	  <ntasks_rof>-208</ntasks_rof> 
-	  <ntasks_ice>-208</ntasks_ice> 
-	  <ntasks_ocn>-208</ntasks_ocn> 
-	  <ntasks_glc>-208</ntasks_glc> 
-	  <ntasks_wav>-208</ntasks_wav> 
-	  <ntasks_cpl>-208</ntasks_cpl> 
+	  <ntasks_atm>-208</ntasks_atm>
+	  <ntasks_lnd>-208</ntasks_lnd>
+	  <ntasks_rof>-208</ntasks_rof>
+	  <ntasks_ice>-208</ntasks_ice>
+	  <ntasks_ocn>-208</ntasks_ocn>
+	  <ntasks_glc>-208</ntasks_glc>
+	  <ntasks_wav>-208</ntasks_wav>
+	  <ntasks_cpl>-208</ntasks_cpl>
 	</ntasks>
 	<nthrds>
-	  <nthrds_atm>8</nthrds_atm> 
-	  <nthrds_lnd>8</nthrds_lnd> 
-	  <nthrds_rof>8</nthrds_rof> 
-	  <nthrds_ice>8</nthrds_ice> 
-	  <nthrds_ocn>8</nthrds_ocn> 
-	  <nthrds_glc>8</nthrds_glc> 
-	  <nthrds_wav>8</nthrds_wav> 
-	  <nthrds_cpl>8</nthrds_cpl> 
+	  <nthrds_atm>8</nthrds_atm>
+	  <nthrds_lnd>8</nthrds_lnd>
+	  <nthrds_rof>8</nthrds_rof>
+	  <nthrds_ice>8</nthrds_ice>
+	  <nthrds_ocn>8</nthrds_ocn>
+	  <nthrds_glc>8</nthrds_glc>
+	  <nthrds_wav>8</nthrds_wav>
+	  <nthrds_cpl>8</nthrds_cpl>
 	</nthrds>
 	<rootpe>
-	  <rootpe_atm>0</rootpe_atm> 
-	  <rootpe_lnd>0</rootpe_lnd> 
-	  <rootpe_rof>0</rootpe_rof> 
-	  <rootpe_ice>0</rootpe_ice>    
-	  <rootpe_ocn>0</rootpe_ocn>   
-	  <rootpe_glc>0</rootpe_glc> 
-	  <rootpe_wav>0</rootpe_wav> 
-	  <rootpe_cpl>0</rootpe_cpl>                         
+	  <rootpe_atm>0</rootpe_atm>
+	  <rootpe_lnd>0</rootpe_lnd>
+	  <rootpe_rof>0</rootpe_rof>
+	  <rootpe_ice>0</rootpe_ice>
+	  <rootpe_ocn>0</rootpe_ocn>
+	  <rootpe_glc>0</rootpe_glc>
+	  <rootpe_wav>0</rootpe_wav>
+	  <rootpe_cpl>0</rootpe_cpl>
 	</rootpe>
       </pes>
     </mach>
@@ -924,34 +1027,34 @@
       <pes pesize="any" compset="_(CAM50|CAM60)%(CC|CV|CF|WC)">
 	<comment>none</comment>
 	<ntasks>
-	  <ntasks_atm>384</ntasks_atm> 
-	  <ntasks_lnd>384</ntasks_lnd>           
-	  <ntasks_rof>384</ntasks_rof> 
-	  <ntasks_ice>384</ntasks_ice> 
-	  <ntasks_ocn>384</ntasks_ocn> 
-	  <ntasks_glc>384</ntasks_glc> 
-	  <ntasks_wav>384</ntasks_wav> 
-	  <ntasks_cpl>384</ntasks_cpl> 
+	  <ntasks_atm>384</ntasks_atm>
+	  <ntasks_lnd>384</ntasks_lnd>
+	  <ntasks_rof>384</ntasks_rof>
+	  <ntasks_ice>384</ntasks_ice>
+	  <ntasks_ocn>384</ntasks_ocn>
+	  <ntasks_glc>384</ntasks_glc>
+	  <ntasks_wav>384</ntasks_wav>
+	  <ntasks_cpl>384</ntasks_cpl>
 	</ntasks>
 	<nthrds>
-	  <nthrds_atm>3</nthrds_atm> 
-	  <nthrds_lnd>3</nthrds_lnd> 
-	  <nthrds_rof>3</nthrds_rof> 
-	  <nthrds_ice>3</nthrds_ice> 
-	  <nthrds_ocn>3</nthrds_ocn> 
-	  <nthrds_glc>3</nthrds_glc> 
-	  <nthrds_wav>3</nthrds_wav> 
-	  <nthrds_cpl>3</nthrds_cpl> 
+	  <nthrds_atm>3</nthrds_atm>
+	  <nthrds_lnd>3</nthrds_lnd>
+	  <nthrds_rof>3</nthrds_rof>
+	  <nthrds_ice>3</nthrds_ice>
+	  <nthrds_ocn>3</nthrds_ocn>
+	  <nthrds_glc>3</nthrds_glc>
+	  <nthrds_wav>3</nthrds_wav>
+	  <nthrds_cpl>3</nthrds_cpl>
 	</nthrds>
 	<rootpe>
-	  <rootpe_atm>0</rootpe_atm> 
-	  <rootpe_lnd>0</rootpe_lnd> 
-	  <rootpe_rof>0</rootpe_rof> 
-	  <rootpe_ice>0</rootpe_ice>    
-	  <rootpe_ocn>0</rootpe_ocn>   
-	  <rootpe_glc>0</rootpe_glc> 
-	  <rootpe_wav>0</rootpe_wav> 
-	  <rootpe_cpl>0</rootpe_cpl>                         
+	  <rootpe_atm>0</rootpe_atm>
+	  <rootpe_lnd>0</rootpe_lnd>
+	  <rootpe_rof>0</rootpe_rof>
+	  <rootpe_ice>0</rootpe_ice>
+	  <rootpe_ocn>0</rootpe_ocn>
+	  <rootpe_glc>0</rootpe_glc>
+	  <rootpe_wav>0</rootpe_wav>
+	  <rootpe_cpl>0</rootpe_cpl>
 	</rootpe>
       </pes>
     </mach>
@@ -961,34 +1064,34 @@
       <pes pesize="any" compset="any">
 	<comment>none</comment>
 	<ntasks>
-	  <ntasks_atm>-8</ntasks_atm> 
-	  <ntasks_lnd>-8</ntasks_lnd>           
-	  <ntasks_rof>-8</ntasks_rof> 
-	  <ntasks_ice>-8</ntasks_ice> 
-	  <ntasks_ocn>-8</ntasks_ocn> 
-	  <ntasks_glc>-8</ntasks_glc> 
-	  <ntasks_wav>-8</ntasks_wav> 
-	  <ntasks_cpl>-8</ntasks_cpl> 
+	  <ntasks_atm>-8</ntasks_atm>
+	  <ntasks_lnd>-8</ntasks_lnd>
+	  <ntasks_rof>-8</ntasks_rof>
+	  <ntasks_ice>-8</ntasks_ice>
+	  <ntasks_ocn>-8</ntasks_ocn>
+	  <ntasks_glc>-8</ntasks_glc>
+	  <ntasks_wav>-8</ntasks_wav>
+	  <ntasks_cpl>-8</ntasks_cpl>
 	</ntasks>
 	<nthrds>
-	  <nthrds_atm>1</nthrds_atm>                   
-	  <nthrds_lnd>1</nthrds_lnd> 
-	  <nthrds_rof>1</nthrds_rof> 
-	  <nthrds_ice>1</nthrds_ice> 
-	  <nthrds_ocn>1</nthrds_ocn> 
-	  <nthrds_glc>1</nthrds_glc> 
-	  <nthrds_wav>1</nthrds_wav> 
-	  <nthrds_cpl>1</nthrds_cpl> 
+	  <nthrds_atm>1</nthrds_atm>
+	  <nthrds_lnd>1</nthrds_lnd>
+	  <nthrds_rof>1</nthrds_rof>
+	  <nthrds_ice>1</nthrds_ice>
+	  <nthrds_ocn>1</nthrds_ocn>
+	  <nthrds_glc>1</nthrds_glc>
+	  <nthrds_wav>1</nthrds_wav>
+	  <nthrds_cpl>1</nthrds_cpl>
 	</nthrds>
 	<rootpe>
-	  <rootpe_atm>0</rootpe_atm> 
-	  <rootpe_lnd>0</rootpe_lnd> 
-	  <rootpe_rof>0</rootpe_rof> 
-	  <rootpe_ice>0</rootpe_ice>    
-	  <rootpe_ocn>0</rootpe_ocn>   
-	  <rootpe_glc>0</rootpe_glc> 
-	  <rootpe_wav>0</rootpe_wav> 
-	  <rootpe_cpl>0</rootpe_cpl>                         
+	  <rootpe_atm>0</rootpe_atm>
+	  <rootpe_lnd>0</rootpe_lnd>
+	  <rootpe_rof>0</rootpe_rof>
+	  <rootpe_ice>0</rootpe_ice>
+	  <rootpe_ocn>0</rootpe_ocn>
+	  <rootpe_glc>0</rootpe_glc>
+	  <rootpe_wav>0</rootpe_wav>
+	  <rootpe_cpl>0</rootpe_cpl>
 	</rootpe>
       </pes>
     </mach>
@@ -996,34 +1099,34 @@
       <pes pesize="any" compset="_CAM60%(CC|WC)">
 	<comment>none</comment>
 	<ntasks>
-	  <ntasks_atm>768</ntasks_atm> 
-	  <ntasks_lnd>768</ntasks_lnd>           
-	  <ntasks_rof>768</ntasks_rof> 
-	  <ntasks_ice>768</ntasks_ice> 
-	  <ntasks_ocn>768</ntasks_ocn> 
-	  <ntasks_glc>768</ntasks_glc> 
-	  <ntasks_wav>768</ntasks_wav> 
-	  <ntasks_cpl>768</ntasks_cpl> 
+	  <ntasks_atm>768</ntasks_atm>
+	  <ntasks_lnd>768</ntasks_lnd>
+	  <ntasks_rof>768</ntasks_rof>
+	  <ntasks_ice>768</ntasks_ice>
+	  <ntasks_ocn>768</ntasks_ocn>
+	  <ntasks_glc>768</ntasks_glc>
+	  <ntasks_wav>768</ntasks_wav>
+	  <ntasks_cpl>768</ntasks_cpl>
 	</ntasks>
 	<nthrds>
-	  <nthrds_atm>3</nthrds_atm>                   
-	  <nthrds_lnd>3</nthrds_lnd> 
-	  <nthrds_rof>3</nthrds_rof> 
-	  <nthrds_ice>3</nthrds_ice> 
-	  <nthrds_ocn>3</nthrds_ocn> 
-	  <nthrds_glc>3</nthrds_glc> 
-	  <nthrds_wav>3</nthrds_wav> 
-	  <nthrds_cpl>3</nthrds_cpl> 
+	  <nthrds_atm>3</nthrds_atm>
+	  <nthrds_lnd>3</nthrds_lnd>
+	  <nthrds_rof>3</nthrds_rof>
+	  <nthrds_ice>3</nthrds_ice>
+	  <nthrds_ocn>3</nthrds_ocn>
+	  <nthrds_glc>3</nthrds_glc>
+	  <nthrds_wav>3</nthrds_wav>
+	  <nthrds_cpl>3</nthrds_cpl>
 	</nthrds>
 	<rootpe>
-	  <rootpe_atm>0</rootpe_atm> 
-	  <rootpe_lnd>0</rootpe_lnd> 
-	  <rootpe_rof>0</rootpe_rof> 
-	  <rootpe_ice>0</rootpe_ice>    
-	  <rootpe_ocn>0</rootpe_ocn>   
-	  <rootpe_glc>0</rootpe_glc> 
-	  <rootpe_wav>0</rootpe_wav> 
-	  <rootpe_cpl>0</rootpe_cpl>                         
+	  <rootpe_atm>0</rootpe_atm>
+	  <rootpe_lnd>0</rootpe_lnd>
+	  <rootpe_rof>0</rootpe_rof>
+	  <rootpe_ice>0</rootpe_ice>
+	  <rootpe_ocn>0</rootpe_ocn>
+	  <rootpe_glc>0</rootpe_glc>
+	  <rootpe_wav>0</rootpe_wav>
+	  <rootpe_cpl>0</rootpe_cpl>
 	</rootpe>
       </pes>
       <pes pesize="any" compset="_CAM\d0%WX">
@@ -1066,34 +1169,34 @@
       <pes pesize="any" compset="any">
 	<comment>none</comment>
 	<ntasks>
-	  <ntasks_atm>480</ntasks_atm> 
-	  <ntasks_lnd>480</ntasks_lnd>           
-	  <ntasks_rof>480</ntasks_rof> 
-	  <ntasks_ice>480</ntasks_ice> 
-	  <ntasks_ocn>480</ntasks_ocn> 
-	  <ntasks_glc>480</ntasks_glc> 
-	  <ntasks_wav>480</ntasks_wav> 
-	  <ntasks_cpl>480</ntasks_cpl> 
+	  <ntasks_atm>480</ntasks_atm>
+	  <ntasks_lnd>480</ntasks_lnd>
+	  <ntasks_rof>480</ntasks_rof>
+	  <ntasks_ice>480</ntasks_ice>
+	  <ntasks_ocn>480</ntasks_ocn>
+	  <ntasks_glc>480</ntasks_glc>
+	  <ntasks_wav>480</ntasks_wav>
+	  <ntasks_cpl>480</ntasks_cpl>
 	</ntasks>
 	<nthrds>
 	  <nthrds_atm>1</nthrds_atm>
-	  <nthrds_lnd>1</nthrds_lnd> 
-	  <nthrds_rof>1</nthrds_rof> 
-	  <nthrds_ice>1</nthrds_ice> 
-	  <nthrds_ocn>1</nthrds_ocn> 
-	  <nthrds_glc>1</nthrds_glc> 
-	  <nthrds_wav>1</nthrds_wav> 
-	  <nthrds_cpl>1</nthrds_cpl> 
+	  <nthrds_lnd>1</nthrds_lnd>
+	  <nthrds_rof>1</nthrds_rof>
+	  <nthrds_ice>1</nthrds_ice>
+	  <nthrds_ocn>1</nthrds_ocn>
+	  <nthrds_glc>1</nthrds_glc>
+	  <nthrds_wav>1</nthrds_wav>
+	  <nthrds_cpl>1</nthrds_cpl>
 	</nthrds>
 	<rootpe>
-	  <rootpe_atm>0</rootpe_atm> 
-	  <rootpe_lnd>0</rootpe_lnd> 
-	  <rootpe_rof>0</rootpe_rof> 
-	  <rootpe_ice>0</rootpe_ice>    
-	  <rootpe_ocn>0</rootpe_ocn>   
-	  <rootpe_glc>0</rootpe_glc> 
-	  <rootpe_wav>0</rootpe_wav> 
-	  <rootpe_cpl>0</rootpe_cpl>                         
+	  <rootpe_atm>0</rootpe_atm>
+	  <rootpe_lnd>0</rootpe_lnd>
+	  <rootpe_rof>0</rootpe_rof>
+	  <rootpe_ice>0</rootpe_ice>
+	  <rootpe_ocn>0</rootpe_ocn>
+	  <rootpe_glc>0</rootpe_glc>
+	  <rootpe_wav>0</rootpe_wav>
+	  <rootpe_cpl>0</rootpe_cpl>
 	</rootpe>
       </pes>
     </mach>
@@ -1103,34 +1206,34 @@
       <pes pesize="any" compset="any">
 	<comment>none</comment>
 	<ntasks>
-	  <ntasks_atm>-16</ntasks_atm> 
-	  <ntasks_lnd>-16</ntasks_lnd>           
-	  <ntasks_rof>-16</ntasks_rof> 
-	  <ntasks_ice>-16</ntasks_ice> 
-	  <ntasks_ocn>-16</ntasks_ocn> 
-	  <ntasks_glc>-16</ntasks_glc> 
-	  <ntasks_wav>-16</ntasks_wav> 
-	  <ntasks_cpl>-16</ntasks_cpl> 
+	  <ntasks_atm>-16</ntasks_atm>
+	  <ntasks_lnd>-16</ntasks_lnd>
+	  <ntasks_rof>-16</ntasks_rof>
+	  <ntasks_ice>-16</ntasks_ice>
+	  <ntasks_ocn>-16</ntasks_ocn>
+	  <ntasks_glc>-16</ntasks_glc>
+	  <ntasks_wav>-16</ntasks_wav>
+	  <ntasks_cpl>-16</ntasks_cpl>
 	</ntasks>
 	<nthrds>
-	  <nthrds_atm>1</nthrds_atm>                   
-	  <nthrds_lnd>1</nthrds_lnd> 
-	  <nthrds_rof>1</nthrds_rof> 
-	  <nthrds_ice>1</nthrds_ice> 
-	  <nthrds_ocn>1</nthrds_ocn> 
-	  <nthrds_glc>1</nthrds_glc> 
-	  <nthrds_wav>1</nthrds_wav> 
-	  <nthrds_cpl>1</nthrds_cpl> 
+	  <nthrds_atm>1</nthrds_atm>
+	  <nthrds_lnd>1</nthrds_lnd>
+	  <nthrds_rof>1</nthrds_rof>
+	  <nthrds_ice>1</nthrds_ice>
+	  <nthrds_ocn>1</nthrds_ocn>
+	  <nthrds_glc>1</nthrds_glc>
+	  <nthrds_wav>1</nthrds_wav>
+	  <nthrds_cpl>1</nthrds_cpl>
 	</nthrds>
 	<rootpe>
-	  <rootpe_atm>0</rootpe_atm> 
-	  <rootpe_lnd>0</rootpe_lnd> 
-	  <rootpe_rof>0</rootpe_rof> 
-	  <rootpe_ice>0</rootpe_ice>    
-	  <rootpe_ocn>0</rootpe_ocn>   
-	  <rootpe_glc>0</rootpe_glc> 
-	  <rootpe_wav>0</rootpe_wav> 
-	  <rootpe_cpl>0</rootpe_cpl>                         
+	  <rootpe_atm>0</rootpe_atm>
+	  <rootpe_lnd>0</rootpe_lnd>
+	  <rootpe_rof>0</rootpe_rof>
+	  <rootpe_ice>0</rootpe_ice>
+	  <rootpe_ocn>0</rootpe_ocn>
+	  <rootpe_glc>0</rootpe_glc>
+	  <rootpe_wav>0</rootpe_wav>
+	  <rootpe_cpl>0</rootpe_cpl>
 	</rootpe>
       </pes>
     </mach>
@@ -1140,34 +1243,34 @@
       <pes pesize="any" compset="any">
 	<comment>none</comment>
 	<ntasks>
-	  <ntasks_atm>960</ntasks_atm> 
-	  <ntasks_lnd>960</ntasks_lnd>           
-	  <ntasks_rof>960</ntasks_rof> 
-	  <ntasks_ice>960</ntasks_ice> 
-	  <ntasks_ocn>960</ntasks_ocn> 
-	  <ntasks_glc>960</ntasks_glc> 
-	  <ntasks_wav>960</ntasks_wav> 
-	  <ntasks_cpl>960</ntasks_cpl> 
+	  <ntasks_atm>960</ntasks_atm>
+	  <ntasks_lnd>960</ntasks_lnd>
+	  <ntasks_rof>960</ntasks_rof>
+	  <ntasks_ice>960</ntasks_ice>
+	  <ntasks_ocn>960</ntasks_ocn>
+	  <ntasks_glc>960</ntasks_glc>
+	  <ntasks_wav>960</ntasks_wav>
+	  <ntasks_cpl>960</ntasks_cpl>
 	</ntasks>
 	<nthrds>
 	  <nthrds_atm>1</nthrds_atm>
-	  <nthrds_lnd>1</nthrds_lnd> 
-	  <nthrds_rof>1</nthrds_rof> 
-	  <nthrds_ice>1</nthrds_ice> 
-	  <nthrds_ocn>1</nthrds_ocn> 
-	  <nthrds_glc>1</nthrds_glc> 
-	  <nthrds_wav>1</nthrds_wav> 
-	  <nthrds_cpl>1</nthrds_cpl> 
+	  <nthrds_lnd>1</nthrds_lnd>
+	  <nthrds_rof>1</nthrds_rof>
+	  <nthrds_ice>1</nthrds_ice>
+	  <nthrds_ocn>1</nthrds_ocn>
+	  <nthrds_glc>1</nthrds_glc>
+	  <nthrds_wav>1</nthrds_wav>
+	  <nthrds_cpl>1</nthrds_cpl>
 	</nthrds>
 	<rootpe>
-	  <rootpe_atm>0</rootpe_atm> 
-	  <rootpe_lnd>0</rootpe_lnd> 
-	  <rootpe_rof>0</rootpe_rof> 
-	  <rootpe_ice>0</rootpe_ice>    
-	  <rootpe_ocn>0</rootpe_ocn>   
-	  <rootpe_glc>0</rootpe_glc> 
-	  <rootpe_wav>0</rootpe_wav> 
-	  <rootpe_cpl>0</rootpe_cpl>                         
+	  <rootpe_atm>0</rootpe_atm>
+	  <rootpe_lnd>0</rootpe_lnd>
+	  <rootpe_rof>0</rootpe_rof>
+	  <rootpe_ice>0</rootpe_ice>
+	  <rootpe_ocn>0</rootpe_ocn>
+	  <rootpe_glc>0</rootpe_glc>
+	  <rootpe_wav>0</rootpe_wav>
+	  <rootpe_cpl>0</rootpe_cpl>
 	</rootpe>
       </pes>
     </mach>
@@ -1177,14 +1280,14 @@
     <mach name="any">
       <pes pesize="any" compset="AR9[57]">
 	<ntasks>
-	  <ntasks_atm>1</ntasks_atm> 
-	  <ntasks_lnd>1</ntasks_lnd>           
-	  <ntasks_rof>1</ntasks_rof> 
-	  <ntasks_ice>1</ntasks_ice> 
-	  <ntasks_ocn>1</ntasks_ocn> 
-	  <ntasks_glc>1</ntasks_glc> 
-	  <ntasks_wav>1</ntasks_wav> 
-	  <ntasks_cpl>1</ntasks_cpl> 
+	  <ntasks_atm>1</ntasks_atm>
+	  <ntasks_lnd>1</ntasks_lnd>
+	  <ntasks_rof>1</ntasks_rof>
+	  <ntasks_ice>1</ntasks_ice>
+	  <ntasks_ocn>1</ntasks_ocn>
+	  <ntasks_glc>1</ntasks_glc>
+	  <ntasks_wav>1</ntasks_wav>
+	  <ntasks_cpl>1</ntasks_cpl>
 	</ntasks>
       </pes>
     </mach>
@@ -1196,34 +1299,34 @@
       <pes pesize="any" compset="any">
         <comment>none</comment>
 	      <ntasks>
-	        <ntasks_atm>-1</ntasks_atm> 
-	        <ntasks_lnd>-1</ntasks_lnd>           
-	        <ntasks_rof>-1</ntasks_rof> 
-	        <ntasks_ice>-1</ntasks_ice> 
-	        <ntasks_ocn>-1</ntasks_ocn> 
-	        <ntasks_glc>-1</ntasks_glc> 
-	        <ntasks_wav>-1</ntasks_wav> 
-	        <ntasks_cpl>-1</ntasks_cpl> 
+	        <ntasks_atm>-1</ntasks_atm>
+	        <ntasks_lnd>-1</ntasks_lnd>
+	        <ntasks_rof>-1</ntasks_rof>
+	        <ntasks_ice>-1</ntasks_ice>
+	        <ntasks_ocn>-1</ntasks_ocn>
+	        <ntasks_glc>-1</ntasks_glc>
+	        <ntasks_wav>-1</ntasks_wav>
+	        <ntasks_cpl>-1</ntasks_cpl>
 	      </ntasks>
 	      <nthrds>
 	        <nthrds_atm>1</nthrds_atm>
-	        <nthrds_lnd>1</nthrds_lnd> 
-	        <nthrds_rof>1</nthrds_rof> 
-	        <nthrds_ice>1</nthrds_ice> 
-	        <nthrds_ocn>1</nthrds_ocn> 
-	        <nthrds_glc>1</nthrds_glc> 
-	        <nthrds_wav>1</nthrds_wav> 
-	        <nthrds_cpl>1</nthrds_cpl> 
+	        <nthrds_lnd>1</nthrds_lnd>
+	        <nthrds_rof>1</nthrds_rof>
+	        <nthrds_ice>1</nthrds_ice>
+	        <nthrds_ocn>1</nthrds_ocn>
+	        <nthrds_glc>1</nthrds_glc>
+	        <nthrds_wav>1</nthrds_wav>
+	        <nthrds_cpl>1</nthrds_cpl>
 	      </nthrds>
 	      <rootpe>
-	        <rootpe_atm>0</rootpe_atm> 
-	        <rootpe_lnd>0</rootpe_lnd> 
-	        <rootpe_rof>0</rootpe_rof> 
-	        <rootpe_ice>0</rootpe_ice>    
-	        <rootpe_ocn>0</rootpe_ocn>   
-	        <rootpe_glc>0</rootpe_glc> 
-	        <rootpe_wav>0</rootpe_wav> 
-	        <rootpe_cpl>0</rootpe_cpl>                         
+	        <rootpe_atm>0</rootpe_atm>
+	        <rootpe_lnd>0</rootpe_lnd>
+	        <rootpe_rof>0</rootpe_rof>
+	        <rootpe_ice>0</rootpe_ice>
+	        <rootpe_ocn>0</rootpe_ocn>
+	        <rootpe_glc>0</rootpe_glc>
+	        <rootpe_wav>0</rootpe_wav>
+	        <rootpe_cpl>0</rootpe_cpl>
         </rootpe>
       </pes>
     </mach>
@@ -1234,34 +1337,34 @@
       <pes pesize="any" compset="any">
         <comment>none</comment>
 	      <ntasks>
-	        <ntasks_atm>-4</ntasks_atm> 
-	        <ntasks_lnd>-4</ntasks_lnd>           
-	        <ntasks_rof>-4</ntasks_rof> 
-	        <ntasks_ice>-4</ntasks_ice> 
-	        <ntasks_ocn>-4</ntasks_ocn> 
-	        <ntasks_glc>-4</ntasks_glc> 
-	        <ntasks_wav>-4</ntasks_wav> 
-	        <ntasks_cpl>-4</ntasks_cpl> 
+	        <ntasks_atm>-4</ntasks_atm>
+	        <ntasks_lnd>-4</ntasks_lnd>
+	        <ntasks_rof>-4</ntasks_rof>
+	        <ntasks_ice>-4</ntasks_ice>
+	        <ntasks_ocn>-4</ntasks_ocn>
+	        <ntasks_glc>-4</ntasks_glc>
+	        <ntasks_wav>-4</ntasks_wav>
+	        <ntasks_cpl>-4</ntasks_cpl>
 	      </ntasks>
 	      <nthrds>
 	        <nthrds_atm>1</nthrds_atm>
-	        <nthrds_lnd>1</nthrds_lnd> 
-	        <nthrds_rof>1</nthrds_rof> 
-	        <nthrds_ice>1</nthrds_ice> 
-	        <nthrds_ocn>1</nthrds_ocn> 
-	        <nthrds_glc>1</nthrds_glc> 
-	        <nthrds_wav>1</nthrds_wav> 
-	        <nthrds_cpl>1</nthrds_cpl> 
+	        <nthrds_lnd>1</nthrds_lnd>
+	        <nthrds_rof>1</nthrds_rof>
+	        <nthrds_ice>1</nthrds_ice>
+	        <nthrds_ocn>1</nthrds_ocn>
+	        <nthrds_glc>1</nthrds_glc>
+	        <nthrds_wav>1</nthrds_wav>
+	        <nthrds_cpl>1</nthrds_cpl>
 	      </nthrds>
 	      <rootpe>
-	        <rootpe_atm>0</rootpe_atm> 
-	        <rootpe_lnd>0</rootpe_lnd> 
-	        <rootpe_rof>0</rootpe_rof> 
-	        <rootpe_ice>0</rootpe_ice>    
-	        <rootpe_ocn>0</rootpe_ocn>   
-	        <rootpe_glc>0</rootpe_glc> 
-	        <rootpe_wav>0</rootpe_wav> 
-	        <rootpe_cpl>0</rootpe_cpl>                         
+	        <rootpe_atm>0</rootpe_atm>
+	        <rootpe_lnd>0</rootpe_lnd>
+	        <rootpe_rof>0</rootpe_rof>
+	        <rootpe_ice>0</rootpe_ice>
+	        <rootpe_ocn>0</rootpe_ocn>
+	        <rootpe_glc>0</rootpe_glc>
+	        <rootpe_wav>0</rootpe_wav>
+	        <rootpe_cpl>0</rootpe_cpl>
         </rootpe>
       </pes>
     </mach>
@@ -1272,34 +1375,34 @@
       <pes pesize="any" compset="any">
         <comment>none</comment>
 	      <ntasks>
-	        <ntasks_atm>-16</ntasks_atm> 
-	        <ntasks_lnd>-16</ntasks_lnd>           
-	        <ntasks_rof>-16</ntasks_rof> 
-	        <ntasks_ice>-16</ntasks_ice> 
-	        <ntasks_ocn>-16</ntasks_ocn> 
-	        <ntasks_glc>-16</ntasks_glc> 
-	        <ntasks_wav>-16</ntasks_wav> 
-	        <ntasks_cpl>-16</ntasks_cpl> 
+	        <ntasks_atm>-16</ntasks_atm>
+	        <ntasks_lnd>-16</ntasks_lnd>
+	        <ntasks_rof>-16</ntasks_rof>
+	        <ntasks_ice>-16</ntasks_ice>
+	        <ntasks_ocn>-16</ntasks_ocn>
+	        <ntasks_glc>-16</ntasks_glc>
+	        <ntasks_wav>-16</ntasks_wav>
+	        <ntasks_cpl>-16</ntasks_cpl>
 	      </ntasks>
 	      <nthrds>
 	        <nthrds_atm>1</nthrds_atm>
-	        <nthrds_lnd>1</nthrds_lnd> 
-	        <nthrds_rof>1</nthrds_rof> 
-	        <nthrds_ice>1</nthrds_ice> 
-	        <nthrds_ocn>1</nthrds_ocn> 
-	        <nthrds_glc>1</nthrds_glc> 
-	        <nthrds_wav>1</nthrds_wav> 
-	        <nthrds_cpl>1</nthrds_cpl> 
+	        <nthrds_lnd>1</nthrds_lnd>
+	        <nthrds_rof>1</nthrds_rof>
+	        <nthrds_ice>1</nthrds_ice>
+	        <nthrds_ocn>1</nthrds_ocn>
+	        <nthrds_glc>1</nthrds_glc>
+	        <nthrds_wav>1</nthrds_wav>
+	        <nthrds_cpl>1</nthrds_cpl>
 	      </nthrds>
 	      <rootpe>
-	        <rootpe_atm>0</rootpe_atm> 
-	        <rootpe_lnd>0</rootpe_lnd> 
-	        <rootpe_rof>0</rootpe_rof> 
-	        <rootpe_ice>0</rootpe_ice>    
-	        <rootpe_ocn>0</rootpe_ocn>   
-	        <rootpe_glc>0</rootpe_glc> 
-	        <rootpe_wav>0</rootpe_wav> 
-	        <rootpe_cpl>0</rootpe_cpl>                         
+	        <rootpe_atm>0</rootpe_atm>
+	        <rootpe_lnd>0</rootpe_lnd>
+	        <rootpe_rof>0</rootpe_rof>
+	        <rootpe_ice>0</rootpe_ice>
+	        <rootpe_ocn>0</rootpe_ocn>
+	        <rootpe_glc>0</rootpe_glc>
+	        <rootpe_wav>0</rootpe_wav>
+	        <rootpe_cpl>0</rootpe_cpl>
         </rootpe>
       </pes>
     </mach>
@@ -1310,34 +1413,34 @@
       <pes pesize="any" compset="any">
         <comment>none</comment>
 	      <ntasks>
-	        <ntasks_atm>-32</ntasks_atm> 
-	        <ntasks_lnd>-32</ntasks_lnd>           
-	        <ntasks_rof>-32</ntasks_rof> 
-	        <ntasks_ice>-32</ntasks_ice> 
-	        <ntasks_ocn>-32</ntasks_ocn> 
-	        <ntasks_glc>-32</ntasks_glc> 
-	        <ntasks_wav>-32</ntasks_wav> 
-	        <ntasks_cpl>-32</ntasks_cpl> 
+	        <ntasks_atm>-32</ntasks_atm>
+	        <ntasks_lnd>-32</ntasks_lnd>
+	        <ntasks_rof>-32</ntasks_rof>
+	        <ntasks_ice>-32</ntasks_ice>
+	        <ntasks_ocn>-32</ntasks_ocn>
+	        <ntasks_glc>-32</ntasks_glc>
+	        <ntasks_wav>-32</ntasks_wav>
+	        <ntasks_cpl>-32</ntasks_cpl>
 	      </ntasks>
 	      <nthrds>
 	        <nthrds_atm>1</nthrds_atm>
-	        <nthrds_lnd>1</nthrds_lnd> 
-	        <nthrds_rof>1</nthrds_rof> 
-	        <nthrds_ice>1</nthrds_ice> 
-	        <nthrds_ocn>1</nthrds_ocn> 
-	        <nthrds_glc>1</nthrds_glc> 
-	        <nthrds_wav>1</nthrds_wav> 
-	        <nthrds_cpl>1</nthrds_cpl> 
+	        <nthrds_lnd>1</nthrds_lnd>
+	        <nthrds_rof>1</nthrds_rof>
+	        <nthrds_ice>1</nthrds_ice>
+	        <nthrds_ocn>1</nthrds_ocn>
+	        <nthrds_glc>1</nthrds_glc>
+	        <nthrds_wav>1</nthrds_wav>
+	        <nthrds_cpl>1</nthrds_cpl>
 	      </nthrds>
 	      <rootpe>
-	        <rootpe_atm>0</rootpe_atm> 
-	        <rootpe_lnd>0</rootpe_lnd> 
-	        <rootpe_rof>0</rootpe_rof> 
-	        <rootpe_ice>0</rootpe_ice>    
-	        <rootpe_ocn>0</rootpe_ocn>   
-	        <rootpe_glc>0</rootpe_glc> 
-	        <rootpe_wav>0</rootpe_wav> 
-	        <rootpe_cpl>0</rootpe_cpl>                         
+	        <rootpe_atm>0</rootpe_atm>
+	        <rootpe_lnd>0</rootpe_lnd>
+	        <rootpe_rof>0</rootpe_rof>
+	        <rootpe_ice>0</rootpe_ice>
+	        <rootpe_ocn>0</rootpe_ocn>
+	        <rootpe_glc>0</rootpe_glc>
+	        <rootpe_wav>0</rootpe_wav>
+	        <rootpe_cpl>0</rootpe_cpl>
         </rootpe>
       </pes>
     </mach>
@@ -1348,34 +1451,34 @@
       <pes pesize="any" compset="any">
         <comment>none</comment>
 	      <ntasks>
-	        <ntasks_atm>-32</ntasks_atm> 
-	        <ntasks_lnd>-32</ntasks_lnd>           
-	        <ntasks_rof>-32</ntasks_rof> 
-	        <ntasks_ice>-32</ntasks_ice> 
-	        <ntasks_ocn>-32</ntasks_ocn> 
-	        <ntasks_glc>-32</ntasks_glc> 
-	        <ntasks_wav>-32</ntasks_wav> 
-	        <ntasks_cpl>-32</ntasks_cpl> 
+	        <ntasks_atm>-32</ntasks_atm>
+	        <ntasks_lnd>-32</ntasks_lnd>
+	        <ntasks_rof>-32</ntasks_rof>
+	        <ntasks_ice>-32</ntasks_ice>
+	        <ntasks_ocn>-32</ntasks_ocn>
+	        <ntasks_glc>-32</ntasks_glc>
+	        <ntasks_wav>-32</ntasks_wav>
+	        <ntasks_cpl>-32</ntasks_cpl>
 	      </ntasks>
 	      <nthrds>
 	        <nthrds_atm>1</nthrds_atm>
-	        <nthrds_lnd>1</nthrds_lnd> 
-	        <nthrds_rof>1</nthrds_rof> 
-	        <nthrds_ice>1</nthrds_ice> 
-	        <nthrds_ocn>1</nthrds_ocn> 
-	        <nthrds_glc>1</nthrds_glc> 
-	        <nthrds_wav>1</nthrds_wav> 
-	        <nthrds_cpl>1</nthrds_cpl> 
+	        <nthrds_lnd>1</nthrds_lnd>
+	        <nthrds_rof>1</nthrds_rof>
+	        <nthrds_ice>1</nthrds_ice>
+	        <nthrds_ocn>1</nthrds_ocn>
+	        <nthrds_glc>1</nthrds_glc>
+	        <nthrds_wav>1</nthrds_wav>
+	        <nthrds_cpl>1</nthrds_cpl>
 	      </nthrds>
 	      <rootpe>
-	        <rootpe_atm>0</rootpe_atm> 
-	        <rootpe_lnd>0</rootpe_lnd> 
-	        <rootpe_rof>0</rootpe_rof> 
-	        <rootpe_ice>0</rootpe_ice>    
-	        <rootpe_ocn>0</rootpe_ocn>   
-	        <rootpe_glc>0</rootpe_glc> 
-	        <rootpe_wav>0</rootpe_wav> 
-	        <rootpe_cpl>0</rootpe_cpl>                         
+	        <rootpe_atm>0</rootpe_atm>
+	        <rootpe_lnd>0</rootpe_lnd>
+	        <rootpe_rof>0</rootpe_rof>
+	        <rootpe_ice>0</rootpe_ice>
+	        <rootpe_ocn>0</rootpe_ocn>
+	        <rootpe_glc>0</rootpe_glc>
+	        <rootpe_wav>0</rootpe_wav>
+	        <rootpe_cpl>0</rootpe_cpl>
         </rootpe>
       </pes>
     </mach>
@@ -1388,34 +1491,34 @@
       <pes pesize="any" compset="any">
         <comment>none</comment>
 	      <ntasks>
-	        <ntasks_atm>-91</ntasks_atm> 
-	        <ntasks_lnd>-91</ntasks_lnd>           
-	        <ntasks_rof>-91</ntasks_rof> 
-	        <ntasks_ice>-91</ntasks_ice> 
-	        <ntasks_ocn>-91</ntasks_ocn> 
-	        <ntasks_glc>-91</ntasks_glc> 
-	        <ntasks_wav>-91</ntasks_wav> 
-	        <ntasks_cpl>-91</ntasks_cpl> 
+	        <ntasks_atm>-91</ntasks_atm>
+	        <ntasks_lnd>-91</ntasks_lnd>
+	        <ntasks_rof>-91</ntasks_rof>
+	        <ntasks_ice>-91</ntasks_ice>
+	        <ntasks_ocn>-91</ntasks_ocn>
+	        <ntasks_glc>-91</ntasks_glc>
+	        <ntasks_wav>-91</ntasks_wav>
+	        <ntasks_cpl>-91</ntasks_cpl>
 	      </ntasks>
 	      <nthrds>
 	        <nthrds_atm>1</nthrds_atm>
-	        <nthrds_lnd>1</nthrds_lnd> 
-	        <nthrds_rof>1</nthrds_rof> 
-	        <nthrds_ice>1</nthrds_ice> 
-	        <nthrds_ocn>1</nthrds_ocn> 
-	        <nthrds_glc>1</nthrds_glc> 
-	        <nthrds_wav>1</nthrds_wav> 
-	        <nthrds_cpl>1</nthrds_cpl> 
+	        <nthrds_lnd>1</nthrds_lnd>
+	        <nthrds_rof>1</nthrds_rof>
+	        <nthrds_ice>1</nthrds_ice>
+	        <nthrds_ocn>1</nthrds_ocn>
+	        <nthrds_glc>1</nthrds_glc>
+	        <nthrds_wav>1</nthrds_wav>
+	        <nthrds_cpl>1</nthrds_cpl>
 	      </nthrds>
 	      <rootpe>
-	        <rootpe_atm>0</rootpe_atm> 
-	        <rootpe_lnd>0</rootpe_lnd> 
-	        <rootpe_rof>0</rootpe_rof> 
-	        <rootpe_ice>0</rootpe_ice>    
-	        <rootpe_ocn>0</rootpe_ocn>   
-	        <rootpe_glc>0</rootpe_glc> 
-	        <rootpe_wav>0</rootpe_wav> 
-	        <rootpe_cpl>0</rootpe_cpl>                         
+	        <rootpe_atm>0</rootpe_atm>
+	        <rootpe_lnd>0</rootpe_lnd>
+	        <rootpe_rof>0</rootpe_rof>
+	        <rootpe_ice>0</rootpe_ice>
+	        <rootpe_ocn>0</rootpe_ocn>
+	        <rootpe_glc>0</rootpe_glc>
+	        <rootpe_wav>0</rootpe_wav>
+	        <rootpe_cpl>0</rootpe_cpl>
         </rootpe>
       </pes>
     </mach>
@@ -1426,34 +1529,34 @@
       <pes pesize="any" compset="any">
         <comment>none</comment>
 	      <ntasks>
-	        <ntasks_atm>-118</ntasks_atm> 
-	        <ntasks_lnd>-118</ntasks_lnd>           
-	        <ntasks_rof>-118</ntasks_rof> 
-	        <ntasks_ice>-118</ntasks_ice> 
-	        <ntasks_ocn>-118</ntasks_ocn> 
-	        <ntasks_glc>-118</ntasks_glc> 
-	        <ntasks_wav>-118</ntasks_wav> 
-	        <ntasks_cpl>-118</ntasks_cpl> 
+	        <ntasks_atm>-118</ntasks_atm>
+	        <ntasks_lnd>-118</ntasks_lnd>
+	        <ntasks_rof>-118</ntasks_rof>
+	        <ntasks_ice>-118</ntasks_ice>
+	        <ntasks_ocn>-118</ntasks_ocn>
+	        <ntasks_glc>-118</ntasks_glc>
+	        <ntasks_wav>-118</ntasks_wav>
+	        <ntasks_cpl>-118</ntasks_cpl>
 	      </ntasks>
 	      <nthrds>
 	        <nthrds_atm>1</nthrds_atm>
-	        <nthrds_lnd>1</nthrds_lnd> 
-	        <nthrds_rof>1</nthrds_rof> 
-	        <nthrds_ice>1</nthrds_ice> 
-	        <nthrds_ocn>1</nthrds_ocn> 
-	        <nthrds_glc>1</nthrds_glc> 
-	        <nthrds_wav>1</nthrds_wav> 
-	        <nthrds_cpl>1</nthrds_cpl> 
+	        <nthrds_lnd>1</nthrds_lnd>
+	        <nthrds_rof>1</nthrds_rof>
+	        <nthrds_ice>1</nthrds_ice>
+	        <nthrds_ocn>1</nthrds_ocn>
+	        <nthrds_glc>1</nthrds_glc>
+	        <nthrds_wav>1</nthrds_wav>
+	        <nthrds_cpl>1</nthrds_cpl>
 	      </nthrds>
 	      <rootpe>
-	        <rootpe_atm>0</rootpe_atm> 
-	        <rootpe_lnd>0</rootpe_lnd> 
-	        <rootpe_rof>0</rootpe_rof> 
-	        <rootpe_ice>0</rootpe_ice>    
-	        <rootpe_ocn>0</rootpe_ocn>   
-	        <rootpe_glc>0</rootpe_glc> 
-	        <rootpe_wav>0</rootpe_wav> 
-	        <rootpe_cpl>0</rootpe_cpl>                         
+	        <rootpe_atm>0</rootpe_atm>
+	        <rootpe_lnd>0</rootpe_lnd>
+	        <rootpe_rof>0</rootpe_rof>
+	        <rootpe_ice>0</rootpe_ice>
+	        <rootpe_ocn>0</rootpe_ocn>
+	        <rootpe_glc>0</rootpe_glc>
+	        <rootpe_wav>0</rootpe_wav>
+	        <rootpe_cpl>0</rootpe_cpl>
         </rootpe>
       </pes>
     </mach>
@@ -1464,34 +1567,34 @@
       <pes pesize="any" compset="any">
         <comment>none</comment>
 	      <ntasks>
-	        <ntasks_atm>-135</ntasks_atm> 
-	        <ntasks_lnd>-135</ntasks_lnd>           
-	        <ntasks_rof>-135</ntasks_rof> 
-	        <ntasks_ice>-135</ntasks_ice> 
-	        <ntasks_ocn>-135</ntasks_ocn> 
-	        <ntasks_glc>-135</ntasks_glc> 
-	        <ntasks_wav>-135</ntasks_wav> 
-	        <ntasks_cpl>-135</ntasks_cpl> 
+	        <ntasks_atm>-135</ntasks_atm>
+	        <ntasks_lnd>-135</ntasks_lnd>
+	        <ntasks_rof>-135</ntasks_rof>
+	        <ntasks_ice>-135</ntasks_ice>
+	        <ntasks_ocn>-135</ntasks_ocn>
+	        <ntasks_glc>-135</ntasks_glc>
+	        <ntasks_wav>-135</ntasks_wav>
+	        <ntasks_cpl>-135</ntasks_cpl>
 	      </ntasks>
 	      <nthrds>
 	        <nthrds_atm>1</nthrds_atm>
-	        <nthrds_lnd>1</nthrds_lnd> 
-	        <nthrds_rof>1</nthrds_rof> 
-	        <nthrds_ice>1</nthrds_ice> 
-	        <nthrds_ocn>1</nthrds_ocn> 
-	        <nthrds_glc>1</nthrds_glc> 
-	        <nthrds_wav>1</nthrds_wav> 
-	        <nthrds_cpl>1</nthrds_cpl> 
+	        <nthrds_lnd>1</nthrds_lnd>
+	        <nthrds_rof>1</nthrds_rof>
+	        <nthrds_ice>1</nthrds_ice>
+	        <nthrds_ocn>1</nthrds_ocn>
+	        <nthrds_glc>1</nthrds_glc>
+	        <nthrds_wav>1</nthrds_wav>
+	        <nthrds_cpl>1</nthrds_cpl>
 	      </nthrds>
 	      <rootpe>
-	        <rootpe_atm>0</rootpe_atm> 
-	        <rootpe_lnd>0</rootpe_lnd> 
-	        <rootpe_rof>0</rootpe_rof> 
-	        <rootpe_ice>0</rootpe_ice>    
-	        <rootpe_ocn>0</rootpe_ocn>   
-	        <rootpe_glc>0</rootpe_glc> 
-	        <rootpe_wav>0</rootpe_wav> 
-	        <rootpe_cpl>0</rootpe_cpl>                         
+	        <rootpe_atm>0</rootpe_atm>
+	        <rootpe_lnd>0</rootpe_lnd>
+	        <rootpe_rof>0</rootpe_rof>
+	        <rootpe_ice>0</rootpe_ice>
+	        <rootpe_ocn>0</rootpe_ocn>
+	        <rootpe_glc>0</rootpe_glc>
+	        <rootpe_wav>0</rootpe_wav>
+	        <rootpe_cpl>0</rootpe_cpl>
         </rootpe>
       </pes>
     </mach>

--- a/src/dynamics/fv/dyn_grid.F90
+++ b/src/dynamics/fv/dyn_grid.F90
@@ -1113,8 +1113,13 @@ subroutine define_cam_grids()
     ind = ind + 1
     grid_map(1, ind) = 1
     grid_map(2, ind) = i
-    grid_map(3, ind) = 1
-    grid_map(4, ind) = i
+    if (beglonxy == 1) then
+      grid_map(3, ind) = 1
+      grid_map(4, ind) = i
+    else
+      grid_map(3, ind) = 0
+      grid_map(4, ind) = 0
+    end if
   end do
   ! We need a special, size-one "longigude" coordinate
   ! NB: This is never a distributed coordinate so calc even on inactive PEs


### PR DESCRIPTION
This is needed for waccm(x) on derecho.  This fix was merged into cam_development at tag cam6_3_008.

fixes #901 