### PR TITLE
part of cam6_4_020:  Corrections to waccm forcings in FWsc2000climo and FWsc2010climo compsets

### DIFF
--- a/bld/namelist_files/use_cases/waccm_sc_2000_cam6.xml
+++ b/bld/namelist_files/use_cases/waccm_sc_2000_cam6.xml
@@ -21,8 +21,8 @@
 <flbc_list>'CO2','CH4','N2O','CFC11','CFC12','CFC11eq'</flbc_list>
 
 <!-- upper atmos forcings -->
-<waccm_forcing_type>FIXED</waccm_forcing_type>
-<waccm_forcing_fixed_ymd>20000101</waccm_forcing_fixed_ymd>
+<waccm_forcing_type>CYCLICAL</waccm_forcing_type>
+<waccm_forcing_cycle_yr>2000</waccm_forcing_cycle_yr>
 <waccm_forcing_file>SCWACCM_forcing_WACCM6_zm_5day_L70_1975-2014_c191121.nc</waccm_forcing_file>
 <waccm_forcing_datapath>atm/waccm/waccm_forcing</waccm_forcing_datapath>
 

--- a/bld/namelist_files/use_cases/waccm_sc_2010_cam6.xml
+++ b/bld/namelist_files/use_cases/waccm_sc_2010_cam6.xml
@@ -21,8 +21,8 @@
 <flbc_list>'CO2','CH4','N2O','CFC11','CFC12','CFC11eq'</flbc_list>
 
 <!-- upper atmos forcings -->
-<waccm_forcing_type>FIXED</waccm_forcing_type>
-<waccm_forcing_fixed_ymd>20100101</waccm_forcing_fixed_ymd>
+<waccm_forcing_type>CYCLICAL</waccm_forcing_type>
+<waccm_forcing_cycle_yr>2010</waccm_forcing_cycle_yr>
 <waccm_forcing_file>SCWACCM_forcing_WACCM6_zm_5day_L70_1975-2014_c191121.nc</waccm_forcing_file>
 <waccm_forcing_datapath>atm/waccm/waccm_forcing</waccm_forcing_datapath>
 


### PR DESCRIPTION
Cycle over appropriate years in waccm forcings input datasets.

closes #1030