### PR TITLE
cam6_4_044: limit t_sfc to valid temperature range

### DIFF
--- a/src/physics/rrtmgp/rrtmgp_inputs.F90
+++ b/src/physics/rrtmgp/rrtmgp_inputs.F90
@@ -178,6 +178,8 @@ subroutine rrtmgp_set_state( &
    tref_max = kdist_sw%get_temp_max()
    t_rad = merge(t_rad, tref_min, t_rad > tref_min)
    t_rad = merge(t_rad, tref_max, t_rad < tref_max)
+   t_sfc = merge(t_sfc, tref_min, t_sfc > tref_min)
+   t_sfc = merge(t_sfc, tref_max, t_sfc < tref_max)
 
    ! Construct arrays containing only daylight columns
    do i = 1, nday


### PR DESCRIPTION
@jedwards4b reported: All of the coupled tests using the new cam tag seem to be blowing up with an error in radiation_tend: 
```
radiation_tend: ERROR: kdist_lw%gas_optics: gas_optics(): array tsfc has values outside range
```
This fix applies the same limiter to the `t_sfc` array passed to the gas optics as is already being applied to the atmosphere temperatures that are passed.