### PR TITLE
part of cam6_4_075: Fix incorrect definition of FREQSH in CAM4 Hack shallow convection

### DIFF
--- a/src/physics/cam/convect_shallow.F90
+++ b/src/physics/cam/convect_shallow.F90
@@ -684,11 +684,9 @@
    ! Calculate fractional occurance of shallow convection    !
    ! --------------------------------------------------------!
 
- ! Modification : I should check whether below computation of freqsh is correct.
-
    freqsh(:) = 0._r8
    do i = 1, ncol
-      if( maxval(cmfmc2(i,:pver)) <= 0._r8 ) then
+      if (maxval(cmfmc2(i,:pver)) > 0._r8) then
           freqsh(i) = 1._r8
       end if
    end do


### PR DESCRIPTION
Fixes #1254 

A change to the `FREQSH` diagnostic in CAM4 is expected, but CAM regression tests should be B4B as `FREQSH` is not a default history field and isn't specified in any of the regression tests.