### PR TITLE
cam6_4_132: Remove extraneous log messages

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -28,8 +28,8 @@
 
 [submodule "atmos_phys"]
 	path = src/atmos_phys
-	url = https://github.com/ESCOMP/atmospheric_physics
-	fxtag = atmos_phys0_18_002
+	url = https://github.com/peverwhee/atmospheric_physics
+	fxtag = 9b5ec5e8d501bd80ac64766730ab70ad968e8640
         fxrequired = AlwaysRequired
 	fxDONOTUSEurl = https://github.com/ESCOMP/atmospheric_physics
 

--- a/.gitmodules
+++ b/.gitmodules
@@ -28,8 +28,8 @@
 
 [submodule "atmos_phys"]
 	path = src/atmos_phys
-	url = https://github.com/peverwhee/atmospheric_physics
-	fxtag = 9b5ec5e8d501bd80ac64766730ab70ad968e8640
+	url = https://github.com/ESCOMP/atmospheric_physics
+	fxtag = atmos_phys0_18_003
         fxrequired = AlwaysRequired
 	fxDONOTUSEurl = https://github.com/ESCOMP/atmospheric_physics
 

--- a/bld/namelist_files/namelist_defaults_cam.xml
+++ b/bld/namelist_files/namelist_defaults_cam.xml
@@ -37,6 +37,7 @@
 <ncdata nlev="58" analytic_ic="1" >atm/cam/inic/cam_vcoords_L58_c250227.nc</ncdata>
 
 <!-- Vertical/Horizontal coordinates only - MPAS initial files for analytic cases-->
+<ncdata hgrid="mpasa120" nlev="26" analytic_ic="1" >atm/cam/inic/mpas/mpasa120_L26_notopo_coords_c251105.nc</ncdata>
 <ncdata hgrid="mpasa480" nlev="32" analytic_ic="1" >atm/cam/inic/mpas/mpasa480_L32_notopo_coords_c240507.nc</ncdata>
 <ncdata hgrid="mpasa120" nlev="32" analytic_ic="1" >atm/cam/inic/mpas/mpasa120_L32_notopo_coords_c240507.nc</ncdata>
 <ncdata hgrid="mpasa60"  nlev="32" analytic_ic="1" >atm/cam/inic/mpas/mpasa60_L32_notopo_coords_c240507.nc</ncdata>

--- a/doc/ChangeLog
+++ b/doc/ChangeLog
@@ -13,8 +13,8 @@ Purpose of changes (include the issue number and title text for each relevant Gi
 Describe any changes made to build system: N/A
 
 Describe any changes made to the namelist:
-M   bld/namelist_files/namelist_defaults_cam.xml
-- Add new MPAS 120km L26 analystic ics
+  M   bld/namelist_files/namelist_defaults_cam.xml
+       - Add new MPAS 120km L26 analystic ics
 
 List any changes to the defaults for the boundary datasets: N/A
 
@@ -27,14 +27,13 @@ List all files eliminated: N/A
 List all files added and what they do: N/A
 
 List all existing files that have been modified, and describe the changes:
-M    .gitmodules
-M    src/atmos_phys/
-M    src/physics/rrtmgp/radiation.F90
-- update atmospheric physics tag and rrtmgp_inputs_run interface to remove
-   RRTMGP messages
+  M    .gitmodules
+  M    src/atmos_phys/
+  M    src/physics/rrtmgp/radiation.F90
+         - update atmospheric physics tag and rrtmgp_inputs_run interface to remove RRTMGP messages
 
-M    src/chemistry/geoschem/chemistry.F90
-- remove extraneous geoschem messages
+  M    src/chemistry/geoschem/chemistry.F90
+         - remove extraneous geoschem messages
 
 If there were any failures reported from running test_driver.sh on any test
 platform, and checkin with these failures has been OK'd by the gatekeeper,
@@ -51,9 +50,9 @@ derecho/nvhpc/aux_cam:
                       reported the issue to CISL.  Note cam6_4_128 is the last CAM tag with baselines to use for comparison
                       but answer changes are expected starting with cam6_4_130
 
-izumi/nag/aux_cam:
+izumi/nag/aux_cam: all BFB
 
-izumi/gnu/aux_cam:
+izumi/gnu/aux_cam: all BFB
 
 Summarize any changes to answers: n/a
 

--- a/doc/ChangeLog
+++ b/doc/ChangeLog
@@ -1,5 +1,63 @@
 ===============================================================
 
+Tag name: cam6_4_132
+Originator(s): peverwhee, jimmielin, cacraigucar, nusbaume
+Date: Nov 26, 2025
+One-line Summary: Remove extraneous log messages
+Github PR URL: https://github.com/ESCOMP/CAM/pull/1442
+
+Purpose of changes (include the issue number and title text for each relevant GitHub issue):
+   Remove extraneous log messages from GEOS-Chem and RRTMGP
+   Add new MPAS 120 km L26 analytic ICs.
+
+Describe any changes made to build system: N/A
+
+Describe any changes made to the namelist:
+M   bld/namelist_files/namelist_defaults_cam.xml
+- Add new MPAS 120km L26 analystic ics
+
+List any changes to the defaults for the boundary datasets: N/A
+
+Describe any substantial timing or memory changes: N/A
+
+Code reviewed by: cacraigucar
+
+List all files eliminated: N/A
+
+List all files added and what they do: N/A
+
+List all existing files that have been modified, and describe the changes:
+M    .gitmodules
+M    src/atmos_phys/
+M    src/physics/rrtmgp/radiation.F90
+- update atmospheric physics tag and rrtmgp_inputs_run interface to remove
+   RRTMGP messages
+
+M    src/chemistry/geoschem/chemistry.F90
+- remove extraneous geoschem messages
+
+If there were any failures reported from running test_driver.sh on any test
+platform, and checkin with these failures has been OK'd by the gatekeeper,
+then copy the lines from the td.*.status files for the failed tests to the
+appropriate machine below.  All failed tests must be justified.
+
+derecho/intel/aux_cam:
+  SMS_D_Ln9_P1536x1.ne0CONUSne30x8_ne0CONUSne30x8_mt12.FCHIST.derecho_intel.cam-outfrq9s (Overall: FAIL) details:
+      - intermittent failure in CTSM code (lnd_set_decomp_and_domain.F90)
+
+derecho/nvhpc/aux_cam:
+  ERS_Ln9.ne30pg3_ne30pg3_mt232.FHISTC_LTso.derecho_nvhpc.cam-outfrq9s_gpu_default (Overall: FAIL) details:
+     - timing issue - Jian has determined this is due to changes on derecho with the the last upgrade.  He has
+                      reported the issue to CISL.  Note cam6_4_128 is the last CAM tag with baselines to use for comparison
+                      but answer changes are expected starting with cam6_4_130
+
+izumi/nag/aux_cam:
+
+izumi/gnu/aux_cam:
+
+Summarize any changes to answers: n/a
+
+===============================================================
 Tag name: cam6_4_131
 Originator(s): johnmauff, pel, cacraig, nusbaume
 Date: Nov 26, 2025

--- a/src/chemistry/geoschem/chemistry.F90
+++ b/src/chemistry/geoschem/chemistry.F90
@@ -949,8 +949,6 @@ contains
     ! Purpose: return true if specified constituent is implemented by this package
     ! Author: B. Eaton
 
-    IMPLICIT NONE
-
     CHARACTER(LEN=*), INTENT(IN) :: name   ! constituent name
     LOGICAL :: chem_implements_cnst        ! return value
     INTEGER :: M
@@ -4640,11 +4638,7 @@ contains
     use tracer_cnst,      only : init_tracer_cnst_restart
     use tracer_srcs,      only : init_tracer_srcs_restart
 
-    IMPLICIT NONE
-
     TYPE(file_desc_t) :: File
-
-    WRITE(iulog,'(a)') 'chem_init_restart: init restarts for tracer sources and offline fields'
 
     !
     ! data for offline tracers
@@ -4665,11 +4659,7 @@ contains
     use tracer_cnst, only : write_tracer_cnst_restart
     use tracer_srcs, only : write_tracer_srcs_restart
 
-    IMPLICIT NONE
-
     TYPE(file_desc_t) :: File
-
-    WRITE(iulog,'(a)') 'chem_write_restart: writing restarts for tracer sources and offline fields'
 
     ! data for offline tracers
     call write_tracer_cnst_restart(File)
@@ -4687,11 +4677,7 @@ contains
     use tracer_cnst, only : read_tracer_cnst_restart
     use tracer_srcs, only : read_tracer_srcs_restart
 
-    IMPLICIT NONE
-
     TYPE(file_desc_t) :: File
-
-    WRITE(iulog,'(a)') 'GCCALL CHEM_READ_RESTART'
 
     ! data for offline tracers
     call read_tracer_cnst_restart(File)

--- a/src/physics/rrtmgp/radiation.F90
+++ b/src/physics/rrtmgp/radiation.F90
@@ -1172,7 +1172,7 @@ subroutine radiation_tend( &
       ! Prepare state variables, daylit columns, albedos for RRTMGP
       ! Also calculate modified cloud fraction
       call rrtmgp_inputs_run(dosw, dolw, associated(cldfsnow), associated(cldfgrau), &
-                  masterproc, iulog, is_mpas, state%pmid(:ncol,:), state%pint(:ncol,:), state%t(:ncol,:), &
+                  is_mpas, state%pmid(:ncol,:), state%pint(:ncol,:), state%t(:ncol,:), &
                   nday, idxday, cldfprime(:ncol,:), coszrs(:ncol), kdist_sw, t_sfc,       &
                   emis_sfc, t_rad, pmid_rad, pint_rad, t_day, pmid_day,   &
                   pint_day, coszrs_day, alb_dir, alb_dif, cam_in%lwup(:ncol), stebol,  &


### PR DESCRIPTION
1. Brings in new atmospheric_physics tag to remove RRTMGP tricking messages
2. Updates GEOS-Chem's `chemistry.F90` to remove extraneous logging