### PR TITLE
cam6_4_161: fixes for root dirs in cesm blds

### DIFF
--- a/cime_config/buildlib
+++ b/cime_config/buildlib
@@ -203,7 +203,7 @@ def _build_tuvx(caseroot, libroot, bldroot):
         bldpath = os.path.join(bldroot, "tuv-x")
         if not os.path.exists(bldpath):
             os.makedirs(bldpath)
-        srcpath = os.path.abspath(os.path.join(case.get_value("COMP_ROOT_DIR_ATM"), \
+        srcpath = os.path.abspath(os.path.join(case.get_value("SRCROOT"), \
                                                "libraries", "tuv-x", ""))
         logger.info("Building TUV-x in {} from source in {}\n".format(bldpath, srcpath))
 

--- a/cime_config/buildnml
+++ b/cime_config/buildnml
@@ -49,7 +49,7 @@ def buildnml(case, caseroot, compname):
     COMP_INTERFACE      = case.get_value("COMP_INTERFACE")
     CALENDAR            = case.get_value("CALENDAR")
     COMPSET             = case.get_value("COMPSET")
- 
+
 # The Gregorian calendar currently can't be used with spinup compsets
 # because CAM's stream-handling code can't handle a request for data
 # for Feb 29 (possibly specified in a leapday testmod) from a non-leap-year
@@ -64,6 +64,7 @@ def buildnml(case, caseroot, compname):
             "Gregorian calendar (modifier _cG) cannot be used with spinup compset \n  {}".format(COMPSET)
         )
 
+    tuvx_data_src = os.path.join(srcroot, "libraries", "tuv-x", "data")
 
     testsrc = os.path.join(srcroot, "components", "cam")
     if os.path.exists(testsrc):
@@ -235,8 +236,7 @@ def buildnml(case, caseroot, compname):
         dest_data = os.path.join(rundir, "data")
         if os.path.exists(dest_data):
             shutil.rmtree(dest_data)
-        shutil.copytree(os.path.join(srcroot, "libraries", "tuv-x", "data"), \
-                                              dest_data)
+        shutil.copytree(tuvx_data_src, dest_data)
 
 ###############################################################################
 def _main_func():

--- a/doc/ChangeLog
+++ b/doc/ChangeLog
@@ -1,6 +1,6 @@
 ===============================================================
 
-Tag name: cam6_4_160
+Tag name: cam6_4_161
 Originator(s): fvitt
 Date: 27 Mar 2026
 One-line Summary: Fix for CESM builds
@@ -41,6 +41,8 @@ appropriate machine below.  All failed tests must be justified.
 derecho/intel/aux_cam: All PASS
 
 derecho/nvhpc/aux_cam:
+  FAIL ERS_Ln9.ne30pg3_ne30pg3_mt232.FHISTC_LTso.derecho_nvhpc.cam-outfrq9s_gpu_default COMPARE_base_rest
+   - pre-existing failure -- see https://github.com/ESCOMP/CAM/issues/1513
 
 izumi/nag/aux_cam:
   FAIL ERC_D_Ln9.f10_f10_mt232.FHIST_C5.izumi_nag.cam-outfrq3s_subcol

--- a/doc/ChangeLog
+++ b/doc/ChangeLog
@@ -2,6 +2,59 @@
 
 Tag name: cam6_4_160
 Originator(s): fvitt
+Date: 27 Mar 2026
+One-line Summary: Fix for CESM builds
+Github PR URL: https://github.com/ESCOMP/CAM/pull/1518
+
+Purpose of changes (include the issue number and title text for each relevant GitHub issue):
+
+ Issue #1518:
+ Fixes for TUV-x library builds in cesm tree as well as stand-alone cam tree.
+
+Describe any changes made to build system:
+
+ Corrections to root paths needed to be able to build TUV-x library when
+ CAM is checked out into the CESM tree and stand-alone.
+
+Describe any changes made to the namelist: N/A
+
+List any changes to the defaults for the boundary datasets: N/A
+
+Describe any substantial timing or memory changes: N/A
+
+Code reviewed by: cacraigucar
+
+List all files eliminated: N/A
+
+List all files added and what they do: N/A
+
+List all existing files that have been modified, and describe the changes:
+M       cime_config/buildlib
+M       cime_config/buildnml
+ - corrections to directory locations
+
+If there were any failures reported from running test_driver.sh on any test
+platform, and checkin with these failures has been OK'd by the gatekeeper,
+then copy the lines from the td.*.status files for the failed tests to the
+appropriate machine below.  All failed tests must be justified.
+
+derecho/intel/aux_cam: All PASS
+
+derecho/nvhpc/aux_cam:
+
+izumi/nag/aux_cam:
+  FAIL ERC_D_Ln9.f10_f10_mt232.FHIST_C5.izumi_nag.cam-outfrq3s_subcol
+   - pre-existing failure -- see https://github.com/ESCOMP/CAM/issues/1514
+
+izumi/gnu/aux_cam: All PASS
+
+Summarize any changes to answers: bit-for-bit
+
+===============================================================
+===============================================================
+
+Tag name: cam6_4_160
+Originator(s): fvitt
 Date: 26 Mar 2026
 One-line Summary: Introduce the option to use TUV-x photolysis library
 Github PR URL: https://github.com/ESCOMP/CAM/pull/1471


### PR DESCRIPTION
Fixes for TUVx lib builds in cesm tree as well as stand-alone cam tree.

