### PR TITLE
part of cam6_4_182: Force CAM to build yaml-cpp (vs searching for it first when building TUV-x)

### DIFF
--- a/cime_config/buildlib
+++ b/cime_config/buildlib
@@ -242,9 +242,8 @@ def _build_tuvx(caseroot, libroot, bldroot):
         incldir = os.environ.get('USER_INCLDIR')
         if incldir is None:
             incldir = ''
-        #os.environ['USER_INCLDIR'] = incldir + \
-        #    f" -I{_tuvx_include_dir(libroot)} "
-        os.environ['USER_INCLDIR'] = f" -I{_tuvx_include_dir(libroot)} " + incldir
+        os.environ['USER_INCLDIR'] = incldir + \
+            f" -I{_tuvx_include_dir(libroot)} "
 
         # create symlink to library in folder CIME expects libraries to be in
         dst = os.path.join(libroot, "libtuvx.a")

--- a/cime_config/buildlib
+++ b/cime_config/buildlib
@@ -218,6 +218,7 @@ def _build_tuvx(caseroot, libroot, bldroot):
         cmake_args += "-DCMAKE_Fortran_COMPILER_WORKS=1 "
         cmake_args += "-DCMAKE_C_COMPILER_WORKS=1 "
         cmake_args += "-DCMAKE_CXX_COMPILER_WORKS=1 "
+        cmake_args += "-DCMAKE_DISABLE_FIND_PACKAGE_yaml-cpp=1 "
         if (case.get_value("MACH") == "izumi") :
             cmake_args += f"-DCMAKE_PREFIX_PATH={arg_dict['NETCDF_PATH']} "
             cmake_args += f"-DCMAKE_IGNORE_PATH={os.environ.get('PYTHONHOME')} "
@@ -241,8 +242,9 @@ def _build_tuvx(caseroot, libroot, bldroot):
         incldir = os.environ.get('USER_INCLDIR')
         if incldir is None:
             incldir = ''
-        os.environ['USER_INCLDIR'] = incldir + \
-            f" -I{_tuvx_include_dir(libroot)} "
+        #os.environ['USER_INCLDIR'] = incldir + \
+        #    f" -I{_tuvx_include_dir(libroot)} "
+        os.environ['USER_INCLDIR'] = f" -I{_tuvx_include_dir(libroot)} " + incldir
 
         # create symlink to library in folder CIME expects libraries to be in
         dst = os.path.join(libroot, "libtuvx.a")


### PR DESCRIPTION
There's an issue with CAM / CESM cases and TUV-x when users have Conda environments active, since it finds a yaml-cpp library there, but it often isn't compatible.  This PR introduces a one-line change to force CAM to use its own copy so we have consistent behavior regardless of someone's conda environment.

Fixes #1537 