### PR TITLE
cam6_4_018: Update git-fleximod to 8.4 and add fleximod_test workflow

### DIFF
--- a/.github/workflows/fleximod_test.yaml
+++ b/.github/workflows/fleximod_test.yaml
@@ -1,0 +1,21 @@
+on: pull_request
+
+jobs:
+  fleximod-test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        # oldest supported and latest supported
+        python-version: ["3.7", "3.x"]
+    steps:
+      - id: checkout-CESM
+        uses: actions/checkout@v4
+      - id: run-fleximod
+        run: |
+          $GITHUB_WORKSPACE/bin/git-fleximod update
+          $GITHUB_WORKSPACE/bin/git-fleximod test
+#      - name: Setup tmate session
+#        if: ${{ failure() }}
+#        uses: mxschmitt/action-tmate@v3
+        
+          

--- a/.gitmodules
+++ b/.gitmodules
@@ -174,7 +174,7 @@ path = components/cice
 url = https://github.com/ESCOMP/CESM_CICE
 fxtag = cesm_cice6_5_0_10
 fxrequired = ToplevelRequired
-fxDONOTUSEurl = https://github.com/NCAR/ParallelIO
+fxDONOTUSEurl = https://github.com/ESCOMP/CESM_CICE
 
 [submodule "clm"]
 path = components/clm

--- a/.lib/git-fleximod/git_fleximod/cli.py
+++ b/.lib/git-fleximod/git_fleximod/cli.py
@@ -2,7 +2,7 @@ from pathlib import Path
 import argparse
 from git_fleximod import utils
 
-__version__ = "0.8.2"
+__version__ = "0.8.4"
 
 def find_root_dir(filename=".gitmodules"):
     """ finds the highest directory in tree

--- a/.lib/git-fleximod/git_fleximod/git_fleximod.py
+++ b/.lib/git-fleximod/git_fleximod/git_fleximod.py
@@ -195,18 +195,19 @@ def submodules_status(gitmodules, root_dir, toplevel=False, depth=0):
         submod = init_submodule_from_gitmodules(gitmodules, name, root_dir, logger)
             
         result,n,l,t = submod.status()
-        testfails += t
-        localmods += l
-        needsupdate += n
         if toplevel or not submod.toplevel():
             print(wrapper.fill(result))
-        subdir = os.path.join(root_dir, submod.path)
-        if os.path.exists(os.path.join(subdir, ".gitmodules")):
-            submod = GitModules(logger, confpath=subdir)
-            t,l,n = submodules_status(submod, subdir, depth=depth+1)
             testfails += t
             localmods += l
             needsupdate += n
+        subdir = os.path.join(root_dir, submod.path)
+        if os.path.exists(os.path.join(subdir, ".gitmodules")):
+            gsubmod = GitModules(logger, confpath=subdir)
+            t,l,n = submodules_status(gsubmod, subdir, depth=depth+1)
+            if toplevel or not submod.toplevel():
+                testfails += t
+                localmods += l
+                needsupdate += n
             
     return testfails, localmods, needsupdate
 

--- a/.lib/git-fleximod/pyproject.toml
+++ b/.lib/git-fleximod/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "git-fleximod"
-version = "0.8.2"
+version = "0.8.4"
 description = "Extended support for git-submodule and git-sparse-checkout"
 authors = ["Jim Edwards <jedwards@ucar.edu>"]
 maintainers = ["Jim Edwards <jedwards@ucar.edu>"]

--- a/.lib/git-fleximod/tbump.toml
+++ b/.lib/git-fleximod/tbump.toml
@@ -2,7 +2,7 @@
 github_url = "https://github.com/jedwards4b/git-fleximod/"
 
 [version]
-current = "0.8.2"
+current = "0.8.4"
 
 # Example of a semver regexp.
 # Make sure this matches current_version before


### PR DESCRIPTION
## Description
Update to the latest version of git-fleximod and add the continuous integration git-fleximod test to the github workflows

## Modifications
A &ensp;&ensp;.github/workflows/fleximod_test.yaml: github workflow for git-fleximod CI tests

M &ensp;&ensp;.lib/git-fleximod/*: updates to latest version of git-fleximod (8.4)
M &ensp;&ensp; .gitmodules: fix DONOTUSE url for cice

closes #1113