### PR TITLE
part of cam6_4_033: Wrap MPAS longitude values to [0,2pi) range

### DIFF
--- a/src/dynamics/mpas/driver/cam_mpas_subdriver.F90
+++ b/src/dynamics/mpas/driver/cam_mpas_subdriver.F90
@@ -884,15 +884,16 @@ contains
 
        use pio, only : file_desc_t
 
-       use mpas_kind_types, only : StrKIND
+       use mpas_kind_types, only : StrKIND, RKIND
        use mpas_io_streams, only : MPAS_createStream, MPAS_closeStream, MPAS_streamAddField, MPAS_readStream
        use mpas_derived_types, only : MPAS_IO_READ, MPAS_IO_NETCDF, MPAS_Stream_type, MPAS_pool_type, &
                                       field0DReal, field1DReal, field2DReal, field3DReal, field1DInteger, field2DInteger, &
                                       MPAS_STREAM_NOERR
        use mpas_pool_routines, only : MPAS_pool_get_subpool, MPAS_pool_get_field, MPAS_pool_create_pool, MPAS_pool_destroy_pool, &
-                                      MPAS_pool_add_config
+                                      MPAS_pool_add_config, MPAS_pool_get_dimension, MPAS_pool_get_array
        use mpas_dmpar, only : MPAS_dmpar_exch_halo_field
        use mpas_stream_manager, only : postread_reindex
+       use mpas_constants, only : pii
 
        ! Arguments
        type (file_desc_t), pointer :: fh_ini
@@ -929,8 +930,13 @@ contains
 
        type (MPAS_Stream_type) :: mesh_stream
 
+       integer, pointer :: nCells
+       real(kind=RKIND), dimension(:), pointer :: lonCell_arr
+
        nullify(cell_gradient_coef_x)
        nullify(cell_gradient_coef_y)
+       nullify(nCells)
+       nullify(lonCell_arr)
 
        call MPAS_createStream(mesh_stream, domain_ptr % ioContext, 'not_used', MPAS_IO_NETCDF, MPAS_IO_READ, &
                               pio_file_desc=fh_ini, ierr=ierr)
@@ -1170,6 +1176,12 @@ contains
        if (ierr /= MPAS_STREAM_NOERR) then
            call endrun(subname//': FATAL: Failed to close static input stream.')
        end if
+
+       call mpas_pool_get_dimension(meshPool, 'nCells', nCells)
+       call mpas_pool_get_array(meshPool, 'lonCell', lonCell_arr)
+
+       ! Ensure longitudes w/i [0, 2*pi) range
+       lonCell_arr(:) = lonCell_arr(:) - (2.*pii) * floor(lonCell_arr(:) / (2.*pii))
 
        !
        ! Perform halo updates for all decomposed fields (i.e., fields with

--- a/src/dynamics/mpas/driver/cam_mpas_subdriver.F90
+++ b/src/dynamics/mpas/driver/cam_mpas_subdriver.F90
@@ -1178,7 +1178,7 @@ contains
        call mpas_pool_get_array(meshPool, 'lonCell', lonCell_arr)
 
        ! Ensure longitudes w/i [0, 2*pi) range
-       lonCell_arr(:) = lonCell_arr(:) - (2.*pii) * floor(lonCell_arr(:) / (2.*pii))
+       lonCell_arr(:) = lonCell_arr(:) - (2._RKIND*pii) * floor(lonCell_arr(:) / (2._RKIND*pii))
 
        !
        ! Perform halo updates for all decomposed fields (i.e., fields with

--- a/src/dynamics/mpas/driver/cam_mpas_subdriver.F90
+++ b/src/dynamics/mpas/driver/cam_mpas_subdriver.F90
@@ -890,7 +890,7 @@ contains
                                       field0DReal, field1DReal, field2DReal, field3DReal, field1DInteger, field2DInteger, &
                                       MPAS_STREAM_NOERR
        use mpas_pool_routines, only : MPAS_pool_get_subpool, MPAS_pool_get_field, MPAS_pool_create_pool, MPAS_pool_destroy_pool, &
-                                      MPAS_pool_add_config, MPAS_pool_get_dimension, MPAS_pool_get_array
+                                      MPAS_pool_add_config, MPAS_pool_get_array
        use mpas_dmpar, only : MPAS_dmpar_exch_halo_field
        use mpas_stream_manager, only : postread_reindex
        use mpas_constants, only : pii
@@ -930,12 +930,10 @@ contains
 
        type (MPAS_Stream_type) :: mesh_stream
 
-       integer, pointer :: nCells
        real(kind=RKIND), dimension(:), pointer :: lonCell_arr
 
        nullify(cell_gradient_coef_x)
        nullify(cell_gradient_coef_y)
-       nullify(nCells)
        nullify(lonCell_arr)
 
        call MPAS_createStream(mesh_stream, domain_ptr % ioContext, 'not_used', MPAS_IO_NETCDF, MPAS_IO_READ, &
@@ -1177,7 +1175,6 @@ contains
            call endrun(subname//': FATAL: Failed to close static input stream.')
        end if
 
-       call mpas_pool_get_dimension(meshPool, 'nCells', nCells)
        call mpas_pool_get_array(meshPool, 'lonCell', lonCell_arr)
 
        ! Ensure longitudes w/i [0, 2*pi) range

--- a/src/dynamics/mpas/driver/cam_mpas_subdriver.F90
+++ b/src/dynamics/mpas/driver/cam_mpas_subdriver.F90
@@ -884,16 +884,15 @@ contains
 
        use pio, only : file_desc_t
 
-       use mpas_kind_types, only : StrKIND, RKIND
+       use mpas_kind_types, only : StrKIND
        use mpas_io_streams, only : MPAS_createStream, MPAS_closeStream, MPAS_streamAddField, MPAS_readStream
        use mpas_derived_types, only : MPAS_IO_READ, MPAS_IO_NETCDF, MPAS_Stream_type, MPAS_pool_type, &
                                       field0DReal, field1DReal, field2DReal, field3DReal, field1DInteger, field2DInteger, &
                                       MPAS_STREAM_NOERR
        use mpas_pool_routines, only : MPAS_pool_get_subpool, MPAS_pool_get_field, MPAS_pool_create_pool, MPAS_pool_destroy_pool, &
-                                      MPAS_pool_add_config, MPAS_pool_get_array
+                                      MPAS_pool_add_config
        use mpas_dmpar, only : MPAS_dmpar_exch_halo_field
        use mpas_stream_manager, only : postread_reindex
-       use mpas_constants, only : pii
 
        ! Arguments
        type (file_desc_t), pointer :: fh_ini
@@ -930,11 +929,8 @@ contains
 
        type (MPAS_Stream_type) :: mesh_stream
 
-       real(kind=RKIND), dimension(:), pointer :: lonCell_arr
-
        nullify(cell_gradient_coef_x)
        nullify(cell_gradient_coef_y)
-       nullify(lonCell_arr)
 
        call MPAS_createStream(mesh_stream, domain_ptr % ioContext, 'not_used', MPAS_IO_NETCDF, MPAS_IO_READ, &
                               pio_file_desc=fh_ini, ierr=ierr)
@@ -1174,11 +1170,6 @@ contains
        if (ierr /= MPAS_STREAM_NOERR) then
            call endrun(subname//': FATAL: Failed to close static input stream.')
        end if
-
-       call mpas_pool_get_array(meshPool, 'lonCell', lonCell_arr)
-
-       ! Ensure longitudes w/i [0, 2*pi) range
-       lonCell_arr(:) = lonCell_arr(:) - (2._RKIND*pii) * floor(lonCell_arr(:) / (2._RKIND*pii))
 
        !
        ! Perform halo updates for all decomposed fields (i.e., fields with

--- a/src/dynamics/mpas/dyn_grid.F90
+++ b/src/dynamics/mpas/dyn_grid.F90
@@ -453,6 +453,8 @@ subroutine setup_time_invariant(fh_ini)
    type(mpas_pool_type),   pointer :: meshPool
    real(r8), pointer     :: rdzw(:)
    real(r8), allocatable :: dzw(:)
+   integer, pointer :: nCells
+   real(r8), dimension(:), pointer :: lonCell
 
    integer :: k, kk
    integer :: ierr
@@ -473,6 +475,7 @@ subroutine setup_time_invariant(fh_ini)
    call mpas_pool_get_dimension(meshPool, 'nEdgesSolve', nEdgesSolve)
    call mpas_pool_get_dimension(meshPool, 'nVerticesSolve', nVerticesSolve)
    call mpas_pool_get_dimension(meshPool, 'nVertLevels', nVertLevelsSolve) ! MPAS always solves over the full column
+   call mpas_pool_get_dimension(meshPool, 'nCells', nCells)
 
    ! check that number of vertical layers matches MPAS grid data
    if (plev /= nVertLevelsSolve) then
@@ -481,6 +484,16 @@ subroutine setup_time_invariant(fh_ini)
       call endrun(subname//': ERROR: number of levels in IC file ('//int2str(nVertLevelsSolve)// &
                            ') does not match plev ('//int2str(nVertLevelsSolve)//').')
    end if
+
+   ! Ensure longitudes are within the [0,2*pi) range, and only remap values that
+   ! are outside the range.  Some non-simple physics in CAM require this
+   ! longitude range, MPAS may have any (radian) value in lonCell
+   call mpas_pool_get_array(meshPool, 'lonCell', lonCell)
+   do k=1,nCells
+      if (lonCell(k) < 0._r8 .or. lonCell(k) .ge. (2._r8 * pi)) then
+         lonCell(k) = lonCell(k) - (2._r8 * pi) * floor(lonCell(k) / (2._r8 * pi))
+      end if
+   end do
 
    ! Initialize fields needed for reconstruction of cell-centered winds from edge-normal winds
    ! Note: This same pair of calls happens a second time later in the initialization of

--- a/src/dynamics/mpas/dyn_grid.F90
+++ b/src/dynamics/mpas/dyn_grid.F90
@@ -490,7 +490,7 @@ subroutine setup_time_invariant(fh_ini)
    ! longitude range, MPAS may have any (radian) value in lonCell
    call mpas_pool_get_array(meshPool, 'lonCell', lonCell)
    do k=1,nCells
-      if (lonCell(k) < 0._r8 .or. lonCell(k) .ge. (2._r8 * pi)) then
+      if (lonCell(k) < 0._r8 .or. lonCell(k) >= (2._r8 * pi)) then
          lonCell(k) = lonCell(k) - (2._r8 * pi) * floor(lonCell(k) / (2._r8 * pi))
       end if
    end do

--- a/src/dynamics/mpas/dyn_grid.F90
+++ b/src/dynamics/mpas/dyn_grid.F90
@@ -486,8 +486,9 @@ subroutine setup_time_invariant(fh_ini)
    end if
 
    ! Ensure longitudes are within the [0,2*pi) range, and only remap values that
-   ! are outside the range.  Some non-simple physics in CAM require this
-   ! longitude range, MPAS may have any (radian) value in lonCell
+   ! are outside the range. Some non-simple physics in CAM require this
+   ! longitude range, the MPAS-A dycore does not require any specific range for
+   ! lonCell
    call mpas_pool_get_array(meshPool, 'lonCell', lonCell)
    do k=1,nCells
       if (lonCell(k) < 0._r8 .or. lonCell(k) >= (2._r8 * pi)) then


### PR DESCRIPTION
This PR addresses issues that were seen when using ncdata with longitudes in the $[-\pi, \pi]$ range in cases with full physics.  This would cause the atmosphere to become unphysical and runs to fail. This change is made just after the longitude values are read to ensure they are correct for the remainder of execution.

Fixes #1094