### PR TITLE
cam6_4_178: Update atmos_phys to atmos_phys0_22_001

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -29,7 +29,7 @@
 [submodule "atmos_phys"]
 	path = src/atmos_phys
 	url = https://github.com/ESCOMP/atmospheric_physics
-	fxtag = atmos_phys0_22_000
+	fxtag = atmos_phys0_22_001
         fxrequired = AlwaysRequired
         fxDONOTUSEurl = https://github.com/ESCOMP/atmospheric_physics
 

--- a/doc/ChangeLog
+++ b/doc/ChangeLog
@@ -1,5 +1,53 @@
 ===============================================================
 
+Tag name: cam6_4_178
+Originator(s): jimmielin
+Date: June 1, 2026
+One-line Summary: Update atmos_phys to atmos_phys0_22_001
+Github PR URL: https://github.com/ESCOMP/CAM/pull/1564
+
+Purpose of changes (include the issue number and title text for each relevant GitHub issue):
+- Closes #1566 - update atmos_phys0_22_001
+
+Describe any changes made to build system: N/A
+
+Describe any changes made to the namelist: N/A
+
+List any changes to the defaults for the boundary datasets: N/A
+
+Describe any substantial timing or memory changes: N/A
+
+Code reviewed by: cacraig
+
+List all files eliminated: N/A
+
+List all files added and what they do: N/A
+
+List all existing files that have been modified, and describe the changes:
+M       .gitmodules
+M       src/atmos_phys
+  - submodule update to atmos_phys0_22_001 (HB PBL refactor; ZM energy checker for SIMA)
+
+If there were any failures reported from running test_driver.sh on any test
+platform, and checkin with these failures has been OK'd by the gatekeeper,
+then copy the lines from the td.*.status files for the failed tests to the
+appropriate machine below.  All failed tests must be justified.
+
+derecho/intel/aux_cam: All PASS
+
+derecho/nvhpc/aux_cam: All PASS
+
+izumi/nag/aux_cam:
+  ERC_D_Ln9.f10_f10_mt232.FHIST_C5.izumi_nag.cam-outfrq3s_subcol (Overall: FAIL) details:
+    FAIL ERC_D_Ln9.f10_f10_mt232.FHIST_C5.izumi_nag.cam-outfrq3s_subcol COMPARE_base_rest
+  - pre-existing failure -- see https://github.com/ESCOMP/CAM/issues/1514
+
+izumi/gnu/aux_cam: All PASS
+
+Summarize any changes to answers: All B4B
+
+===============================================================
+
 Tag name: cam6_4_177
 Originator(s): fvitt
 Date: 29 May 2026


### PR DESCRIPTION
Closes #1566 
B4B update to bring in refactored HB PBL (from @mwaxmonsky) and ZM energy checker. It should be a bit-for-bit update for CAM. 

This tag is being made out of caution as we are retiring the `development` branch in atmospheric_physics, although it has never been used in CAM.