### PR TITLE
fix the path to fms for fv3 build, remove mct reference

### DIFF
--- a/cime_config/buildcpp
+++ b/cime_config/buildcpp
@@ -73,15 +73,6 @@ def buildcpp(case):
         case.set_value("EPS_AAREA", "1.0e-04")
         case.set_value("EPS_AGRID", "1.0e-05")
 
-    # The vector mapping (in the mediator) needs to be 'cart3d' for SE
-    # NB: This is currently the default, is it working by conincidence for
-    #     other unstructured dycores?
-    # For cmeps/nuopc cart3d is always the default option for all grids
-    match = re.match(r'ne[0-9]', atm_grid)
-    if match:
-        if (comp_interface == 'mct'):
-            case.set_value('VECT_MAP', 'cart3d')
-
     # if need to build - then construct configure command
     config_opts = ["-s", "-fc_type", compiler, "-dyn", cam_dycore,
                    "-hgrid", atm_grid, "-cpl", comp_interface,

--- a/cime_config/buildlib
+++ b/cime_config/buildlib
@@ -52,7 +52,7 @@ def _build_fms(caseroot, libroot, bldroot):
 
                 mpilib = case.get_value("MPILIB")
                 sharedpath = os.path.join(case.get_value("COMPILER"), mpilib,
-                                          strdebug, strthread, "nuopc")
+                                          strdebug, strthread)
                 slr = os.path.abspath(case.get_value("SHAREDLIBROOT"))
                 fmsbuildroot = os.path.join(slr, sharedpath)
                 fmsinstallpath = os.path.join(fmsbuildroot, "FMS")
@@ -108,7 +108,7 @@ def _build_cam(caseroot, libroot, bldroot):
             threaded = "threads" if case.get_value("BUILD_THREADED") or case.get_value("FORCE_BUILD_SMP") else "nothreads"
             comp_interface = case.get_value("COMP_INTERFACE")
             fmsbuilddir = os.path.join(
-                slr, compiler, mpilib, debug, threaded, comp_interface, "FMS")
+                slr, compiler, mpilib, debug, threaded, "FMS")
             user_incldir = '"-I{} -I{} -I{}"'.format(
                 os.path.join(srcroot, "libraries", "FMS", "src", "include"),
                 os.path.join(srcroot, "libraries", "FMS", "src", "mpp", "include"),


### PR DESCRIPTION
The path to the FMS library needs to be updated for fv3 builds.