### PR TITLE
cam6_4_058: Fix Exner bug in CLUBB interface and change CLUBB namelist

### DIFF
--- a/bld/namelist_files/namelist_defaults_cam.xml
+++ b/bld/namelist_files/namelist_defaults_cam.xml
@@ -2214,7 +2214,7 @@
 <clubb_l_intr_sfc_flux_smooth phys="cam7"         > .true.  </clubb_l_intr_sfc_flux_smooth>
 <clubb_l_lmm_stepping                             > .false. </clubb_l_lmm_stepping>
 <clubb_l_lscale_plume_centered                    > .false. </clubb_l_lscale_plume_centered>
-<clubb_l_min_wp2_from_corr_wx                     > .true.  </clubb_l_min_wp2_from_corr_wx>
+<clubb_l_min_wp2_from_corr_wx                     > .false.  </clubb_l_min_wp2_from_corr_wx>
 <clubb_l_min_xp2_from_corr_wx                     > .true.  </clubb_l_min_xp2_from_corr_wx>
 <clubb_l_mono_flux_lim_rtm                        > .true.  </clubb_l_mono_flux_lim_rtm>
 <clubb_l_mono_flux_lim_spikefix                   > .true.  </clubb_l_mono_flux_lim_spikefix>

--- a/src/physics/cam/cam_snapshot.F90
+++ b/src/physics/cam/cam_snapshot.F90
@@ -115,18 +115,53 @@ use time_manager,   only: is_first_step, is_first_restart_step
 
    lchnk = state%lchnk
 
+   call cam_history_snapshot_activate('tphysbc_flx_heat', file_num)
    call outfld('tphysbc_flx_heat', flx_heat, pcols, lchnk)
+   call cam_history_snapshot_deactivate('tphysbc_flx_heat')
+
+   call cam_history_snapshot_activate('tphysbc_cmfmc', file_num)
    call outfld('tphysbc_cmfmc', cmfmc, pcols, lchnk)
+   call cam_history_snapshot_deactivate('tphysbc_cmfmc')
+
+   call cam_history_snapshot_activate('tphysbc_cmfcme', file_num)
    call outfld('tphysbc_cmfcme', cmfcme, pcols, lchnk)
+   call cam_history_snapshot_deactivate('tphysbc_cmfcme')
+
+   call cam_history_snapshot_activate('tphysbc_zdu', file_num)
    call outfld('tphysbc_zdu', zdu, pcols, lchnk)
+   call cam_history_snapshot_deactivate('tphysbc_zdu')
+
+   call cam_history_snapshot_activate('tphysbc_rliq', file_num)
    call outfld('tphysbc_rliq', rliq, pcols, lchnk)
+   call cam_history_snapshot_deactivate('tphysbc_rliq')
+
+   call cam_history_snapshot_activate('tphysbc_rice', file_num)
    call outfld('tphysbc_rice', rice, pcols, lchnk)
+   call cam_history_snapshot_deactivate('tphysbc_rice')
+
+   call cam_history_snapshot_activate('tphysbc_dlf', file_num)
    call outfld('tphysbc_dlf', dlf, pcols, lchnk)
+   call cam_history_snapshot_deactivate('tphysbc_dlf')
+
+   call cam_history_snapshot_activate('tphysbc_dlf2', file_num)
    call outfld('tphysbc_dlf2', dlf2, pcols, lchnk)
+   call cam_history_snapshot_deactivate('tphysbc_dlf2')
+
+   call cam_history_snapshot_activate('tphysbc_rliq2', file_num)
    call outfld('tphysbc_rliq2', rliq2, pcols, lchnk)
+   call cam_history_snapshot_deactivate('tphysbc_rliq2')
+
+   call cam_history_snapshot_activate('tphysbc_det_s', file_num)
    call outfld('tphysbc_det_s', det_s, pcols, lchnk)
+   call cam_history_snapshot_deactivate('tphysbc_det_s')
+
+   call cam_history_snapshot_activate('tphysbc_det_ice', file_num)
    call outfld('tphysbc_det_ice', det_ice, pcols, lchnk)
+   call cam_history_snapshot_deactivate('tphysbc_det_ice')
+
+   call cam_history_snapshot_activate('tphysbc_net_flx', file_num)
    call outfld('tphysbc_net_flx', net_flx, pcols, lchnk)
+   call cam_history_snapshot_deactivate('tphysbc_net_flx')
 
    call cam_snapshot_all_outfld(file_num, state, tend, cam_in, cam_out, pbuf)
 
@@ -163,10 +198,22 @@ use time_manager,   only: is_first_step
 
    lchnk = state%lchnk
 
+   call cam_history_snapshot_activate('tphysac_fh2o', file_num)
    call outfld('tphysac_fh2o', fh2o, pcols, lchnk)
+   call cam_history_snapshot_deactivate('tphysac_fh2o')
+
+   call cam_history_snapshot_activate('tphysac_surfric', file_num)
    call outfld('tphysac_surfric', surfric, pcols, lchnk)
+   call cam_history_snapshot_deactivate('tphysac_surfric')
+
+   call cam_history_snapshot_activate('tphysac_obklen', file_num)
    call outfld('tphysac_obklen', obklen, pcols, lchnk)
+   call cam_history_snapshot_deactivate('tphysac_obklen')
+
+   call cam_history_snapshot_activate('tphysac_flx_heat', file_num)
    call outfld('tphysac_flx_heat', flx_heat, pcols, lchnk)
+   call cam_history_snapshot_deactivate('tphysac_flx_heat')
+
 
    call cam_snapshot_all_outfld(file_num, state, tend, cam_in, cam_out, pbuf)
 

--- a/src/physics/cam/clubb_intr.F90
+++ b/src/physics/cam/clubb_intr.F90
@@ -4700,8 +4700,8 @@ end subroutine clubb_init_cnst
     ! --------------------------------------------------------------------------------- !
     do i=1,ncol
       do k=1,pver
-         !use local exner since state%exner is not a proper exner
-         th(i,k) = state1%t(i,k)*inv_exner_clubb(i,k)
+         !subroutine pblind expects "Stull" definition of Exner
+         th(i,k) = state1%t(i,k)*state1%exner(i,k)
          !thv should have condensate loading to be consistent with earlier def's in this module
          thv(i,k) = th(i,k)*(1.0_r8+zvir*state1%q(i,k,ixq) - state1%q(i,k,ixcldliq))
       enddo


### PR DESCRIPTION
The computation of the Exner function in the CLUBB interface code currently passes an incorrect version to the PBL utilities. The PBL utilities expect the "Stull" definition of the Exner function rather than the traditional "atmospheric" Exner function. Code provided by @adamrher 
closes #1222

The CLUBB group (@bstephens82) has recommended a namelist change to address this issue.
closes #1208
