### PR TITLE
cam6_4_034: Add missing total energy in physics state from dycore in snapshots and cleanup total water

### DIFF
--- a/src/control/cam_snapshot_common.F90
+++ b/src/control/cam_snapshot_common.F90
@@ -266,16 +266,28 @@ subroutine cam_state_snapshot_init(cam_snapshot_before_num_in, cam_snapshot_afte
      'state%zi',        'state_zi',         'm',                'ilev')
 
    call snapshot_addfld( nstate_var, state_snapshot,  cam_snapshot_before_num, cam_snapshot_after_num, &
-     'state%te_ini',    'state_te_ini',     'unset',            horiz_only)
+     'state%te_ini_phys', 'state_te_ini_phys',  'unset',            horiz_only)
 
    call snapshot_addfld( nstate_var, state_snapshot,  cam_snapshot_before_num, cam_snapshot_after_num, &
-     'state%te_cur',    'state_te_cur',     'unset',            horiz_only)
+     'state%te_cur_phys', 'state_te_cur_phys',  'unset',            horiz_only)
 
    call snapshot_addfld( nstate_var, state_snapshot,  cam_snapshot_before_num, cam_snapshot_after_num, &
-     'state%tw_ini',    'state_tw_ini',     'unset',            horiz_only)
+     'state%tw_ini_phys', 'state_tw_ini_phys',  'unset',            horiz_only)
 
    call snapshot_addfld( nstate_var, state_snapshot,  cam_snapshot_before_num, cam_snapshot_after_num, &
-     'state%tw_cur',    'state_tw_cur',     'unset',            horiz_only)
+     'state%tw_cur_phys', 'state_tw_cur_phys',  'unset',            horiz_only)
+
+   call snapshot_addfld( nstate_var, state_snapshot,  cam_snapshot_before_num, cam_snapshot_after_num, &
+     'state%te_ini_dyn',  'state_te_ini_dyn',   'unset',            horiz_only)
+
+   call snapshot_addfld( nstate_var, state_snapshot,  cam_snapshot_before_num, cam_snapshot_after_num, &
+     'state%te_cur_dyn',  'state_te_cur_dyn',   'unset',            horiz_only)
+
+   call snapshot_addfld( nstate_var, state_snapshot,  cam_snapshot_before_num, cam_snapshot_after_num, &
+     'state%tw_ini_dyn',  'state_tw_ini_dyn',   'unset',            horiz_only)
+
+   call snapshot_addfld( nstate_var, state_snapshot,  cam_snapshot_before_num, cam_snapshot_after_num, &
+     'state%tw_cur_dyn',  'state_tw_cur_dyn',   'unset',            horiz_only)
 
 end subroutine cam_state_snapshot_init
 
@@ -734,6 +746,8 @@ end subroutine snapshot_addfld
 
 subroutine state_snapshot_all_outfld(lchnk, file_num, state)
 
+   use physics_types,    only: phys_te_idx, dyn_te_idx
+
    integer,              intent(in)  :: lchnk
    integer,              intent(in)  :: file_num
    type(physics_state),  intent(in)  :: state
@@ -817,17 +831,29 @@ subroutine state_snapshot_all_outfld(lchnk, file_num, state)
       case ('state%zi')
          call outfld(state_snapshot(i)%standard_name, state%zi, pcols, lchnk)
 
-      case ('state%te_ini')
-         call outfld(state_snapshot(i)%standard_name, state%te_ini, pcols, lchnk)
+      case ('state%te_ini_phys')
+         call outfld(state_snapshot(i)%standard_name, state%te_ini(:, phys_te_idx), pcols, lchnk)
 
-      case ('state%te_cur')
-         call outfld(state_snapshot(i)%standard_name, state%te_cur, pcols, lchnk)
+      case ('state%te_cur_phys')
+         call outfld(state_snapshot(i)%standard_name, state%te_cur(:, phys_te_idx), pcols, lchnk)
 
-      case ('state%tw_ini')
-         call outfld(state_snapshot(i)%standard_name, state%tw_ini, pcols, lchnk)
+      case ('state%tw_ini_phys')
+         call outfld(state_snapshot(i)%standard_name, state%tw_ini(:, phys_te_idx), pcols, lchnk)
 
-      case ('state%tw_cur')
-         call outfld(state_snapshot(i)%standard_name, state%tw_cur, pcols, lchnk)
+      case ('state%tw_cur_phys')
+         call outfld(state_snapshot(i)%standard_name, state%tw_cur(:, phys_te_idx), pcols, lchnk)
+
+      case ('state%te_ini_dyn')
+         call outfld(state_snapshot(i)%standard_name, state%te_ini(:, dyn_te_idx), pcols, lchnk)
+
+      case ('state%te_cur_dyn')
+         call outfld(state_snapshot(i)%standard_name, state%te_cur(:, dyn_te_idx), pcols, lchnk)
+
+      case ('state%tw_ini_dyn')
+         call outfld(state_snapshot(i)%standard_name, state%tw_ini(:, dyn_te_idx), pcols, lchnk)
+
+      case ('state%tw_cur_dyn')
+         call outfld(state_snapshot(i)%standard_name, state%tw_cur(:, dyn_te_idx), pcols, lchnk)
 
       case default
          call endrun('ERROR in state_snapshot_all_outfld: no match found for '//trim(state_snapshot(i)%ddt_string))

--- a/src/control/cam_snapshot_common.F90
+++ b/src/control/cam_snapshot_common.F90
@@ -81,7 +81,7 @@ integer :: npbuf_var
 integer :: cam_snapshot_before_num, cam_snapshot_after_num
 
 ! Note the maximum number of variables for each type
-type (snapshot_type)    ::  state_snapshot(31)
+type (snapshot_type)    ::  state_snapshot(29)
 type (snapshot_type)    ::  cnst_snapshot(pcnst)
 type (snapshot_type)    ::  tend_snapshot(6)
 type (snapshot_type)    ::  cam_in_snapshot(30)
@@ -272,22 +272,16 @@ subroutine cam_state_snapshot_init(cam_snapshot_before_num_in, cam_snapshot_afte
      'state%te_cur_phys', 'state_te_cur_phys',  'unset',            horiz_only)
 
    call snapshot_addfld( nstate_var, state_snapshot,  cam_snapshot_before_num, cam_snapshot_after_num, &
-     'state%tw_ini_phys', 'state_tw_ini_phys',  'unset',            horiz_only)
+     'state%tw_ini', 'state_tw_ini',  'unset',                      horiz_only)
 
    call snapshot_addfld( nstate_var, state_snapshot,  cam_snapshot_before_num, cam_snapshot_after_num, &
-     'state%tw_cur_phys', 'state_tw_cur_phys',  'unset',            horiz_only)
+     'state%tw_cur', 'state_tw_cur',  'unset',                      horiz_only)
 
    call snapshot_addfld( nstate_var, state_snapshot,  cam_snapshot_before_num, cam_snapshot_after_num, &
      'state%te_ini_dyn',  'state_te_ini_dyn',   'unset',            horiz_only)
 
    call snapshot_addfld( nstate_var, state_snapshot,  cam_snapshot_before_num, cam_snapshot_after_num, &
      'state%te_cur_dyn',  'state_te_cur_dyn',   'unset',            horiz_only)
-
-   call snapshot_addfld( nstate_var, state_snapshot,  cam_snapshot_before_num, cam_snapshot_after_num, &
-     'state%tw_ini_dyn',  'state_tw_ini_dyn',   'unset',            horiz_only)
-
-   call snapshot_addfld( nstate_var, state_snapshot,  cam_snapshot_before_num, cam_snapshot_after_num, &
-     'state%tw_cur_dyn',  'state_tw_cur_dyn',   'unset',            horiz_only)
 
 end subroutine cam_state_snapshot_init
 
@@ -837,23 +831,17 @@ subroutine state_snapshot_all_outfld(lchnk, file_num, state)
       case ('state%te_cur_phys')
          call outfld(state_snapshot(i)%standard_name, state%te_cur(:, phys_te_idx), pcols, lchnk)
 
-      case ('state%tw_ini_phys')
-         call outfld(state_snapshot(i)%standard_name, state%tw_ini(:, phys_te_idx), pcols, lchnk)
+      case ('state%tw_ini')
+         call outfld(state_snapshot(i)%standard_name, state%tw_ini, pcols, lchnk)
 
-      case ('state%tw_cur_phys')
-         call outfld(state_snapshot(i)%standard_name, state%tw_cur(:, phys_te_idx), pcols, lchnk)
+      case ('state%tw_cur')
+         call outfld(state_snapshot(i)%standard_name, state%tw_cur, pcols, lchnk)
 
       case ('state%te_ini_dyn')
          call outfld(state_snapshot(i)%standard_name, state%te_ini(:, dyn_te_idx), pcols, lchnk)
 
       case ('state%te_cur_dyn')
          call outfld(state_snapshot(i)%standard_name, state%te_cur(:, dyn_te_idx), pcols, lchnk)
-
-      case ('state%tw_ini_dyn')
-         call outfld(state_snapshot(i)%standard_name, state%tw_ini(:, dyn_te_idx), pcols, lchnk)
-
-      case ('state%tw_cur_dyn')
-         call outfld(state_snapshot(i)%standard_name, state%tw_cur(:, dyn_te_idx), pcols, lchnk)
 
       case default
          call endrun('ERROR in state_snapshot_all_outfld: no match found for '//trim(state_snapshot(i)%ddt_string))

--- a/src/control/cam_snapshot_common.F90
+++ b/src/control/cam_snapshot_common.F90
@@ -81,7 +81,7 @@ integer :: npbuf_var
 integer :: cam_snapshot_before_num, cam_snapshot_after_num
 
 ! Note the maximum number of variables for each type
-type (snapshot_type)    ::  state_snapshot(27)
+type (snapshot_type)    ::  state_snapshot(31)
 type (snapshot_type)    ::  cnst_snapshot(pcnst)
 type (snapshot_type)    ::  tend_snapshot(6)
 type (snapshot_type)    ::  cam_in_snapshot(30)

--- a/src/physics/cam/physics_types.F90
+++ b/src/physics/cam/physics_types.F90
@@ -101,7 +101,8 @@ module physics_types
                            ! Second dimension is (phys_te_idx) CAM physics total energy and
                            ! (dyn_te_idx) dycore total energy computed in physics
           te_ini,         &! vertically integrated total (kinetic + static) energy of initial state
-          te_cur,         &! vertically integrated total (kinetic + static) energy of current state
+          te_cur           ! vertically integrated total (kinetic + static) energy of current state
+     real(r8), dimension(:), allocatable           :: &
           tw_ini,         &! vertically integrated total water of initial state
           tw_cur           ! vertically integrated total water of new state
      real(r8), dimension(:,:),allocatable          :: &
@@ -537,9 +538,9 @@ contains
          varname="state%te_ini",    msg=msg)
     call shr_assert_in_domain(state%te_cur(:ncol,:),    is_nan=.false., &
          varname="state%te_cur",    msg=msg)
-    call shr_assert_in_domain(state%tw_ini(:ncol,:),    is_nan=.false., &
+    call shr_assert_in_domain(state%tw_ini(:ncol),      is_nan=.false., &
          varname="state%tw_ini",    msg=msg)
-    call shr_assert_in_domain(state%tw_cur(:ncol,:),    is_nan=.false., &
+    call shr_assert_in_domain(state%tw_cur(:ncol),      is_nan=.false., &
          varname="state%tw_cur",    msg=msg)
     call shr_assert_in_domain(state%temp_ini(:ncol,:),  is_nan=.false., &
          varname="state%temp_ini",  msg=msg)
@@ -615,9 +616,9 @@ contains
          varname="state%te_ini",    msg=msg)
     call shr_assert_in_domain(state%te_cur(:ncol,:),    lt=posinf_r8, gt=neginf_r8, &
          varname="state%te_cur",    msg=msg)
-    call shr_assert_in_domain(state%tw_ini(:ncol,:),    lt=posinf_r8, gt=neginf_r8, &
+    call shr_assert_in_domain(state%tw_ini(:ncol),      lt=posinf_r8, gt=neginf_r8, &
          varname="state%tw_ini",    msg=msg)
-    call shr_assert_in_domain(state%tw_cur(:ncol,:),    lt=posinf_r8, gt=neginf_r8, &
+    call shr_assert_in_domain(state%tw_cur(:ncol),      lt=posinf_r8, gt=neginf_r8, &
          varname="state%tw_cur",    msg=msg)
     call shr_assert_in_domain(state%temp_ini(:ncol,:),  lt=posinf_r8, gt=neginf_r8, &
          varname="state%temp_ini",  msg=msg)
@@ -1351,8 +1352,8 @@ end subroutine physics_ptend_copy
      end do
      state_out%te_ini(:ncol,:) = state_in%te_ini(:ncol,:)
      state_out%te_cur(:ncol,:) = state_in%te_cur(:ncol,:)
-     state_out%tw_ini(:ncol,:) = state_in%tw_ini(:ncol,:)
-     state_out%tw_cur(:ncol,:) = state_in%tw_cur(:ncol,:)
+     state_out%tw_ini(:ncol)   = state_in%tw_ini(:ncol)
+     state_out%tw_cur(:ncol)   = state_in%tw_cur(:ncol)
 
     do k = 1, pver
        do i = 1, ncol
@@ -1667,10 +1668,10 @@ subroutine physics_state_alloc(state,lchnk,psetcols)
   allocate(state%te_cur(psetcols,2), stat=ierr)
   if ( ierr /= 0 ) call endrun('physics_state_alloc error: allocation error for state%te_cur')
 
-  allocate(state%tw_ini(psetcols,2), stat=ierr)
+  allocate(state%tw_ini(psetcols), stat=ierr)
   if ( ierr /= 0 ) call endrun('physics_state_alloc error: allocation error for state%tw_ini')
 
-  allocate(state%tw_cur(psetcols,2), stat=ierr)
+  allocate(state%tw_cur(psetcols), stat=ierr)
   if ( ierr /= 0 ) call endrun('physics_state_alloc error: allocation error for state%tw_cur')
 
   allocate(state%temp_ini(psetcols,pver), stat=ierr)
@@ -1720,8 +1721,8 @@ subroutine physics_state_alloc(state,lchnk,psetcols)
 
   state%te_ini(:,:) = inf
   state%te_cur(:,:) = inf
-  state%tw_ini(:,:) = inf
-  state%tw_cur(:,:) = inf
+  state%tw_ini(:) = inf
+  state%tw_cur(:) = inf
   state%temp_ini(:,:) = inf
   state%z_ini(:,:)  = inf
 


### PR DESCRIPTION
Closes #1141 

Saves second dimension (dycore formula) of total energy and total water initial and current condition.

Companion PR in CAM-SIMA to read updated snapshot file and updates to standard names: 
https://github.com/ESCOMP/CAM-SIMA/pull/296