### PR TITLE
cam6_4_092: MPAS dp_coupling bug fixes

### DIFF
--- a/src/dynamics/mpas/dp_coupling.F90
+++ b/src/dynamics/mpas/dp_coupling.F90
@@ -886,8 +886,9 @@ subroutine hydrostatic_pressure(nCells, nVertLevels, qsize, index_qv, zz, zgrid,
         ! (has been found to be an issue at ~3.75km resolution in surface layer)
         !
         dp_epsilon = dp(k) * epsilon
+        dpdry_epsilon = dpdry(k)*epsilon
         pmid   (k, iCell) = max(min(pmid   (k, iCell), pint   (k, iCell) - dp_epsilon), pint   (k + 1, iCell) + dp_epsilon)
-        pmiddry(k, iCell) = max(min(pmiddry(k, iCell), pintdry(k, iCell) - dp_epsilon), pintdry(k + 1, iCell) + dp_epsilon)
+        pmiddry(k, iCell) = max(min(pmiddry(k, iCell), pintdry(k, iCell) - dpdry_epsilon), pintdry(k + 1, iCell) + dpdry_epsilon)
      end do
    end do
 end subroutine hydrostatic_pressure

--- a/src/dynamics/mpas/dp_coupling.F90
+++ b/src/dynamics/mpas/dp_coupling.F90
@@ -832,7 +832,7 @@ subroutine hydrostatic_pressure(nCells, nVertLevels, qsize, index_qv, zz, zgrid,
    real(r8) :: sum_water
    real(r8) :: pk,rhok,rhodryk,thetavk,kap1,kap2,tvk,tk
    real(r8), parameter :: epsilon = 0.05_r8
-   real(r8) :: dp_epsilon
+   real(r8) :: dp_epsilon, dpdry_epsilon
    !
    ! For each column, integrate downward from model top to compute dry hydrostatic pressure at layer
    ! midpoints and interfaces. The pressure averaged to layer midpoints should be consistent with

--- a/src/dynamics/mpas/dp_coupling.F90
+++ b/src/dynamics/mpas/dp_coupling.F90
@@ -8,7 +8,7 @@ use shr_kind_mod,   only: r8=>shr_kind_r8
 use pmgrid,         only: plev
 use ppgrid,         only: begchunk, endchunk, pcols, pver, pverp
 use constituents,   only: pcnst, cnst_type
-use physconst,      only: gravit, cappa, zvir
+use physconst,      only: gravit, zvir
 use air_composition,only: cpairv
 use air_composition,only: dry_air_species_num
 use dyn_comp,       only: dyn_export_t, dyn_import_t
@@ -417,7 +417,7 @@ subroutine derived_phys(phys_state, phys_tend, pbuf2d)
    use shr_vmath_mod,   only: shr_vmath_log
    use phys_control,    only: waccmx_is
    use cam_thermo,      only: cam_thermo_dry_air_update, cam_thermo_water_update
-   use air_composition, only: rairv, dry_air_species_num
+   use air_composition, only: rairv, dry_air_species_num, cappav
    use qneg_module,     only: qneg3
    use shr_const_mod,   only: shr_const_rwv
    use constituents,    only: qmin
@@ -433,8 +433,6 @@ subroutine derived_phys(phys_state, phys_tend, pbuf2d)
 
    real(r8) :: factor(pcols,pver)
    real(r8) :: zvirv(pcols,pver)
-
-   real(r8), parameter :: pref = 1.e5_r8 ! reference pressure (Pa)
 
    type(physics_buffer_desc), pointer :: pbuf_chnk(:)
 
@@ -504,13 +502,6 @@ subroutine derived_phys(phys_state, phys_tend, pbuf2d)
                             phys_state(lchnk)%lnpmid(:ncol,k), ncol)
       end do
 
-      do k = 1, pver
-         phys_state(lchnk)%exner(:ncol,k) = (phys_state(lchnk)%pint(:ncol,pver+1) / phys_state(lchnk)%pmid(:ncol,k))**cappa
-      end do
-
-
-
-
       if (dry_air_species_num>0) then
         !------------------------------------------------------------
         ! Apply limiters to mixing ratios of major species
@@ -527,6 +518,10 @@ subroutine derived_phys(phys_state, phys_tend, pbuf2d)
       else
         zvirv(:,:) = zvir
       endif
+      do k = 1, pver
+         phys_state(lchnk)%exner(:ncol,k) = (phys_state(lchnk)%pint(:ncol,pver+1) / phys_state(lchnk)%pmid(:ncol,k))**cappav(:ncol,k,lchnk)
+      end do
+
       !
       ! update cp_dycore in module air_composition.
       ! (note: at this point q is dry)

--- a/src/dynamics/mpas/dp_coupling.F90
+++ b/src/dynamics/mpas/dp_coupling.F90
@@ -519,7 +519,7 @@ subroutine derived_phys(phys_state, phys_tend, pbuf2d)
         zvirv(:,:) = zvir
       endif
       do k = 1, pver
-         phys_state(lchnk)%exner(:ncol,k) = (phys_state(lchnk)%pint(:ncol,pver+1) / phys_state(lchnk)%pmid(:ncol,k))**cappav(:ncol,k,lchnk)
+         phys_state(lchnk)%exner(:ncol,k) = (phys_state(lchnk)%pint(:ncol,pverp) / phys_state(lchnk)%pmid(:ncol,k))**cappav(:ncol,k,lchnk)
       end do
 
       !

--- a/src/dynamics/mpas/dp_coupling.F90
+++ b/src/dynamics/mpas/dp_coupling.F90
@@ -885,10 +885,9 @@ subroutine hydrostatic_pressure(nCells, nVertLevels, qsize, index_qv, zz, zgrid,
         ! PMID is not necessarily bounded by the hydrostatic interface pressure.
         ! (has been found to be an issue at ~3.75km resolution in surface layer)
         !
-        dp_epsilon = dp(k)*epsilon
-        if (pmid(k,iCell)>pint(k,iCell)-dp_epsilon.or.pmid(k,iCell)<pint(k+1,iCell)+dp_epsilon) then
-           pmid(k, iCell) = 0.5*(pint(k,iCell)+pint(k+1,iCell))
-        end if
+        dp_epsilon = dp(k) * epsilon
+        pmid   (k, iCell) = max(min(pmid   (k, iCell), pint   (k, iCell) - dp_epsilon), pint   (k + 1, iCell) + dp_epsilon)
+        pmiddry(k, iCell) = max(min(pmiddry(k, iCell), pintdry(k, iCell) - dp_epsilon), pintdry(k + 1, iCell) + dp_epsilon)
      end do
    end do
 end subroutine hydrostatic_pressure


### PR DESCRIPTION
Purpose of changes (include the issue number and title text for each relevant GitHub issue):

- fix issue with mid-level pressure not being bounded by interface pressures in MPAS physics-dynamics coupling: https://github.com/ESCOMP/CAM/issues/1268
- fix Exner bug in MPAS physics-dynamics coupling: https://github.com/ESCOMP/CAM/issues/753

Not able to add @kuanchihwang as a reviewer ...

Please note we need to make this change in CAM-SIMA as well.

Closes #1268 
Closes #753