### PR TITLE
part of cam6_3_153: fix so that all three flavors of intel compiler are recognized 

### DIFF
--- a/bld/configure
+++ b/bld/configure
@@ -1696,7 +1696,7 @@ elsif ($fc =~ /nvfor/)  { $fc_type = 'nvhpc'; }
 
 # User override for Fortran compiler type
 if (defined $opts{'fc_type'}) { $fc_type = $opts{'fc_type'}; }
-if ($fc_type eq "oneapi") {$fc_type = 'intel'; }
+if ($fc_type =~ /intel/) {$fc_type = 'intel'; }
 if ($fc_type) {
     $cfg_ref->set('fc_type', $fc_type);
     if ($print>=2) { print "Fortran compiler type: $fc_type$eol"; }


### PR DESCRIPTION
on derecho.   Without this change using intel-oneapi or intel-classic will result in an error from cam configure:
`ERROR: Command: '/glade/work/jedwards/sandboxes/cesm2_x_alpha/components/cam/bld/configure -s -fc_type intel-oneapi -dyn se -hgrid ne30np4.pg3 -cpl nuopc -usr_src /glade/derecho/scratch/jedwards/SMS_Ln9.ne30pg3_ne30pg3_mg17.FHIST.derecho_intel-oneapi.20240308_140143_2n0bg8/SourceMods/src.cam -spmd -nosmp -ocn docn -phys cam6' failed with error 'ERROR: intel-oneapi is not a valid value for parameter fc_type: valid values are cray,pgi,intel,gnu,pathscale,ibm,nag,nvhpc,pgi-gpu,nvhpc-gpu' from dir '/glade/derecho/scratch/jedwards/SMS_Ln9.ne30pg3_ne30pg3_mg17.FHIST.derecho_intel-oneapi.20240308_140143_2n0bg8/Buildconf/camconf'
`