### PR TITLE
cam6_4_174: Update MPAS dynamical core to version 8.4.0

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -88,7 +88,7 @@
 	url = https://github.com/MPAS-Dev/MPAS-Model.git
         fxrequired = AlwaysRequired
         fxsparse = ../.mpas_sparse_checkout
-        fxtag = v8.2.1
+        fxtag = v8.4.0
 	fxDONOTUSEurl = https://github.com/MPAS-Dev/MPAS-Model.git
 
 [submodule "cosp2"]

--- a/bld/build-namelist
+++ b/bld/build-namelist
@@ -4388,7 +4388,6 @@ if ($dyn =~ /mpas/) {
     add_default($nl, 'mpas_coef_3rd_order');
     add_default($nl, 'mpas_smagorinsky_coef');
     add_default($nl, 'mpas_mix_full');
-    add_default($nl, 'mpas_epssm');
     add_default($nl, 'mpas_smdiv');
     add_default($nl, 'mpas_apvm_upwinding');
     add_default($nl, 'mpas_h_ScaleWithMesh');
@@ -4399,12 +4398,18 @@ if ($dyn =~ /mpas/) {
     add_default($nl, 'mpas_rayleigh_damp_u');
     add_default($nl, 'mpas_rayleigh_damp_u_timescale_days');
     add_default($nl, 'mpas_number_rayleigh_damp_u_levels');
+    add_default($nl, 'mpas_epssm_minimum');
+    add_default($nl, 'mpas_epssm_maximum');
+    add_default($nl, 'mpas_epssm_transition_bottom_z');
+    add_default($nl, 'mpas_epssm_transition_top_z');
     add_default($nl, 'mpas_apply_lbcs');
     add_default($nl, 'mpas_jedi_da');
     add_default($nl, 'mpas_do_restart');
     add_default($nl, 'mpas_print_global_minmax_vel');
     add_default($nl, 'mpas_print_detailed_minmax_vel');
     add_default($nl, 'mpas_print_global_minmax_sca');
+    add_default($nl, 'mpas_halo_exch_method');
+    add_default($nl, 'mpas_gpu_aware_mpi');
 
     # mpas_block_decomp_file_prefix should only be set when more than one task is used.
     # Otherwise the file is not used and should not be added to the input dataset file.

--- a/bld/namelist_files/namelist_defaults_cam.xml
+++ b/bld/namelist_files/namelist_defaults_cam.xml
@@ -3463,8 +3463,6 @@
 <mpas_coef_3rd_order          > 1.0D0 </mpas_coef_3rd_order>
 <mpas_smagorinsky_coef        > 0.125D0 </mpas_smagorinsky_coef>
 <mpas_mix_full                > .true. </mpas_mix_full>
-<mpas_epssm                   > 0.1D0 </mpas_epssm>
-<mpas_epssm hgrid="mpasa120" waccm_phys="1"> 0.5D0 </mpas_epssm>
 <mpas_smdiv                   > 0.1D0 </mpas_smdiv>
 <mpas_apvm_upwinding          > 0.5D0 </mpas_apvm_upwinding>
 <mpas_apvm_upwinding hgrid="mpasa120" waccm_phys="1"> 0.0D0 </mpas_apvm_upwinding>
@@ -3478,6 +3476,11 @@
 <mpas_rayleigh_damp_u         > .true. </mpas_rayleigh_damp_u>
 <mpas_rayleigh_damp_u_timescale_days> 5.0 </mpas_rayleigh_damp_u_timescale_days>
 <mpas_number_rayleigh_damp_u_levels> 5 </mpas_number_rayleigh_damp_u_levels>
+<mpas_epssm_minimum> 0.1D0 </mpas_epssm_minimum>
+<mpas_epssm_maximum> 0.1D0 </mpas_epssm_maximum>
+<mpas_epssm_maximum hgrid="mpasa120" waccm_phys="1"> 0.5D0 </mpas_epssm_maximum>
+<mpas_epssm_transition_bottom_z> 30000.0D0 </mpas_epssm_transition_bottom_z>
+<mpas_epssm_transition_top_z> 50000.0D0 </mpas_epssm_transition_top_z>
 <mpas_apply_lbcs> .false. </mpas_apply_lbcs>
 <mpas_jedi_da> .false. </mpas_jedi_da>
 <mpas_block_decomp_file_prefix hgrid="mpasa480">atm/cam/inic/mpas/mpasa480.graph.info.part.</mpas_block_decomp_file_prefix>
@@ -3492,6 +3495,9 @@
 <mpas_print_global_minmax_vel  > .false. </mpas_print_global_minmax_vel>
 <mpas_print_detailed_minmax_vel> .false. </mpas_print_detailed_minmax_vel>
 <mpas_print_global_minmax_sca  > .false. </mpas_print_global_minmax_sca>
+
+<mpas_halo_exch_method> mpas_halo </mpas_halo_exch_method>
+<mpas_gpu_aware_mpi> .false. </mpas_gpu_aware_mpi>
 
 <!-- ================================================================== -->
 <!-- Chemistry Rates Diagnostics                                        -->

--- a/bld/namelist_files/namelist_definition.xml
+++ b/bld/namelist_files/namelist_definition.xml
@@ -8993,13 +8993,13 @@ Default: 0.5
 
 <entry id="mpas_epssm_transition_bottom_z" type="real" category="mpas"
        group="damping" valid_values="positive real values">
-Height above MSL for the bottom of transition zone for epssm.
+Height (in meters) above MSL for the bottom of transition zone for epssm.
 Default: 30000.0
 </entry>
 
 <entry id="mpas_epssm_transition_top_z" type="real" category="mpas"
        group="damping" valid_values="positive real values">
-Height above MSL for the top of transition zone for epssm.
+Height (in meters) above MSL for the top of transition zone for epssm.
 Default: 50000.0
 </entry>
 

--- a/bld/namelist_files/namelist_definition.xml
+++ b/bld/namelist_files/namelist_definition.xml
@@ -8810,8 +8810,8 @@ Default: 120000.0
 
 <entry id="mpas_visc4_2dsmag" type="real" category="mpas"
        group="nhyd_model" valid_values="">
-Scaling coefficient of delta_x^3 to obtain Del^4 diffusion coefficient in
-MPAS dycore.
+Coefficient multiplied by delta x^3 to obtain Del^4 physical hyperviscosity
+in MPAS dycore.
 Default: 0.05
 </entry>
 
@@ -8902,13 +8902,6 @@ MPAS dycore.
 Default: TRUE
 </entry>
 
-<entry id="mpas_epssm" type="real" category="mpas"
-       group="nhyd_model" valid_values="">
-Off-centering parameter for the vertically implicit acoustic integration in
-MPAS dycore
-Default: 0.1
-</entry>
-
 <entry id="mpas_smdiv" type="real" category="mpas"
        group="nhyd_model" valid_values="">
 3-d divergence damping coefficient in MPAS dycore.
@@ -8984,6 +8977,32 @@ damping linearly ramps to zero by layer number from the top
 Default: 3
 </entry>
 
+<entry id="mpas_epssm_minimum" type="real" category="mpas"
+       group="damping" valid_values="real values between 0 and 1">
+Value of epssm, the off-centering parameter for the vertically implicit acoustic integration,
+below transition zone.
+Default: 0.1
+</entry>
+
+<entry id="mpas_epssm_maximum" type="real" category="mpas"
+       group="damping" valid_values="real values between 0 and 1">
+Value of epssm, the off-centering parameter for the vertically implicit acoustic integration,
+above transition zone.
+Default: 0.5
+</entry>
+
+<entry id="mpas_epssm_transition_bottom_z" type="real" category="mpas"
+       group="damping" valid_values="positive real values">
+Height above MSL for the bottom of transition zone for epssm.
+Default: 30000.0
+</entry>
+
+<entry id="mpas_epssm_transition_top_z" type="real" category="mpas"
+       group="damping" valid_values="positive real values">
+Height above MSL for the top of transition zone for epssm.
+Default: 50000.0
+</entry>
+
 <entry id="mpas_apply_lbcs" type="logical" category="mpas"
        group="limited_area" valid_values="">
 Whether to apply lateral boundary conditions
@@ -9034,6 +9053,18 @@ dycore.
 Default: FALSE
 </entry>
 
+<entry id="mpas_halo_exch_method" type="char*512" category="mpas"
+       group="development" valid_values="mpas_dmpar,mpas_halo">
+Method to use for exchanging halos in MPAS dycore.
+Default: mpas_halo
+</entry>
+
+<entry id="mpas_gpu_aware_mpi" type="logical" category="mpas"
+       group="development" valid_values=".false.,.true.">
+Whether to use GPU-aware MPI for halo exchanges in MPAS dycore. GPU-aware MPI
+is only implemented for mpas_halo_exch_method = mpas_halo.
+Default: FALSE
+</entry>
 
 <!-- Dycore testing  -->
 

--- a/doc/ChangeLog
+++ b/doc/ChangeLog
@@ -1,6 +1,6 @@
 Tag name: cam6_4_174
 Originator(s): kuanchihwang
-Date: TBD
+Date: 21 May 2026
 One-line Summary: Update MPAS dynamical core to version 8.4.0
 Github PR URL: https://github.com/ESCOMP/CAM/pull/1545
 
@@ -67,22 +67,57 @@ platform, and checkin with these failures has been OK'd by the gatekeeper,
 then copy the lines from the td.*.status files for the failed tests to the
 appropriate machine below. All failed tests must be justified.
 
-derecho/intel/aux_cam: In progress
+derecho/intel/aux_cam:
+  ERC_D_Ln9.mpasa120_mpasa120.F2000climo.derecho_intel.cam-outfrq9s_mpasa120 (Overall: DIFF) details:
+    FAIL ERC_D_Ln9.mpasa120_mpasa120.F2000climo.derecho_intel.cam-outfrq9s_mpasa120 NLCOMP
+    FAIL ERC_D_Ln9.mpasa120_mpasa120.F2000climo.derecho_intel.cam-outfrq9s_mpasa120 BASELINE /glade/campaign/cesm/community/amwg/cam_baselines/cam6_4_173_intel: DIFF
+  ERC_D_Ln9.mpasa120_mpasa120.FHISTC_LTso.derecho_intel.cam-outfrq9s_mpasa120 (Overall: DIFF) details:
+    FAIL ERC_D_Ln9.mpasa120_mpasa120.FHISTC_LTso.derecho_intel.cam-outfrq9s_mpasa120 NLCOMP
+    FAIL ERC_D_Ln9.mpasa120_mpasa120.FHISTC_LTso.derecho_intel.cam-outfrq9s_mpasa120 BASELINE /glade/campaign/cesm/community/amwg/cam_baselines/cam6_4_173_intel: DIFF
+  ERC_D_Ln9.mpasa120_mpasa120.QPC7.derecho_intel.cam-outfrq9s_mpasa120 (Overall: DIFF) details:
+    FAIL ERC_D_Ln9.mpasa120_mpasa120.QPC7.derecho_intel.cam-outfrq9s_mpasa120 NLCOMP
+    FAIL ERC_D_Ln9.mpasa120_mpasa120.QPC7.derecho_intel.cam-outfrq9s_mpasa120 BASELINE /glade/campaign/cesm/community/amwg/cam_baselines/cam6_4_173_intel: DIFF
 
-derecho/nvhpc/aux_cam: In progress
+  Expected namelist and answer changes due to MPAS version update.
 
-izumi/nag/aux_cam: In progress
+  Notes about SMS_D_Ln9_P1536x1.ne0CONUSne30x8_ne0CONUSne30x8_mt12.FCHIST.derecho_intel.cam-outfrq9s:
+  This test is flaky. It may sometimes fail with a "floating invalid" error in CTSM.
 
-izumi/gnu/aux_cam: In progress
+derecho/nvhpc/aux_cam:
+  PASS.
+
+izumi/nag/aux_cam:
+  ERC_D_Ln9.mpasa480_mpasa480_mt232.FHS94.izumi_nag.cam-outfrq9s (Overall: DIFF) details:
+    FAIL ERC_D_Ln9.mpasa480_mpasa480_mt232.FHS94.izumi_nag.cam-outfrq9s NLCOMP
+    FAIL ERC_D_Ln9.mpasa480_mpasa480_mt232.FHS94.izumi_nag.cam-outfrq9s BASELINE /fs/cgd/csm/models/atm/cam/pretag_bl/cam6_4_173_nag: DIFF
+  ERC_D_Ln9.mpasa480_mpasa480_mt232.QPC7.izumi_nag.cam-outfrq9s_mpasa480 (Overall: DIFF) details:
+    FAIL ERC_D_Ln9.mpasa480_mpasa480_mt232.QPC7.izumi_nag.cam-outfrq9s_mpasa480 NLCOMP
+    FAIL ERC_D_Ln9.mpasa480_mpasa480_mt232.QPC7.izumi_nag.cam-outfrq9s_mpasa480 BASELINE /fs/cgd/csm/models/atm/cam/pretag_bl/cam6_4_173_nag: DIFF
+
+  Expected namelist and answer changes due to MPAS version update.
+
+  ERC_D_Ln9.f10_f10_mt232.FHIST_C5.izumi_nag.cam-outfrq3s_subcol (Overall: FAIL) details:
+    FAIL ERC_D_Ln9.f10_f10_mt232.FHIST_C5.izumi_nag.cam-outfrq3s_subcol COMPARE_base_rest
+
+  Pre-existing test failure. See https://github.com/ESCOMP/CAM/issues/1514.
+
+izumi/gnu/aux_cam:
+  ERC_D_Ln9.mpasa480_mpasa480_mt232.FHISTC_LTso.izumi_gnu.cam-outfrq9s_mpasa480 (Overall: DIFF) details:
+    FAIL ERC_D_Ln9.mpasa480_mpasa480_mt232.FHISTC_LTso.izumi_gnu.cam-outfrq9s_mpasa480 NLCOMP
+    FAIL ERC_D_Ln9.mpasa480_mpasa480_mt232.FHISTC_LTso.izumi_gnu.cam-outfrq9s_mpasa480 BASELINE /fs/cgd/csm/models/atm/cam/pretag_bl/cam6_4_173_gnu: DIFF
+  ERS_Ln9_P24x1.mpasa480_mpasa480.F2000climo.izumi_gnu.cam-outfrq9s_mpasa480 (Overall: DIFF) details:
+    FAIL ERS_Ln9_P24x1.mpasa480_mpasa480.F2000climo.izumi_gnu.cam-outfrq9s_mpasa480 NLCOMP
+    FAIL ERS_Ln9_P24x1.mpasa480_mpasa480.F2000climo.izumi_gnu.cam-outfrq9s_mpasa480 BASELINE /fs/cgd/csm/models/atm/cam/pretag_bl/cam6_4_173_gnu: DIFF
+
+  Expected namelist and answer changes due to MPAS version update.
 
 CAM tag used for the baseline comparison tests if different than previous
 tag: cam6_4_173
 
-Summarize any changes to answers, i.e.,
-- what code configurations:
-- what platforms/compilers:
-- nature of change (roundoff; larger than roundoff but same climate; new
-  climate):
+Summarize any changes to answers:
+
+In summary, this PR is answer-changing for tests that involve MPAS dynamical core.
+For tests that do not involve MPAS dynamical core, they are bit-for-bit.
 
 ===============================================================
 

--- a/doc/ChangeLog
+++ b/doc/ChangeLog
@@ -1,3 +1,91 @@
+Tag name: cam6_4_174
+Originator(s): kuanchihwang
+Date: TBD
+One-line Summary: Update MPAS dynamical core to version 8.4.0
+Github PR URL: https://github.com/ESCOMP/CAM/pull/1545
+
+Purpose of changes (include the issue number and title text for each relevant GitHub issue):
+
+This PR updates MPAS dynamical core from version 8.2.1 to 8.4.0. See the in-between release notes of MPAS for details.
+
+Closes #1479
+
+Describe any changes made to build system:
+
+M       src/dynamics/mpas/Makefile
+  * Update Makefile to fix build errors
+  * Remove unnecessary Makefile build target
+  * Add patches to fix crash in MPAS 8.4.0
+
+Describe any changes made to the namelist:
+
+M       bld/build-namelist
+M       bld/namelist_files/namelist_defaults_cam.xml
+M       bld/namelist_files/namelist_definition.xml
+  * Update namelist definitions, defaults, and input to accommodate MPAS 8.4.0
+
+List any changes to the defaults for the boundary datasets:
+
+None
+
+Describe any substantial timing or memory changes:
+
+None
+
+Code reviewed by: nusbaume
+
+List all files eliminated:
+
+None
+
+List all files added and what they do:
+
+A       src/dynamics/mpas/driver/0001-Fix-Fortran-standard-violation.patch
+A       src/dynamics/mpas/driver/0002-Add-missing-argument-intent.patch
+A       src/dynamics/mpas/driver/0003-Avoid-implicit-save-attribute.patch
+  * Add patches to fix crash in MPAS 8.4.0
+
+List all existing files that have been modified, and describe the changes:
+
+M       .gitmodules
+  * Update MPAS dynamical core to version 8.4.0
+M       src/dynamics/mpas/dp_coupling.F90
+  * Add support for new deformation coefficients introduced in MPAS 8.4.0
+M       src/dynamics/mpas/driver/cam_mpas_subdriver.F90
+  * Remove deprecated variables that no longer exist
+  * Define new constituent indexes required by MPAS 8.4.0
+M       src/dynamics/mpas/driver/README
+  * Add patches to fix crash in MPAS 8.4.0
+M       src/dynamics/mpas/dycore
+  * Update MPAS dynamical core to version 8.4.0
+M       src/dynamics/mpas/dyn_comp.F90
+  * Update namelist definitions, defaults, and input to accommodate MPAS 8.4.0
+  * Add support for new deformation coefficients introduced in MPAS 8.4.0
+
+If there were any failures reported from running test_driver.sh on any test
+platform, and checkin with these failures has been OK'd by the gatekeeper,
+then copy the lines from the td.*.status files for the failed tests to the
+appropriate machine below. All failed tests must be justified.
+
+derecho/intel/aux_cam: In progress
+
+derecho/nvhpc/aux_cam: In progress
+
+izumi/nag/aux_cam: In progress
+
+izumi/gnu/aux_cam: In progress
+
+CAM tag used for the baseline comparison tests if different than previous
+tag: cam6_4_173
+
+Summarize any changes to answers, i.e.,
+- what code configurations:
+- what platforms/compilers:
+- nature of change (roundoff; larger than roundoff but same climate; new
+  climate):
+
+===============================================================
+
 Tag name: cam6_4_173
 Originator(s): pel, peverwhee, hplin
 Date: 15 May 2026

--- a/src/dynamics/mpas/Makefile
+++ b/src/dynamics/mpas/Makefile
@@ -1,4 +1,4 @@
-GIT_VERSION=$(shell git -C "$(MPAS_SRC_ROOT)/dycore" describe --always --dirty --tags || echo "N/A" )
+GIT_VERSION=$(shell git -C "$(MPAS_SRC_ROOT)/dycore" describe --always --dirty --tags || echo "N/A")
 CPPFLAGS := -D_MPI -DMPAS_NATIVE_TIMERS -DMPAS_CAM_DYCORE -DMPAS_PIO_SUPPORT -DMPAS_NO_ESMF_INIT -DMPAS_GIT_VERSION="$(GIT_VERSION)" -DMPAS_BUILD_TARGET="N/A" -DMPAS_NAMELIST_SUFFIX="atmosphere"
 ifdef PIODEF
   CPPFLAGS += $(PIODEF)
@@ -27,7 +27,8 @@ INTERFACE_OBJS = \
 DYN_OBJS = \
 	mpas_atm_time_integration.o \
 	mpas_atm_boundaries.o \
-	mpas_atm_iau.o
+	mpas_atm_iau.o \
+	mpas_atm_dissipation_models.o
 
 DIAG_OBJS = \
 	mpas_atm_diagnostics_manager.o \
@@ -83,8 +84,6 @@ FRAME_OBJS = \
 	mpas_io_streams.o \
 	mpas_bootstrapping.o \
 	mpas_io_units.o \
-	mpas_stream_inquiry.o \
-	stream_inquiry.o \
 	mpas_stream_manager.o \
 	mpas_stream_list.o \
 	mpas_forcing.o \
@@ -99,8 +98,11 @@ FRAME_OBJS = \
 	regex_matching.o \
 	mpas_log.o \
 	mpas_halo.o \
-	mpas_string_utils.o
-
+	mpas_string_utils.o \
+	mpas_ptscotch_interface.o \
+	ptscotch_interface.o \
+	mpas_stream_inquiry.o \
+	stream_inquiry.o
 
 UTIL_OBJS = \
 	ezxml.o
@@ -139,8 +141,7 @@ mpas_framework.o: mpas_dmpar.o \
                   mpas_io_units.o \
                   mpas_block_decomp.o \
                   mpas_stream_manager.o \
-                  mpas_c_interfacing.o \
-                  mpas_halo.o
+                  mpas_c_interfacing.o
 
 mpas_abort.o: mpas_kind_types.o mpas_io_units.o mpas_threading.o
 
@@ -160,7 +161,7 @@ mpas_pool_routines.o: mpas_derived_types.o mpas_field_routines.o mpas_threading.
 
 mpas_decomp.o: mpas_derived_types.o mpas_stream_manager.o mpas_log.o
 
-mpas_hash.o : mpas_derived_types.o
+mpas_hash.o: mpas_derived_types.o
 
 mpas_dmpar.o: mpas_sort.o mpas_kind_types.o mpas_derived_types.o mpas_hash.o mpas_threading.o mpas_pool_routines.o mpas_log.o
 
@@ -170,7 +171,7 @@ mpas_timekeeping.o: mpas_string_utils.o mpas_kind_types.o mpas_derived_types.o m
 
 mpas_timer.o: mpas_kind_types.o mpas_dmpar.o mpas_threading.o mpas_log.o
 
-mpas_block_decomp.o: mpas_derived_types.o mpas_hash.o mpas_io_units.o mpas_dmpar.o
+mpas_block_decomp.o: mpas_derived_types.o mpas_hash.o mpas_io_units.o mpas_dmpar.o mpas_timer.o mpas_ptscotch_interface.o
 
 mpas_block_creator.o: mpas_dmpar.o mpas_hash.o mpas_sort.o mpas_io_units.o mpas_block_decomp.o mpas_stream_manager.o mpas_decomp.o mpas_abort.o $(DEPS)
 
@@ -184,8 +185,6 @@ mpas_io_units.o: mpas_kind_types.o
 
 mpas_threading.o: mpas_kind_types.o
 
-mpas_stream_inquiry.o: mpas_derived_types.o mpas_log.o mpas_c_interfacing.o stream_inquiry.o
-
 mpas_stream_list.o: mpas_derived_types.o mpas_kind_types.o mpas_io_streams.o mpas_timekeeping.o regex_matching.o mpas_log.o
 
 mpas_stream_manager.o: mpas_io_streams.o mpas_timekeeping.o mpas_derived_types.o mpas_kind_types.o mpas_c_interfacing.o mpas_stream_list.o mpas_dmpar.o mpas_io.o mpas_threading.o mpas_log.o
@@ -193,6 +192,10 @@ mpas_stream_manager.o: mpas_io_streams.o mpas_timekeeping.o mpas_derived_types.o
 mpas_forcing.o: mpas_derived_types.o mpas_timekeeping.o mpas_stream_manager.o mpas_log.o mpas_io_units.o
 
 mpas_halo.o: mpas_derived_types.o mpas_pool_routines.o mpas_log.o
+
+mpas_ptscotch_interface.o: mpas_derived_types.o mpas_log.o
+
+mpas_stream_inquiry.o: mpas_derived_types.o mpas_log.o mpas_c_interfacing.o
 
 #
 # Operator dependencies
@@ -240,8 +243,9 @@ incs: $(REGISTRY_FILE)
 #
 dycore: $(DYN_OBJS) $(DIAGNOSTICS) $(DIAG_OBJS) $(INTERFACE_OBJS)
 
-mpas_atm_time_integration.o: mpas_atm_iau.o mpas_atm_dimensions.o mpas_atm_boundaries.o
+mpas_atm_dissipation_models.o: mpas_atm_dimensions.o
 
+mpas_atm_time_integration.o: mpas_atm_iau.o mpas_atm_dimensions.o mpas_atm_boundaries.o mpas_atm_dissipation_models.o
 
 #
 # Diagnostics
@@ -261,8 +265,7 @@ mpas_atm_core_interface.o: mpas_atm_core.o incs
 
 mpas_atm_core.o: mpas_atm_threading.o mpas_atm_time_integration.o mpas_atm_diagnostics_manager.o mpas_atm_halos.o
 
-cam_mpas_subdriver.o: mpas_atm_core_interface.o mpas_derived_types.o mpas_framework.o mpas_domain_routines.o mpas_pool_routines.o
-
+cam_mpas_subdriver.o: mpas_atm_core.o mpas_atm_core_interface.o mpas_atm_time_integration.o mpas_atm_dimensions.o mpas_atm_halos.o mpas_atm_threading.o
 
 clean:
 	rm registry Registry_processed.xml *.inc *.o *.mod lib*.a
@@ -275,7 +278,7 @@ clean:
 	$(CC) -c $(CFLAGS) -DUNDERSCORE $(CPPFLAGS) $(CPPINCLUDES) -I$(MPAS_SRC_ROOT)/dycore/src/external/ezxml $<
 
 %.o : %.F
-	$(FC) -c $(CPPFLAGS) $(FFLAGS) $(CPPINCLUDES) $(FCINCLUDES) $<
+	$(FC) -c $(CPPFLAGS) $(FFLAGS) $(CPPINCLUDES) $(FCINCLUDES) -I$(MPAS_SRC_ROOT)/dycore/src/framework $<
 
 %.o : %.F90
 	$(FC) -c $(CPPFLAGS) $(FFLAGS) $(CPPINCLUDES) $(FCINCLUDES) $<

--- a/src/dynamics/mpas/Makefile
+++ b/src/dynamics/mpas/Makefile
@@ -105,6 +105,7 @@ UTIL_OBJS = \
 
 
 all:
+	( $(MAKE) apply-patch )
 	( $(MAKE) xml )
 	( $(MAKE) framework )
 	( $(MAKE) operators )
@@ -113,6 +114,13 @@ all:
 	( $(MAKE) dycore )
 	( ar -ru libmpas.a $(INTERFACE_OBJS) $(DYN_OBJS) $(DIAG_OBJS) $(DIAGNOSTICS) $(OPERATOR_OBJS) $(FRAME_OBJS) $(UTIL_OBJS) )
 
+apply-patch:
+	@for file in "$(MPAS_SRC_ROOT)"/driver/*.patch; do \
+		if [ -f "$${file}" ] && git -C "$(MPAS_SRC_ROOT)"/dycore apply --check -p1 "$${file}" 1>/dev/null 2>&1; then \
+			echo "Applying $${file}"; \
+			git -C "$(MPAS_SRC_ROOT)"/dycore apply -p1 "$${file}"; \
+		fi; \
+	done
 
 #
 # EZXML

--- a/src/dynamics/mpas/Makefile
+++ b/src/dynamics/mpas/Makefile
@@ -49,10 +49,6 @@ REG_OBJS = \
 	fortprintf.o \
 	utility.o
 
-STREAMS_GEN_OBJS = \
-	streams_gen.o \
-	test_functions.o
-
 OPERATOR_OBJS = \
 	mpas_vector_operations.o \
 	mpas_matrix_operations.o \
@@ -113,7 +109,6 @@ all:
 	( $(MAKE) framework )
 	( $(MAKE) operators )
 	( $(MAKE) registry )
-	( $(MAKE) streams_gen )
 	( $(MAKE) incs )
 	( $(MAKE) dycore )
 	( ar -ru libmpas.a $(INTERFACE_OBJS) $(DYN_OBJS) $(DIAG_OBJS) $(DIAGNOSTICS) $(OPERATOR_OBJS) $(FRAME_OBJS) $(UTIL_OBJS) )
@@ -222,14 +217,6 @@ mpas_geometry_utils.o: mpas_vector_operations.o mpas_matrix_operations.o
 #
 registry: $(REG_OBJS) ezxml.o
 	$(CC) $(CPPFLAGS) $(CFLAGS) -o $@ $(REG_OBJS) ezxml.o
-
-
-#
-# Default stream file generator
-#
-streams_gen: $(STREAMS_GEN_OBJS) ezxml.o
-	$(CC) $(CPPFLAGS) $(CFLAGS) -o $@ $(STREAMS_GEN_OBJS) ezxml.o
-
 
 #
 # Include files manufactured by the registry code generator

--- a/src/dynamics/mpas/dp_coupling.F90
+++ b/src/dynamics/mpas/dp_coupling.F90
@@ -76,10 +76,8 @@ subroutine d_p_coupling(phys_state, phys_tend, pbuf2d, dyn_out)
    ! mesh information and coefficients needed for
    ! frontogenesis function calculation
    !
-   real(r8), pointer :: defc_a(:,:)
-   real(r8), pointer :: defc_b(:,:)
-   real(r8), pointer :: cell_gradient_coef_x(:,:)
-   real(r8), pointer :: cell_gradient_coef_y(:,:)
+   real(r8), pointer :: deformation_coef_c(:, :) ! Introduced in MPAS 8.4.0, replacing cell_gradient_coef_x.
+   real(r8), pointer :: deformation_coef_s(:, :) ! Introduced in MPAS 8.4.0, replacing cell_gradient_coef_y.
    real(r8), pointer :: edgesOnCell_sign(:,:)
    real(r8), pointer :: dvEdge(:)
    real(r8), pointer :: areaCell(:)
@@ -169,10 +167,8 @@ subroutine d_p_coupling(phys_state, phys_tend, pbuf2d, dyn_out)
       !
       ! compute frontogenesis function and angle for gravity wave scheme
       !
-      defc_a => dyn_out % defc_a
-      defc_b => dyn_out % defc_b
-      cell_gradient_coef_x => dyn_out % cell_gradient_coef_x
-      cell_gradient_coef_y => dyn_out % cell_gradient_coef_y
+      deformation_coef_c => dyn_out % deformation_coef_c
+      deformation_coef_s => dyn_out % deformation_coef_s
       edgesOnCell_sign => dyn_out % edgesOnCell_sign
       dvEdge => dyn_out % dvEdge
       areaCell => dyn_out % areaCell
@@ -192,15 +188,13 @@ subroutine d_p_coupling(phys_state, phys_tend, pbuf2d, dyn_out)
       allocate(frontga_phys(pcols, pver, begchunk:endchunk), stat=ierr)
       if( ierr /= 0 ) call endrun(subname//':failed to allocate frontga_phys array')
 
-
       call calc_frontogenesis( frontogenesisFunction, frontogenesisAngle,  &
                                theta_m, tracers(index_qv,:,:),             &
-                               uperp, utangential, defc_a, defc_b,         &
-                               cell_gradient_coef_x, cell_gradient_coef_y, &
+                               uperp, utangential, dyn_out % defc_a, dyn_out % defc_b, &
+                               deformation_coef_c, deformation_coef_s, &
                                areaCell, dvEdge, cellsOnEdge, edgesOnCell, &
                                nEdgesOnCell, edgesOnCell_sign,             &
                                plev, nCellsSolve )
-
    end if
 
    if (use_gw_movmtn_pbl) then

--- a/src/dynamics/mpas/driver/0001-Fix-Fortran-standard-violation.patch
+++ b/src/dynamics/mpas/driver/0001-Fix-Fortran-standard-violation.patch
@@ -1,0 +1,45 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Kuan-Chih Wang <kuanchihw@ucar.edu>
+Date: Tue, 21 Apr 2026 13:50:09 -0600
+Subject: [PATCH] Fix Fortran standard violation due to pointer argument not
+ being associated
+
+At line 1970, if the `DO_PHYSICS` macro is undefined, the `diag_physics` pointer
+will not be initialized by the call to `mpas_pool_get_subpool`, and therefore
+its pointer association status will remain undefined.
+
+However, at line 2250, this pointer is used as an argument to call `atm_compute_dyn_tend`,
+which constitutes a Fortran standard violation.
+
+Quoted from Fortran 2023,
+
+> 15.5.2.4 Argument association
+> Except in references to intrinsic inquiry functions, a pointer actual argument that
+> corresponds to a nonoptional nonpointer dummy argument shall be pointer associated with
+> a target.
+
+This bug can lead to a runtime crash for models that use MPAS as a dynamical core
+(e.g., CAM, CAM-SIMA).
+
+Fix this issue by adding the `pointer` attribute to the `diag_physics` dummy argument
+for the `atm_compute_dyn_tend` subroutine.
+---
+ src/core_atmosphere/dynamics/mpas_atm_time_integration.F | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/core_atmosphere/dynamics/mpas_atm_time_integration.F b/src/core_atmosphere/dynamics/mpas_atm_time_integration.F
+index 238ca7235..c16072976 100644
+--- a/src/core_atmosphere/dynamics/mpas_atm_time_integration.F
++++ b/src/core_atmosphere/dynamics/mpas_atm_time_integration.F
+@@ -5813,7 +5813,7 @@ module atm_time_integration
+       type (mpas_pool_type), intent(in) :: state
+       type (mpas_pool_type), intent(in) :: diag
+       type (mpas_pool_type), intent(in) :: mesh
+-      type (mpas_pool_type), intent(in) :: diag_physics
++      type (mpas_pool_type), pointer, intent(in) :: diag_physics
+       type (mpas_pool_type), intent(in) :: configs
+       integer, intent(in) :: nVertLevels              ! for allocating stack variables
+       integer, intent(in) :: rk_step, dynamics_substep
+-- 
+2.48.1
+

--- a/src/dynamics/mpas/driver/0002-Add-missing-argument-intent.patch
+++ b/src/dynamics/mpas/driver/0002-Add-missing-argument-intent.patch
@@ -1,0 +1,28 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Kuan-Chih Wang <kuanchihw@ucar.edu>
+Date: Tue, 21 Apr 2026 14:35:05 -0600
+Subject: [PATCH] Add missing argument intent
+
+Throughout the `atm_compute_dyn_tend` subroutine, the `tend_physics` pointer
+never changes its pointer association status. Add the missing `intent(in)`
+attribute for better safety.
+---
+ src/core_atmosphere/dynamics/mpas_atm_time_integration.F | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/core_atmosphere/dynamics/mpas_atm_time_integration.F b/src/core_atmosphere/dynamics/mpas_atm_time_integration.F
+index c16072976..b6e620fe1 100644
+--- a/src/core_atmosphere/dynamics/mpas_atm_time_integration.F
++++ b/src/core_atmosphere/dynamics/mpas_atm_time_integration.F
+@@ -5809,7 +5809,7 @@ module atm_time_integration
+       ! Dummy arguments
+       !
+       type (mpas_pool_type), intent(inout) :: tend
+-      type (mpas_pool_type), pointer :: tend_physics
++      type (mpas_pool_type), pointer, intent(in) :: tend_physics
+       type (mpas_pool_type), intent(in) :: state
+       type (mpas_pool_type), intent(in) :: diag
+       type (mpas_pool_type), intent(in) :: mesh
+-- 
+2.48.1
+

--- a/src/dynamics/mpas/driver/0003-Avoid-implicit-save-attribute.patch
+++ b/src/dynamics/mpas/driver/0003-Avoid-implicit-save-attribute.patch
@@ -1,0 +1,29 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Kuan-Chih Wang <kuanchihw@ucar.edu>
+Date: Tue, 21 Apr 2026 14:49:58 -0600
+Subject: [PATCH] Avoid implicit `save` attribute during variable declaration
+
+In Fortran, explicit initialization of a variable implies the `save` attribute,
+which may have surprising result and is not thread-safe.
+
+Avoid doing it to conform to the Fortran best practices.
+---
+ src/core_atmosphere/dynamics/mpas_atm_time_integration.F | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/core_atmosphere/dynamics/mpas_atm_time_integration.F b/src/core_atmosphere/dynamics/mpas_atm_time_integration.F
+index b6e620fe1..227fbde86 100644
+--- a/src/core_atmosphere/dynamics/mpas_atm_time_integration.F
++++ b/src/core_atmosphere/dynamics/mpas_atm_time_integration.F
+@@ -1918,7 +1918,7 @@ module atm_time_integration
+       type (mpas_pool_type), pointer :: diag_physics
+       type (mpas_pool_type), pointer :: mesh
+       type (mpas_pool_type), pointer :: tend
+-      type (mpas_pool_type), pointer :: tend_physics => null()
++      type (mpas_pool_type), pointer :: tend_physics
+       type (mpas_pool_type), pointer :: lbc  ! regional_MPAS addition
+ 
+       real (kind=RKIND), dimension(:,:), pointer :: w
+-- 
+2.48.1
+

--- a/src/dynamics/mpas/driver/README
+++ b/src/dynamics/mpas/driver/README
@@ -1,2 +1,5 @@
 Code in this directory is compiled using the MPAS-Atmosphere Makefile
 (src/dynamics/mpas/Makefile).
+
+Also, any patches (i.e., `*.patch`) placed in this directory will be applied to
+the MPAS-Atmosphere dycore before building it.

--- a/src/dynamics/mpas/driver/cam_mpas_subdriver.F90
+++ b/src/dynamics/mpas/driver/cam_mpas_subdriver.F90
@@ -943,13 +943,9 @@ contains
        type (field2DReal), pointer :: zgrid, zxu, zz
        type (field3DReal), pointer :: zb, zb3, deriv_two, cellTangentPlane, coeffs_reconstruct
 
-       type (field2DReal), pointer :: edgeNormalVectors, localVerticalUnitVectors, defc_a, defc_b
-       type (field2DReal), pointer :: cell_gradient_coef_x, cell_gradient_coef_y
+       type (field2DReal), pointer :: edgeNormalVectors, localVerticalUnitVectors
 
        type (MPAS_Stream_type) :: mesh_stream
-
-       nullify(cell_gradient_coef_x)
-       nullify(cell_gradient_coef_y)
 
        call MPAS_createStream(mesh_stream, domain_ptr % ioContext, 'not_used', MPAS_IO_NETCDF, MPAS_IO_READ, &
                               pio_file_desc=fh_ini, ierr=ierr)
@@ -1028,14 +1024,6 @@ contains
 
        call mpas_pool_get_field(meshPool, 'edgeNormalVectors', edgeNormalVectors)
        call mpas_pool_get_field(meshPool, 'localVerticalUnitVectors', localVerticalUnitVectors)
-
-       call mpas_pool_get_field(meshPool, 'defc_a', defc_a)
-       call mpas_pool_get_field(meshPool, 'defc_b', defc_b)
-
-       if (use_gw_front .or. use_gw_front_igw) then
-          call mpas_pool_get_field(meshPool, 'cell_gradient_coef_x', cell_gradient_coef_x)
-          call mpas_pool_get_field(meshPool, 'cell_gradient_coef_y', cell_gradient_coef_y)
-       endif
 
        ierr_total = 0
 
@@ -1164,16 +1152,6 @@ contains
        if (ierr /= MPAS_STREAM_NOERR) ierr_total = ierr_total + 1
        call MPAS_streamAddField(mesh_stream, localVerticalUnitVectors, ierr=ierr)
        if (ierr /= MPAS_STREAM_NOERR) ierr_total = ierr_total + 1
-       call MPAS_streamAddField(mesh_stream, defc_a, ierr=ierr)
-       if (ierr /= MPAS_STREAM_NOERR) ierr_total = ierr_total + 1
-       call MPAS_streamAddField(mesh_stream, defc_b, ierr=ierr)
-       if (ierr /= MPAS_STREAM_NOERR) ierr_total = ierr_total + 1
-       if (use_gw_front .or. use_gw_front_igw) then
-          call MPAS_streamAddField(mesh_stream, cell_gradient_coef_x, ierr=ierr)
-          if (ierr /= MPAS_STREAM_NOERR) ierr_total = ierr_total + 1
-          call MPAS_streamAddField(mesh_stream, cell_gradient_coef_y, ierr=ierr)
-          if (ierr /= MPAS_STREAM_NOERR) ierr_total = ierr_total + 1
-       endif
 
        if (ierr_total > 0) then
            write(errString, '(a,i0,a)') subname//': FATAL: Failed to add ', ierr_total, ' fields to static input stream.'
@@ -1253,12 +1231,7 @@ contains
 
        call MPAS_dmpar_exch_halo_field(edgeNormalVectors)
        call MPAS_dmpar_exch_halo_field(localVerticalUnitVectors)
-       call MPAS_dmpar_exch_halo_field(defc_a)
-       call MPAS_dmpar_exch_halo_field(defc_b)
-       if (use_gw_front .or. use_gw_front_igw) then
-          call MPAS_dmpar_exch_halo_field(cell_gradient_coef_x)
-          call MPAS_dmpar_exch_halo_field(cell_gradient_coef_y)
-       endif
+
        !
        ! Re-index from global index space to local index space
        !
@@ -1346,8 +1319,7 @@ contains
        type (field2DReal), pointer :: zgrid, zxu, zz
        type (field3DReal), pointer :: zb, zb3, deriv_two, cellTangentPlane, coeffs_reconstruct
 
-       type (field2DReal), pointer :: edgeNormalVectors, localVerticalUnitVectors, defc_a, defc_b
-       type (field2DReal), pointer :: cell_gradient_coef_x, cell_gradient_coef_y
+       type (field2DReal), pointer :: edgeNormalVectors, localVerticalUnitVectors
 
        type (field0DChar), pointer :: initial_time
        type (field0DChar), pointer :: xtime
@@ -1386,9 +1358,6 @@ contains
 
        type (field1DReal), pointer :: u_init
        type (field1DReal), pointer :: qv_init
-
-       nullify(cell_gradient_coef_x)
-       nullify(cell_gradient_coef_y)
 
        call MPAS_createStream(restart_stream, domain_ptr % ioContext, 'not_used', MPAS_IO_NETCDF, &
                               direction, pio_file_desc=fh_rst, ierr=ierr)
@@ -1467,12 +1436,7 @@ contains
 
        call mpas_pool_get_field(allFields, 'edgeNormalVectors', edgeNormalVectors)
        call mpas_pool_get_field(allFields, 'localVerticalUnitVectors', localVerticalUnitVectors)
-       call mpas_pool_get_field(allFields, 'defc_a', defc_a)
-       call mpas_pool_get_field(allFields, 'defc_b', defc_b)
-       if (use_gw_front .or. use_gw_front_igw) then
-          call mpas_pool_get_field(allFields, 'cell_gradient_coef_x', cell_gradient_coef_x)
-          call mpas_pool_get_field(allFields, 'cell_gradient_coef_y', cell_gradient_coef_y)
-       endif
+
        call mpas_pool_get_field(allFields, 'initial_time', initial_time, timeLevel=1)
        call mpas_pool_get_field(allFields, 'xtime', xtime, timeLevel=1)
        call mpas_pool_get_field(allFields, 'u', u, timeLevel=1)
@@ -1638,16 +1602,7 @@ contains
        if (ierr /= MPAS_STREAM_NOERR) ierr_total = ierr_total + 1
        call MPAS_streamAddField(restart_stream, localVerticalUnitVectors, ierr=ierr)
        if (ierr /= MPAS_STREAM_NOERR) ierr_total = ierr_total + 1
-       call MPAS_streamAddField(restart_stream, defc_a, ierr=ierr)
-       if (ierr /= MPAS_STREAM_NOERR) ierr_total = ierr_total + 1
-       call MPAS_streamAddField(restart_stream, defc_b, ierr=ierr)
-       if (ierr /= MPAS_STREAM_NOERR) ierr_total = ierr_total + 1
-       if (use_gw_front .or. use_gw_front_igw) then
-          call MPAS_streamAddField(restart_stream, cell_gradient_coef_x, ierr=ierr)
-          if (ierr /= MPAS_STREAM_NOERR) ierr_total = ierr_total + 1
-          call MPAS_streamAddField(restart_stream, cell_gradient_coef_y, ierr=ierr)
-          if (ierr /= MPAS_STREAM_NOERR) ierr_total = ierr_total + 1
-       endif
+
        call MPAS_streamAddField(restart_stream, initial_time, ierr=ierr)
        if (ierr /= MPAS_STREAM_NOERR) ierr_total = ierr_total + 1
        call MPAS_streamAddField(restart_stream, xtime, ierr=ierr)
@@ -1854,12 +1809,7 @@ contains
 
        call cam_mpas_update_halo('edgeNormalVectors', endrun)
        call cam_mpas_update_halo('localVerticalUnitVectors', endrun)
-       call cam_mpas_update_halo('defc_a', endrun)
-       call cam_mpas_update_halo('defc_b', endrun)
-       if (use_gw_front .or. use_gw_front_igw) then
-          call cam_mpas_update_halo('cell_gradient_coef_x', endrun)
-          call cam_mpas_update_halo('cell_gradient_coef_y', endrun)
-       endif
+
        call cam_mpas_update_halo('u', endrun)
        call cam_mpas_update_halo('w', endrun)
        call cam_mpas_update_halo('rho_zz', endrun)

--- a/src/dynamics/mpas/driver/cam_mpas_subdriver.F90
+++ b/src/dynamics/mpas/driver/cam_mpas_subdriver.F90
@@ -262,7 +262,8 @@ contains
        ! MPAS-A setup code that it is operating as a CAM dycore, and that it is necessary to
        ! allocate scalars separately from other Registry-defined fields
        !
-       call mpas_pool_add_config(domain_ptr % configs, 'cam_pcnst', num_scalars)
+       ! In MPAS, there must be at least one constituent, `qv`, which denotes water vapor mixing ratio.
+       call mpas_pool_add_config(domain_ptr % configs, 'cam_pcnst', max(1, num_scalars))
 
        mesh_iotype = MPAS_IO_NETCDF  ! Not actually used
        call mpas_bootstrap_framework_phase1(domain_ptr, mesh_filename, mesh_iotype, pio_file_desc=fh_ini)
@@ -482,26 +483,29 @@ contains
           return
        end if
 
-       !
-       ! If at runtime there are not num_scalars names in the array of constituent names provided by CAM,
-       ! something has gone wrong
-       !
-       if (size(cnst_name) /= num_scalars) then
-          call mpas_log_write(trim(subname)//': ERROR: The number of constituent names is not equal to the num_scalars dimension', &
-                              messageType=MPAS_LOG_ERR)
-          call mpas_log_write('size(cnst_name) = $i, num_scalars = $i', intArgs=[size(cnst_name), num_scalars], &
-                              messageType=MPAS_LOG_ERR)
-          ierr = 1
-          return
-       end if
-
-       !
-       ! In CAM, the first scalar (if there are any) is always Q (specific humidity); if this is not
-       ! the case, something has gone wrong
-       !
        if (size(cnst_name) > 0) then
+          !
+          ! If at runtime there are not num_scalars names in the array of constituent names provided by CAM,
+          ! something has gone wrong
+          !
+          if (size(cnst_name) /= num_scalars) then
+             call mpas_log_write(trim(subname) // &
+                ': ERROR: The number of constituent names is not equal to the num_scalars dimension', &
+                messageType=MPAS_LOG_ERR)
+             call mpas_log_write( &
+                'size(cnst_name) = $i, num_scalars = $i', intArgs=[size(cnst_name), num_scalars], &
+                messageType=MPAS_LOG_ERR)
+             ierr = 1
+             return
+          end if
+
+          !
+          ! In CAM, the first scalar (if there are any) is always Q (specific humidity); if this is not
+          ! the case, something has gone wrong
+          !
           if (trim(cnst_name(1)) /= 'Q') then
-             call mpas_log_write(trim(subname)//': ERROR: The first constituent is not Q', messageType=MPAS_LOG_ERR)
+             call mpas_log_write(trim(subname) // &
+                ': ERROR: The first constituent is not Q', messageType=MPAS_LOG_ERR)
              ierr = 1
              return
           end if
@@ -552,6 +556,10 @@ contains
           cam_from_mpas_cnst(mpas_from_cam_cnst(i)) = i
        end do
 
+       call mpas_pool_add_dimension(statePool, 'index_qv', 1)
+       call mpas_pool_add_dimension(statePool, 'index_qc', 0)
+       call mpas_pool_add_dimension(statePool, 'index_tke', 0)
+
        timeLevs = 2
 
        do i = 1, timeLevs
@@ -565,7 +573,6 @@ contains
              return
           end if
 
-          if (i == 1) call mpas_pool_add_dimension(statePool, 'index_qv', 1)
           scalarsField % constituentNames(1) = 'qv'
           call mpas_add_att(scalarsField % attLists(1) % attList, 'units', 'kg kg^{-1}')
           call mpas_add_att(scalarsField % attLists(1) % attList, 'long_name', 'Water vapor mixing ratio')
@@ -615,6 +622,10 @@ contains
           return
        end if
 
+       call mpas_pool_add_dimension(tendPool, 'index_qv', 1)
+       call mpas_pool_add_dimension(tendPool, 'index_qc', 0)
+       call mpas_pool_add_dimension(tendPool, 'index_tke', 0)
+
        timeLevs = 1
 
        do i = 1, timeLevs
@@ -628,7 +639,6 @@ contains
              return
           end if
 
-          if (i == 1) call mpas_pool_add_dimension(tendPool, 'index_qv', 1)
           scalarsField % constituentNames(1) = 'tend_qv'
           call mpas_add_att(scalarsField % attLists(1) % attList, 'units', 'kg m^{-3} s^{-1}')
           call mpas_add_att(scalarsField % attLists(1) % attList, 'long_name', 'Tendency of water vapor mixing ratio')

--- a/src/dynamics/mpas/dyn_comp.F90
+++ b/src/dynamics/mpas/dyn_comp.F90
@@ -578,13 +578,6 @@ subroutine dyn_init(dyn_in, dyn_out)
 
       dyn_out % defc_a(:, :) = dyn_out % deformation_coef_c2(:, :) - dyn_out % deformation_coef_s2(:, :)
       dyn_out % defc_b(:, :) = 2.0_r8 * dyn_out % deformation_coef_cs(:, :)
-
-      if (masterproc) then
-         write(iulog, '(a, 2(1x, es13.6e2))') 'DEBUG: defc_a: ', &
-            maxval(dyn_out % defc_a(:, :)), minval(dyn_out % defc_a(:, :))
-         write(iulog, '(a, 2(1x, es13.6e2))') 'DEBUG: defc_b: ', &
-            maxval(dyn_out % defc_b(:, :)), minval(dyn_out % defc_b(:, :))
-      end if
    end if
 
    !

--- a/src/dynamics/mpas/dyn_comp.F90
+++ b/src/dynamics/mpas/dyn_comp.F90
@@ -298,7 +298,6 @@ subroutine dyn_readnl(NLFileName)
    call mpas_pool_add_config(domain_ptr % configs, 'config_restart_timestamp_name', 'restart_timestamp')
    call mpas_pool_add_config(domain_ptr % configs, 'config_IAU_option', 'off')
    call mpas_pool_add_config(domain_ptr % configs, 'config_do_DAcycling', .false.)
-   call mpas_pool_add_config(domain_ptr % configs, 'config_halo_exch_method', 'mpas_halo')
 
    call cam_mpas_init_phase2(pio_subsystem, endrun, timemgr_get_calendar_cf())
 
@@ -1386,7 +1385,6 @@ subroutine cam_mpas_namelist_read(namelistFilename, configPool)
    real(r8)                :: mpas_coef_3rd_order = 0.25_r8
    real(r8)                :: mpas_smagorinsky_coef = 0.125_r8
    logical                 :: mpas_mix_full = .true.
-   real(r8)                :: mpas_epssm = 0.1_r8
    real(r8)                :: mpas_smdiv = 0.1_r8
    real(r8)                :: mpas_apvm_upwinding = 0.5_r8
    logical                 :: mpas_h_ScaleWithMesh = .true.
@@ -1397,6 +1395,10 @@ subroutine cam_mpas_namelist_read(namelistFilename, configPool)
    logical                 :: mpas_rayleigh_damp_u = .true.
    real(r8)                :: mpas_rayleigh_damp_u_timescale_days = 5.0_r8
    integer                 :: mpas_number_rayleigh_damp_u_levels = 3
+   real(r8)                :: mpas_epssm_minimum = 0.1_r8
+   real(r8)                :: mpas_epssm_maximum = 0.5_r8
+   real(r8)                :: mpas_epssm_transition_bottom_z = 30000.0_r8
+   real(r8)                :: mpas_epssm_transition_top_z = 50000.0_r8
    logical                 :: mpas_apply_lbcs = .false.
    logical                 :: mpas_jedi_da = .false.
    character (len=StrKIND) :: mpas_block_decomp_file_prefix = 'x1.40962.graph.info.part.'
@@ -1404,6 +1406,8 @@ subroutine cam_mpas_namelist_read(namelistFilename, configPool)
    logical                 :: mpas_print_global_minmax_vel = .true.
    logical                 :: mpas_print_detailed_minmax_vel = .false.
    logical                 :: mpas_print_global_minmax_sca = .false.
+   character (len=StrKIND) :: mpas_halo_exch_method = 'mpas_halo'
+   logical                 :: mpas_gpu_aware_mpi = .false.
 
    namelist /nhyd_model/ &
            mpas_time_integration, &
@@ -1435,7 +1439,6 @@ subroutine cam_mpas_namelist_read(namelistFilename, configPool)
            mpas_coef_3rd_order, &
            mpas_smagorinsky_coef, &
            mpas_mix_full, &
-           mpas_epssm, &
            mpas_smdiv, &
            mpas_apvm_upwinding, &
            mpas_h_ScaleWithMesh
@@ -1447,7 +1450,11 @@ subroutine cam_mpas_namelist_read(namelistFilename, configPool)
            mpas_cam_damping_levels, &
            mpas_rayleigh_damp_u, &
            mpas_rayleigh_damp_u_timescale_days, &
-           mpas_number_rayleigh_damp_u_levels
+           mpas_number_rayleigh_damp_u_levels, &
+           mpas_epssm_minimum, &
+           mpas_epssm_maximum, &
+           mpas_epssm_transition_bottom_z, &
+           mpas_epssm_transition_top_z
 
    namelist /limited_area/ &
            mpas_apply_lbcs
@@ -1466,12 +1473,23 @@ subroutine cam_mpas_namelist_read(namelistFilename, configPool)
            mpas_print_detailed_minmax_vel, &
            mpas_print_global_minmax_sca
 
+   namelist /development/ &
+           mpas_halo_exch_method, &
+           mpas_gpu_aware_mpi
+
    ! These configuration parameters must be set in the MPAS configPool, but can't
    ! be changed in CAM.
-   integer                :: config_num_halos = 2
-   integer                :: config_number_of_blocks = 0
-   logical                :: config_explicit_proc_decomp = .false.
-   character(len=StrKIND) :: config_proc_decomp_file_prefix = 'graph.info.part'
+   integer, parameter                :: config_num_halos = 2
+   integer, parameter                :: config_number_of_blocks = 0
+   logical, parameter                :: config_explicit_proc_decomp = .false.
+   character(len=StrKIND), parameter :: config_proc_decomp_file_prefix = 'graph.info.part'
+   real(r8), parameter               :: config_epssm = 0.0_r8
+   character(len=StrKIND), parameter :: config_les_model = 'none'
+   character(len=StrKIND), parameter :: config_les_surface = 'none'
+   real(r8), parameter               :: config_surface_heat_flux = 0.0_r8
+   real(r8), parameter               :: config_surface_moisture_flux = 0.0_r8
+   real(r8), parameter               :: config_surface_drag_coefficient = 0.0_r8
+   logical, parameter                :: config_mix_scalars = .false.
 
    character(len=*), parameter :: subname = 'dyn_comp::cam_mpas_namelist_read'
    !----------------------------------------------------------------------------
@@ -1524,7 +1542,6 @@ subroutine cam_mpas_namelist_read(namelistFilename, configPool)
    call mpi_bcast(mpas_coef_3rd_order,               1, mpi_real8,     masterprocid, mpicom, mpi_ierr)
    call mpi_bcast(mpas_smagorinsky_coef,             1, mpi_real8,     masterprocid, mpicom, mpi_ierr)
    call mpi_bcast(mpas_mix_full,                     1, mpi_logical,   masterprocid, mpicom, mpi_ierr)
-   call mpi_bcast(mpas_epssm,                        1, mpi_real8,     masterprocid, mpicom, mpi_ierr)
    call mpi_bcast(mpas_smdiv,                        1, mpi_real8,     masterprocid, mpicom, mpi_ierr)
    call mpi_bcast(mpas_apvm_upwinding,               1, mpi_real8,     masterprocid, mpicom, mpi_ierr)
    call mpi_bcast(mpas_h_ScaleWithMesh,              1, mpi_logical,   masterprocid, mpicom, mpi_ierr)
@@ -1558,7 +1575,6 @@ subroutine cam_mpas_namelist_read(namelistFilename, configPool)
    call mpas_pool_add_config(configPool, 'config_coef_3rd_order', mpas_coef_3rd_order)
    call mpas_pool_add_config(configPool, 'config_smagorinsky_coef', mpas_smagorinsky_coef)
    call mpas_pool_add_config(configPool, 'config_mix_full', mpas_mix_full)
-   call mpas_pool_add_config(configPool, 'config_epssm', mpas_epssm)
    call mpas_pool_add_config(configPool, 'config_smdiv', mpas_smdiv)
    call mpas_pool_add_config(configPool, 'config_apvm_upwinding', mpas_apvm_upwinding)
    call mpas_pool_add_config(configPool, 'config_h_ScaleWithMesh', mpas_h_ScaleWithMesh)
@@ -1584,6 +1600,10 @@ subroutine cam_mpas_namelist_read(namelistFilename, configPool)
    call mpi_bcast(mpas_rayleigh_damp_u,                1, mpi_logical, masterprocid, mpicom, mpi_ierr)
    call mpi_bcast(mpas_rayleigh_damp_u_timescale_days, 1, mpi_real8, masterprocid, mpicom, mpi_ierr)
    call mpi_bcast(mpas_number_rayleigh_damp_u_levels,  1, mpi_integer, masterprocid, mpicom, mpi_ierr)
+   call mpi_bcast(mpas_epssm_minimum,                  1, mpi_real8, masterprocid, mpicom, mpi_ierr)
+   call mpi_bcast(mpas_epssm_maximum,                  1, mpi_real8, masterprocid, mpicom, mpi_ierr)
+   call mpi_bcast(mpas_epssm_transition_bottom_z,      1, mpi_real8, masterprocid, mpicom, mpi_ierr)
+   call mpi_bcast(mpas_epssm_transition_top_z,         1, mpi_real8, masterprocid, mpicom, mpi_ierr)
 
    call mpas_pool_add_config(configPool, 'config_zd', mpas_zd)
    call mpas_pool_add_config(configPool, 'config_xnutr', mpas_xnutr)
@@ -1592,6 +1612,10 @@ subroutine cam_mpas_namelist_read(namelistFilename, configPool)
    call mpas_pool_add_config(configPool, 'config_rayleigh_damp_u', mpas_rayleigh_damp_u)
    call mpas_pool_add_config(configPool, 'config_rayleigh_damp_u_timescale_days', mpas_rayleigh_damp_u_timescale_days)
    call mpas_pool_add_config(configPool, 'config_number_rayleigh_damp_u_levels', mpas_number_rayleigh_damp_u_levels)
+   call mpas_pool_add_config(configPool, 'config_epssm_minimum', mpas_epssm_minimum)
+   call mpas_pool_add_config(configPool, 'config_epssm_maximum', mpas_epssm_maximum)
+   call mpas_pool_add_config(configPool, 'config_epssm_transition_bottom_z', mpas_epssm_transition_bottom_z)
+   call mpas_pool_add_config(configPool, 'config_epssm_transition_top_z', mpas_epssm_transition_top_z)
 
    ! Read namelist group &limited_area
    if (masterproc) then
@@ -1690,6 +1714,29 @@ subroutine cam_mpas_namelist_read(namelistFilename, configPool)
    call mpas_pool_add_config(configPool, 'config_print_detailed_minmax_vel', mpas_print_detailed_minmax_vel)
    call mpas_pool_add_config(configPool, 'config_print_global_minmax_sca', mpas_print_global_minmax_sca)
 
+   ! Read namelist group &development
+   if (masterproc) then
+      rewind(unitnumber)
+
+      call find_group_name(unitnumber, 'development', ierr)
+
+      if (ierr /= 0) then
+         call endrun(subname // ': Failed to find namelist group &development')
+      end if
+
+      read(unitnumber, development, iostat=ierr)
+
+      if (ierr /= 0) then
+         call endrun(subname // ': Failed to read namelist group &development')
+      end if
+   end if
+
+   call mpi_bcast(mpas_halo_exch_method, strkind, mpi_character, masterprocid, mpicom, mpi_ierr)
+   call mpi_bcast(mpas_gpu_aware_mpi,          1, mpi_logical, masterprocid, mpicom, mpi_ierr)
+
+   call mpas_pool_add_config(configPool, 'config_halo_exch_method', mpas_halo_exch_method)
+   call mpas_pool_add_config(configPool, 'config_gpu_aware_mpi', mpas_gpu_aware_mpi)
+
    if (masterproc) then
       close(unit=unitNumber)
    end if
@@ -1699,7 +1746,13 @@ subroutine cam_mpas_namelist_read(namelistFilename, configPool)
    call mpas_pool_add_config(configPool, 'config_number_of_blocks', config_number_of_blocks)
    call mpas_pool_add_config(configPool, 'config_explicit_proc_decomp', config_explicit_proc_decomp)
    call mpas_pool_add_config(configPool, 'config_proc_decomp_file_prefix', config_proc_decomp_file_prefix)
-
+   call mpas_pool_add_config(configPool, 'config_epssm', config_epssm)
+   call mpas_pool_add_config(configPool, 'config_les_model', config_les_model)
+   call mpas_pool_add_config(configPool, 'config_les_surface', config_les_surface)
+   call mpas_pool_add_config(configPool, 'config_surface_heat_flux', config_surface_heat_flux)
+   call mpas_pool_add_config(configPool, 'config_surface_moisture_flux', config_surface_moisture_flux)
+   call mpas_pool_add_config(configPool, 'config_surface_drag_coefficient', config_surface_drag_coefficient)
+   call mpas_pool_add_config(configPool, 'config_mix_scalars', config_mix_scalars)
 
    if (masterproc) then
       write(iulog,*) 'MPAS-A dycore configuration:'
@@ -1732,7 +1785,6 @@ subroutine cam_mpas_namelist_read(namelistFilename, configPool)
       write(iulog,*) '   mpas_coef_3rd_order = ', mpas_coef_3rd_order
       write(iulog,*) '   mpas_smagorinsky_coef = ', mpas_smagorinsky_coef
       write(iulog,*) '   mpas_mix_full = ', mpas_mix_full
-      write(iulog,*) '   mpas_epssm = ', mpas_epssm
       write(iulog,*) '   mpas_smdiv = ', mpas_smdiv
       write(iulog,*) '   mpas_apvm_upwinding = ', mpas_apvm_upwinding
       write(iulog,*) '   mpas_h_ScaleWithMesh = ', mpas_h_ScaleWithMesh
@@ -1743,6 +1795,10 @@ subroutine cam_mpas_namelist_read(namelistFilename, configPool)
       write(iulog,*) '   mpas_rayleigh_damp_u = ', mpas_rayleigh_damp_u
       write(iulog,*) '   mpas_rayleigh_damp_u_timescale_days = ', mpas_rayleigh_damp_u_timescale_days
       write(iulog,*) '   mpas_number_rayleigh_damp_u_levels = ', mpas_number_rayleigh_damp_u_levels
+      write(iulog,*) '   mpas_epssm_minimum = ', mpas_epssm_minimum
+      write(iulog,*) '   mpas_epssm_maximum = ', mpas_epssm_maximum
+      write(iulog,*) '   mpas_epssm_transition_bottom_z = ', mpas_epssm_transition_bottom_z
+      write(iulog,*) '   mpas_epssm_transition_top_z = ', mpas_epssm_transition_top_z
       write(iulog,*) '   mpas_apply_lbcs = ', mpas_apply_lbcs
       write(iulog,*) '   mpas_jedi_da = ', mpas_jedi_da
       write(iulog,*) '   mpas_block_decomp_file_prefix = ', trim(mpas_block_decomp_file_prefix)
@@ -1750,6 +1806,8 @@ subroutine cam_mpas_namelist_read(namelistFilename, configPool)
       write(iulog,*) '   mpas_print_global_minmax_vel = ', mpas_print_global_minmax_vel
       write(iulog,*) '   mpas_print_detailed_minmax_vel = ', mpas_print_detailed_minmax_vel
       write(iulog,*) '   mpas_print_global_minmax_sca = ', mpas_print_global_minmax_sca
+      write(iulog,*) '   mpas_halo_exch_method = ', trim(mpas_halo_exch_method)
+      write(iulog,*) '   mpas_gpu_aware_mpi = ', mpas_gpu_aware_mpi
    end if
 
 end subroutine cam_mpas_namelist_read

--- a/src/dynamics/mpas/dyn_comp.F90
+++ b/src/dynamics/mpas/dyn_comp.F90
@@ -197,10 +197,13 @@ type dyn_export_t
    !
    ! Invariant -- needed for computing the frontogenesis function
    !
-   real(r8), dimension(:,:),   pointer :: defc_a
-   real(r8), dimension(:,:),   pointer :: defc_b
-   real(r8), dimension(:,:),   pointer :: cell_gradient_coef_x
-   real(r8), dimension(:,:),   pointer :: cell_gradient_coef_y
+   real(r8), allocatable :: defc_a(:, :) ! Backward compatibility for CAM relying on pre-MPAS 8.4.0.
+   real(r8), allocatable :: defc_b(:, :) ! Backward compatibility for CAM relying on pre-MPAS 8.4.0.
+   real(r8), pointer :: deformation_coef_c2(:, :) ! Introduced in MPAS 8.4.0, replacing defc_{a,b}.
+   real(r8), pointer :: deformation_coef_s2(:, :) ! Introduced in MPAS 8.4.0, replacing defc_{a,b}.
+   real(r8), pointer :: deformation_coef_cs(:, :) ! Introduced in MPAS 8.4.0, replacing defc_{a,b}.
+   real(r8), pointer :: deformation_coef_c(:, :)  ! Introduced in MPAS 8.4.0, replacing cell_gradient_coef_x.
+   real(r8), pointer :: deformation_coef_s(:, :)  ! Introduced in MPAS 8.4.0, replacing cell_gradient_coef_y.
    real(r8), dimension(:,:),   pointer :: edgesOnCell_sign
    real(r8), dimension(:),     pointer :: dvEdge
    real(r8), dimension(:),     pointer :: areaCell ! cell area (m^2)
@@ -506,13 +509,21 @@ subroutine dyn_init(dyn_in, dyn_out)
 
    ! for frontogenesis calc
 
+   nullify(dyn_out % deformation_coef_c2)
+   nullify(dyn_out % deformation_coef_s2)
+   nullify(dyn_out % deformation_coef_cs)
+   nullify(dyn_out % deformation_coef_c)
+   nullify(dyn_out % deformation_coef_s)
+
    if (use_gw_front .or. use_gw_front_igw) then
       dyn_out % areaCell => dyn_in % areaCell
       dyn_out % cellsOnEdge => dyn_in % cellsOnEdge
-      call mpas_pool_get_array(mesh_pool, 'defc_a',               dyn_out % defc_a)
-      call mpas_pool_get_array(mesh_pool, 'defc_b',               dyn_out % defc_b)
-      call mpas_pool_get_array(mesh_pool, 'cell_gradient_coef_x', dyn_out % cell_gradient_coef_x)
-      call mpas_pool_get_array(mesh_pool, 'cell_gradient_coef_y', dyn_out % cell_gradient_coef_y)
+
+      call mpas_pool_get_array(mesh_pool, 'deformation_coef_c2',  dyn_out % deformation_coef_c2)
+      call mpas_pool_get_array(mesh_pool, 'deformation_coef_s2',  dyn_out % deformation_coef_s2)
+      call mpas_pool_get_array(mesh_pool, 'deformation_coef_cs',  dyn_out % deformation_coef_cs)
+      call mpas_pool_get_array(mesh_pool, 'deformation_coef_c',   dyn_out % deformation_coef_c)
+      call mpas_pool_get_array(mesh_pool, 'deformation_coef_s',   dyn_out % deformation_coef_s)
       call mpas_pool_get_array(mesh_pool, 'edgesOnCell_sign',     dyn_out % edgesOnCell_sign)
       call mpas_pool_get_array(mesh_pool, 'dvEdge',               dyn_out % dvEdge)
       call mpas_pool_get_array(mesh_pool, 'edgesOnCell',          dyn_out % edgesOnCell)
@@ -547,6 +558,34 @@ subroutine dyn_init(dyn_in, dyn_out)
    end if
 
    call cam_mpas_init_phase4(endrun)
+
+   ! Get the old deformation coefficients back for compatibility with `calc_frontogenesis` in `dp_coupling`.
+   ! Ideally, this should have been done as soon as `deformation_coef_*` become associated. However, they are not initialized
+   ! until `cam_mpas_init_phase4` completes.
+   if (associated(dyn_out % deformation_coef_c2) .and. &
+      associated(dyn_out % deformation_coef_s2) .and. &
+      associated(dyn_out % deformation_coef_cs)) then
+
+      allocate(dyn_out % defc_a, mold=dyn_out % deformation_coef_c2, stat=ierr)
+      if (ierr /= 0) then
+         call endrun(subname // ': Failed to allocate "defc_a" array')
+      end if
+
+      allocate(dyn_out % defc_b, mold=dyn_out % deformation_coef_cs, stat=ierr)
+      if (ierr /= 0) then
+         call endrun(subname // ': Failed to allocate "defc_b" array')
+      end if
+
+      dyn_out % defc_a(:, :) = dyn_out % deformation_coef_c2(:, :) - dyn_out % deformation_coef_s2(:, :)
+      dyn_out % defc_b(:, :) = 2.0_r8 * dyn_out % deformation_coef_cs(:, :)
+
+      if (masterproc) then
+         write(iulog, '(a, 2(1x, es13.6e2))') 'DEBUG: defc_a: ', &
+            maxval(dyn_out % defc_a(:, :)), minval(dyn_out % defc_a(:, :))
+         write(iulog, '(a, 2(1x, es13.6e2))') 'DEBUG: defc_b: ', &
+            maxval(dyn_out % defc_b(:, :)), minval(dyn_out % defc_b(:, :))
+      end if
+   end if
 
    !
    ! Set pointers to tendency fields that are not allocated until the call to cam_mpas_init_phase4
@@ -741,6 +780,17 @@ subroutine dyn_final(dyn_in, dyn_out)
    nullify(dyn_out % rho)
    nullify(dyn_out % ux)
    nullify(dyn_out % uy)
+   nullify(dyn_out % deformation_coef_c2)
+   nullify(dyn_out % deformation_coef_s2)
+   nullify(dyn_out % deformation_coef_cs)
+   nullify(dyn_out % deformation_coef_c)
+   nullify(dyn_out % deformation_coef_s)
+   if (allocated(dyn_out % defc_a)) then
+      deallocate(dyn_out % defc_a)
+   end if
+   if (allocated(dyn_out % defc_b)) then
+      deallocate(dyn_out % defc_b)
+   end if
    deallocate(dyn_out % pmiddry)
    deallocate(dyn_out % pintdry)
    nullify(dyn_out % vorticity)


### PR DESCRIPTION
This PR updates MPAS dynamical core from version 8.2.1 to 8.4.0. See the in-between release notes ([v8.2.2](https://github.com/MPAS-Dev/MPAS-Model/releases/tag/v8.2.2), [v8.2.3](https://github.com/MPAS-Dev/MPAS-Model/releases/tag/v8.2.3), [v8.3.0](https://github.com/MPAS-Dev/MPAS-Model/releases/tag/v8.3.0), [v8.3.1](https://github.com/MPAS-Dev/MPAS-Model/releases/tag/v8.3.1), [v8.4.0](https://github.com/MPAS-Dev/MPAS-Model/releases/tag/v8.4.0)) for details.

Closes #1479

Note that there are user-facing changes to namelist options:

* `mpas_epssm`

This namelist option has been deprecated and set to `0.0`. Setting it to any values other than `0.0` triggers a compatibility warning.

* `mpas_epssm_maximum`, `mpas_epssm_minimum`, `mpas_epssm_transition_bottom_z`, `mpas_epssm_transition_top_z`

These new namelist options provide more fine-grained control on the off-centering parameter for the vertically implicit acoustic integration.

* `mpas_halo_exch_method`, `mpas_gpu_aware_mpi`

These namelist options were previously immutable, but they are now made mutable.

Also note that since MPAS version 8.4.0, the `defc_a`, `defc_b`, `cell_gradient_coef_x`, and `cell_gradient_coef_y` deformation coefficients have been deprecated, with the former two being removed entirely. This causes a major breakage to the computation of frontogenesis function and angle, which are needed by the gravity wave physics in CAM. Therefore, a backward compatibility measure has been implemented to bring back the old coefficients.

Preliminary regression test results:

In summary, this PR is answer-changing for tests that involve MPAS dynamical core. For tests that do not involve MPAS dynamical core, they are bit-for-bit.

```
(derecho/aux_cam_intel)
ERC_D_Ln9.mpasa120_mpasa120.F2000climo.derecho_intel.cam-outfrq9s_mpasa120 (Overall: DIFF) details:
  FAIL ERC_D_Ln9.mpasa120_mpasa120.F2000climo.derecho_intel.cam-outfrq9s_mpasa120 NLCOMP
  FAIL ERC_D_Ln9.mpasa120_mpasa120.F2000climo.derecho_intel.cam-outfrq9s_mpasa120 BASELINE
ERC_D_Ln9.mpasa120_mpasa120.FHISTC_LTso.derecho_intel.cam-outfrq9s_mpasa120 (Overall: DIFF) details:
  FAIL ERC_D_Ln9.mpasa120_mpasa120.FHISTC_LTso.derecho_intel.cam-outfrq9s_mpasa120 NLCOMP
  FAIL ERC_D_Ln9.mpasa120_mpasa120.FHISTC_LTso.derecho_intel.cam-outfrq9s_mpasa120 BASELINE
ERC_D_Ln9.mpasa120_mpasa120.QPC7.derecho_intel.cam-outfrq9s_mpasa120 (Overall: DIFF) details:
  FAIL ERC_D_Ln9.mpasa120_mpasa120.QPC7.derecho_intel.cam-outfrq9s_mpasa120 NLCOMP
  FAIL ERC_D_Ln9.mpasa120_mpasa120.QPC7.derecho_intel.cam-outfrq9s_mpasa120 BASELINE

(izumi/aux_cam_gnu)
ERC_D_Ln9.mpasa480_mpasa480_mt232.FHISTC_LTso.izumi_gnu.cam-outfrq9s_mpasa480 (Overall: DIFF) details:
  FAIL ERC_D_Ln9.mpasa480_mpasa480_mt232.FHISTC_LTso.izumi_gnu.cam-outfrq9s_mpasa480 NLCOMP
  FAIL ERC_D_Ln9.mpasa480_mpasa480_mt232.FHISTC_LTso.izumi_gnu.cam-outfrq9s_mpasa480 BASELINE
ERS_Ln9_P24x1.mpasa480_mpasa480.F2000climo.izumi_gnu.cam-outfrq9s_mpasa480 (Overall: DIFF) details:
  FAIL ERS_Ln9_P24x1.mpasa480_mpasa480.F2000climo.izumi_gnu.cam-outfrq9s_mpasa480 NLCOMP
  FAIL ERS_Ln9_P24x1.mpasa480_mpasa480.F2000climo.izumi_gnu.cam-outfrq9s_mpasa480 BASELINE

(izumi/aux_cam_nag)
ERC_D_Ln9.mpasa480_mpasa480_mt232.FHS94.izumi_nag.cam-outfrq9s (Overall: DIFF) details:
  FAIL ERC_D_Ln9.mpasa480_mpasa480_mt232.FHS94.izumi_nag.cam-outfrq9s NLCOMP
  FAIL ERC_D_Ln9.mpasa480_mpasa480_mt232.FHS94.izumi_nag.cam-outfrq9s BASELINE
ERC_D_Ln9.mpasa480_mpasa480_mt232.QPC7.izumi_nag.cam-outfrq9s_mpasa480 (Overall: DIFF) details:
  FAIL ERC_D_Ln9.mpasa480_mpasa480_mt232.QPC7.izumi_nag.cam-outfrq9s_mpasa480 NLCOMP
  FAIL ERC_D_Ln9.mpasa480_mpasa480_mt232.QPC7.izumi_nag.cam-outfrq9s_mpasa480 BASELINE
```