### PR TITLE
Change CISM2 to SGLC in FCHIST_GC compset

### DIFF
--- a/cime_config/config_compsets.xml
+++ b/cime_config/config_compsets.xml
@@ -423,7 +423,7 @@
   </compset>
     <compset>
     <alias>FCHIST_GC</alias>
-    <lname>HIST_CAM60%GEOSCHEM%HEMCO_CLM50%SP_CICE%PRES_DOCN%DOM_MOSART_CISM2%NOEVOLVE_SWAV</lname>
+    <lname>HIST_CAM60%GEOSCHEM%HEMCO_CLM50%SP_CICE%PRES_DOCN%DOM_MOSART_SGLC_SWAV</lname>
   </compset>
 
   <compset>


### PR DESCRIPTION
Fixes #1416 (and closes #1412 as no longer needed)

This will change answers to the FCHIST_GC compset as the compset definition has changed. Previously, the FCHIST_GC test started failing due to a CISM upstream issue (#1412)

This changes FCHIST_GC to use the stub glacier matching FCHIST