### PR TITLE
add pointers in cslam for intel performance (and update cime external?) for cam_cesm2_2_rel branch

### DIFF
--- a/Externals.cfg
+++ b/Externals.cfg
@@ -9,8 +9,7 @@ local_path = components/cice
 required = True
 
 [cime]
-#tag = cime5.8.32.7
-tag = maint-5.8_5.8.32
+tag = 5.8.32.10
 protocol = git
 repo_url = https://github.com/ESMCI/cime
 local_path = cime

--- a/Externals.cfg
+++ b/Externals.cfg
@@ -9,7 +9,8 @@ local_path = components/cice
 required = True
 
 [cime]
-tag = cime5.8.32.7
+#tag = cime5.8.32.7
+tag = maint-5.8_5.8.32
 protocol = git
 repo_url = https://github.com/ESMCI/cime
 local_path = cime

--- a/src/dynamics/se/dycore/fvm_consistent_se_cslam.F90
+++ b/src/dynamics/se/dycore/fvm_consistent_se_cslam.F90
@@ -44,7 +44,7 @@ contains
     use thread_mod            , only: vert_num_threads, omp_set_nested
     implicit none
     type (element_t)      , intent(inout) :: elem(:)
-    type (fvm_struct)     , intent(inout) :: fvm(:)
+    type (fvm_struct), target     , intent(inout) :: fvm(:)
     type (hybrid_t)       , intent(in)    :: hybrid   ! distributed parallel structure (shared)
     type (TimeLevel_t)    , intent(in)    :: tl              ! time level struct
     type (hvcoord_t)      , intent(in)    :: hvcoord
@@ -72,6 +72,8 @@ contains
     logical :: inJetCall
     logical :: ActiveJetThread
   
+    real(r8), pointer :: fcube(:,:,:,:)
+    real(r8), pointer :: spherecentroid(:,:,:)
 
     llimiter = .true.
 
@@ -152,22 +154,26 @@ contains
 
     !call t_stopf('fvm:orthogonal_swept_areas')
     do ie=nets,nete
+       ! Intel compiler version 2023.0.0 on derecho had significant slowdown on subroutine interface without
+       ! these pointers.  
+      fcube => fvm(ie)%c(:,:,:,:)
+      spherecentroid => fvm(ie)%spherecentroid(:,1-nhe:nc+nhe,1-nhe:nc+nhe)
       do k=kmin,kmax
-        !call t_startf('fvm:tracers_reconstruct')
-        call reconstruction(fvm(ie)%c(:,:,:,:),nlev,k,&
+         !call t_startf('FVM:tracers_reconstruct')
+         call reconstruction(fcube,nlev,k,&
              ctracer(:,:,:,:),irecons_tracer,llimiter,ntrac,&
              nc,nhe,nhr,nhc,nht,ns,nhr+(nhe-1),&
              fvm(ie)%jx_min,fvm(ie)%jx_max,fvm(ie)%jy_min,fvm(ie)%jy_max,&
              fvm(ie)%cubeboundary,fvm(ie)%halo_interp_weight,fvm(ie)%ibase,&
-             fvm(ie)%spherecentroid(:,1-nhe:nc+nhe,1-nhe:nc+nhe),&
+             spherecentroid,&
              fvm(ie)%recons_metrics,fvm(ie)%recons_metrics_integral,&
              fvm(ie)%rot_matrix,fvm(ie)%centroid_stretch,&
              fvm(ie)%vertex_recons_weights,fvm(ie)%vtx_cart,&
              irecons_tracer_lev(k))
-        !call t_stopf('fvm:tracers_reconstruct')
-        !call t_startf('fvm:swept_flux')
-        call swept_flux(elem(ie),fvm(ie),k,ctracer,irecons_tracer_lev(k),gsweights,gspts)
-        !call t_stopf('fvm:swept_flux')
+         !call t_stopf('FVM:tracers_reconstruct')
+         !call t_startf('fvm:swept_flux')
+         call swept_flux(elem(ie),fvm(ie),k,ctracer,irecons_tracer_lev(k),gsweights,gspts)
+         !call t_stopf('fvm:swept_flux')
       end do
     end do
     !


### PR DESCRIPTION
Fixes #955 

For the new cesm2.2 tag, we will need to update the cime external as in https://github.com/ESMCI/cime/pull/4559 i/o performance issues with VR grids. Should we update the external in the cam tag?