### PR TITLE
cam6_4_072: Fix broken RRTMGP GPU tests

### DIFF
--- a/cime_config/testdefs/testmods_dirs/cam/outfrq9s_gpu_default/shell_commands
+++ b/cime_config/testdefs/testmods_dirs/cam/outfrq9s_gpu_default/shell_commands
@@ -3,7 +3,7 @@
 ./xmlchange ROOTPE='0'
 ./xmlchange ROF_NCPL=`./xmlquery --value ATM_NCPL`
 ./xmlchange GLC_NCPL=`./xmlquery --value ATM_NCPL`
-./xmlchange CAM_CONFIG_OPTS=' -microphys mg3 -rad rrtmg' --append
+./xmlchange CAM_CONFIG_OPTS=' -microphys mg3 -rad rrtmgp_gpu ' --append
 ./xmlchange TIMER_DETAIL='6'
 ./xmlchange TIMER_LEVEL='999'
 ./xmlchange GPU_TYPE=a100

--- a/cime_config/testdefs/testmods_dirs/cam/outfrq9s_gpu_pcols760/shell_commands
+++ b/cime_config/testdefs/testmods_dirs/cam/outfrq9s_gpu_pcols760/shell_commands
@@ -3,7 +3,7 @@
 ./xmlchange ROOTPE='0'
 ./xmlchange ROF_NCPL=`./xmlquery --value ATM_NCPL`
 ./xmlchange GLC_NCPL=`./xmlquery --value ATM_NCPL`
-./xmlchange CAM_CONFIG_OPTS=' -microphys mg3 -rad rrtmg -pcols 760 ' --append
+./xmlchange CAM_CONFIG_OPTS=' -microphys mg3 -rad rrtmgp_gpu -pcols 760 ' --append
 ./xmlchange TIMER_DETAIL='6'
 ./xmlchange TIMER_LEVEL='999'
 ./xmlchange GPU_TYPE=a100


### PR DESCRIPTION
This PR fixes the broken RRTMGP GPU tests reported in #997 . The changes are borrowed from the EarthWorks code base (https://github.com/EarthWorksOrg/CAM/pull/25, thanks to John and Supreeth).

I used the `cam6_4_064` tag on Derecho and confirmed that running PUMAS+CLUBB+RRTMGP on the NVIDIA A100 GPU now passed the ensemble consistency test.

The CPU tests should be BFB. I updated the GPU tests to enable the RRTMGP GPU code so the results were different from the existing baseline as expected.