### PR TITLE
part of cam6_4_123: Fix the CAM+RRTMGP GPU interface bug

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -145,7 +145,7 @@ fxDONOTUSEurl = https://github.com/ESCOMP/mizuRoute
 [submodule "ccs_config"]
 path = ccs_config
 url = https://github.com/ESMCI/ccs_config_cesm.git
-fxtag = ccs_config_cesm1.0.53
+fxtag = ccs_config_cesm1.0.59
 fxrequired = ToplevelRequired
 fxDONOTUSEurl = https://github.com/ESMCI/ccs_config_cesm.git
 

--- a/src/physics/rrtmgp/radiation.F90
+++ b/src/physics/rrtmgp/radiation.F90
@@ -1199,7 +1199,7 @@ subroutine radiation_tend( &
                ! diagnostic aerosol output.
                call rrtmgp_set_aer_sw( &
                   icall, state, pbuf, nday, idxday, nnite, idxnite, aer_sw)
-                                 
+
                if (nday > 0) then
 
                   ! Increment the gas optics (in atm_optics_sw) by the aerosol optics in aer_sw.

--- a/src/physics/rrtmgp/radiation.F90
+++ b/src/physics/rrtmgp/radiation.F90
@@ -1180,9 +1180,8 @@ subroutine radiation_tend( &
 
                   ! Compute the gas optics (stored in atm_optics_sw).
                   ! toa_flux is the reference solar source from RRTMGP data.
-                  !$acc data copyin(kdist_sw%gas_props,pmid_day,pint_day,t_day,gas_concs_sw%gas_concs) &
-                  !$acc        copy(atm_optics_sw%optical_props) &
-                  !$acc     copyout(toa_flux)
+                  !$acc data copyin(kdist_sw%gas_props,pmid_day,pint_day,t_day,gas_concs_sw%gas_concs,atm_optics_sw%optical_props) &
+                  !$acc      copyout(toa_flux)
                   errmsg = kdist_sw%gas_props%gas_optics( &
                      pmid_day, pint_day, t_day, gas_concs_sw%gas_concs, atm_optics_sw%optical_props, &
                      toa_flux)
@@ -1200,7 +1199,7 @@ subroutine radiation_tend( &
                ! diagnostic aerosol output.
                call rrtmgp_set_aer_sw( &
                   icall, state, pbuf, nday, idxday, nnite, idxnite, aer_sw)
-                  
+                                 
                if (nday > 0) then
 
                   ! Increment the gas optics (in atm_optics_sw) by the aerosol optics in aer_sw.
@@ -1318,8 +1317,8 @@ subroutine radiation_tend( &
 
                ! Compute the gas optics and Planck sources.
                !$acc data copyin(kdist_lw%gas_props, pmid_rad, pint_rad, t_rad,  &
-               !$acc             t_sfc, gas_concs_lw%gas_concs)                  &
-               !$acc        copy(atm_optics_lw%optical_props, atm_optics_lw%optical_props%tau,                &
+               !$acc             t_sfc, gas_concs_lw%gas_concs, atm_optics_lw%optical_props)         &
+               !$acc        copy(atm_optics_lw%optical_props%tau,                &
                !$acc             sources_lw%sources, sources_lw%sources%lay_source,                  &
                !$acc             sources_lw%sources%sfc_source,                  &
                !$acc             sources_lw%sources%lev_source,                  &

--- a/src/physics/rrtmgp/radiation.F90
+++ b/src/physics/rrtmgp/radiation.F90
@@ -1199,7 +1199,7 @@ subroutine radiation_tend( &
                ! diagnostic aerosol output.
                call rrtmgp_set_aer_sw( &
                   icall, state, pbuf, nday, idxday, nnite, idxnite, aer_sw)
-
+                  
                if (nday > 0) then
 
                   ! Increment the gas optics (in atm_optics_sw) by the aerosol optics in aer_sw.


### PR DESCRIPTION
fix #1383 

Thanks @RobertPincus for providing the RRTMGP GPU unit tests at:
- https://github.com/earth-system-radiation/rte-rrtmgp/blob/main/examples/rfmip-clear-sky/rrtmgp_rfmip_lw.F90
- https://github.com/earth-system-radiation/rte-rrtmgp/blob/main/examples/rfmip-clear-sky/rrtmgp_rfmip_sw.F90
- https://github.com/earth-system-radiation/rte-rrtmgp/blob/main/examples/all-sky/rrtmgp_allsky.F90
- https://github.com/earth-system-radiation/rte-rrtmgp/blob/main/tests/check_variants.F90
- https://github.com/earth-system-radiation/rte-rrtmgp/blob/main/tests/check_equivalence.F90

which helps me figure out what is wrong in the CAM+RRTMGP interface.

It is better to look at those examples in details and do similar data transfer for other variables in the future.
