### PR TITLE
add clim_modal_aero logic around aero prop call in cam7

### DIFF
--- a/src/physics/cam7/physpkg.F90
+++ b/src/physics/cam7/physpkg.F90
@@ -2882,8 +2882,10 @@ contains
       ! Run wet deposition routines to intialize aerosols
       !===================================================
 
-      call modal_aero_calcsize_diag(state, pbuf)
-      call modal_aero_wateruptake_dr(state, pbuf)
+      if (clim_modal_aero) then
+        call modal_aero_calcsize_diag(state, pbuf)
+        call modal_aero_wateruptake_dr(state, pbuf)
+      end if
 
       !===================================================
       ! Radiation computations


### PR DESCRIPTION
Fixes #626

Shouldn't change answers, since there is no regression test for cam7 -chem none.