### PR TITLE
part of cam6_4_123: fix check of COSP with interpolated output

### DIFF
--- a/bld/build-namelist
+++ b/bld/build-namelist
@@ -4444,12 +4444,14 @@ for my $i (0 .. $#interp_output) {
 
 # Currently, interpolated output does not work with the COSP fields that use
 # more than 1 mdims.
-my $cosp_histfile_num = $nl->get_value('cosp_histfile_num');
-if (!defined $cosp_histfile_num) {$cosp_histfile_num = 1;}
-if ($interp_output[$cosp_histfile_num-1] =~ /$TRUE/io) {
-    die "$ProgName - ERROR: interpolate_output does not work with COSP.  Use cosp_histfile_num\n" .
-        " to direct COSP output to a history file that is not interpolated.  COSP output is\n" .
-        " currently on cosp_histfile_num=$cosp_histfile_num which contains interpolated output.";
+if ($docosp) {
+    my $cosp_histfile_num = $nl->get_value('cosp_histfile_num');
+    if (!defined $cosp_histfile_num) {$cosp_histfile_num = 1;}
+    if ($interp_output[$cosp_histfile_num-1] =~ /$TRUE/io) {
+        die "$ProgName - ERROR: interpolate_output does not work with COSP.  Use cosp_histfile_num\n" .
+            " to direct COSP output to a history file that is not interpolated.  COSP output is\n" .
+            " currently on cosp_histfile_num=$cosp_histfile_num which contains interpolated output.";
+    }
 }
 
 


### PR DESCRIPTION
The check in `build-namelist` to disallow having COSP output written to an interpolated stream needs to be inside a conditional that checks whether COSP is active.  That check has been added.

fixes #1397 
