### PR TITLE
part of cam6_4_123: Fix rei_cloud and rel_cloud units to um for CAM4

### DIFF
--- a/src/physics/cam/cloud_diagnostics.F90
+++ b/src/physics/cam/cloud_diagnostics.F90
@@ -172,8 +172,8 @@ contains
     endif
 
     if(one_mom_clouds) then
-       call addfld ('rel_cloud',(/ 'lev' /),'I','1/meter','effective radius of liq in cloud', sampling_seq=sampling_seq)
-       call addfld ('rei_cloud',(/ 'lev' /),'I','1','effective radius of ice in cloud', sampling_seq=sampling_seq)
+       call addfld ('rel_cloud',(/ 'lev' /),'I','micrometers','effective radius of liq in cloud', sampling_seq=sampling_seq)
+       call addfld ('rei_cloud',(/ 'lev' /),'I','micrometers','effective radius of ice in cloud', sampling_seq=sampling_seq)
     endif
 
     call addfld ('SETLWP',(/ 'lev' /), 'A','gram/m2','Prescribed liquid water path'          , sampling_seq=sampling_seq)


### PR DESCRIPTION
Fixes https://github.com/ESCOMP/CAM/issues/1387

The units for `rel_cloud` and `rei_cloud` in CAM for one-moment clouds (CAM4 RK microphysics only) are incorrect and should be microns. The data is correct; only the unit needs to be fixed.

I think this will be b4b and could go in a misc tag. These fields don't look like to be output by default in a CAM4 run and also won't affect anything else.