### PR TITLE
workaround so that sct works on derecho

### DIFF
--- a/cime_config/SystemTests/sct.py
+++ b/cime_config/SystemTests/sct.py
@@ -79,3 +79,13 @@ class SCT(SystemTestsCompareTwo):
                 self._test_status.set_status("{}_{}_{}".format(COMPARE_PHASE, self._run_one_suffix, self._run_two_suffix), TEST_FAIL_STATUS)
                 comments="QDIFF,TDIFF: Difference greater than round off."
             append_testlog(comments, self._orig_caseroot)
+
+    def _case_two_custom_prerun_action(self):
+        """ On NCAR derecho system the mpibind script causes ESMF in the second job to think it is using 128 tasks when it should only use 1
+        changing the env variable PBS_SELECT solves this issue
+        """
+        machine = self._case2.get_value("MACH")
+        if "derecho" in machine:
+            os.environ["PBS_SELECT"] = "1:ncpus=1:mpiprocs=1:ompthreads=1:mem=230gb:Qlist=cpu:ngpus=0"
+            
+                      


### PR DESCRIPTION
The mpibind script used on derecho was having trouble running a single process task in a pbs set up for a full node of tasks - the issue was that ESMF thought you were still using 128 tasks.   The workaround is to adjust the environment variable PBS_SELECT before starting the second job.  I have confirmed this works in test SCT_D_Ln7.T42_T42_mg17.QPC5.derecho_intel.cam-scm_prep using cam6_3_144 

Closes #1017