### PR TITLE
cam6_4_179: Fix ZM downdraft term and atmos_phys update; moving mountain GW when deep convection is off

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -29,7 +29,7 @@
 [submodule "atmos_phys"]
 	path = src/atmos_phys
 	url = https://github.com/ESCOMP/atmospheric_physics
-	fxtag = atmos_phys0_22_002
+	fxtag = atmos_phys0_22_003
         fxrequired = AlwaysRequired
         fxDONOTUSEurl = https://github.com/ESCOMP/atmospheric_physics
 

--- a/.gitmodules
+++ b/.gitmodules
@@ -29,7 +29,7 @@
 [submodule "atmos_phys"]
 	path = src/atmos_phys
 	url = https://github.com/ESCOMP/atmospheric_physics
-	fxtag = atmos_phys0_22_001
+	fxtag = atmos_phys0_22_002
         fxrequired = AlwaysRequired
         fxDONOTUSEurl = https://github.com/ESCOMP/atmospheric_physics
 

--- a/doc/ChangeLog
+++ b/doc/ChangeLog
@@ -1,5 +1,57 @@
 ===============================================================
 
+Tag name: cam6_4_179
+Originator(s): jimmielin
+Date: June 2, 2026
+One-line Summary: Fix ZM downdraft term and atmos_phys update; moving mountain GW when deep convection is off
+Github PR URL: https://github.com/ESCOMP/CAM/pull/1568
+
+Purpose of changes (include the issue number and title text for each relevant GitHub issue):
+- Closes #1565
+- Closes ESCOMP/atmospheric_physics#404
+
+Describe any changes made to build system: N/A
+
+Describe any changes made to the namelist: N/A
+
+List any changes to the defaults for the boundary datasets: N/A
+
+Describe any substantial timing or memory changes: N/A
+
+Code reviewed by: cacraig (atmos_phys and CAM), nusbaume (atmos_phys), peverwhee (atmos_phys)
+
+List all files eliminated: N/A
+
+List all files added and what they do: N/A
+
+List all existing files that have been modified, and describe the changes:
+M       .gitmodules
+M       src/atmos_phys
+  - update to atmos_phys0_22_003: ZM downdraft term and other misc. fixes
+
+M       src/physics/cam/gw_drag_cam.F90
+  - allow using moving mountain gravity wave parameterization when deep convection is off.
+
+If there were any failures reported from running test_driver.sh on any test
+platform, and checkin with these failures has been OK'd by the gatekeeper,
+then copy the lines from the td.*.status files for the failed tests to the
+appropriate machine below.  All failed tests must be justified.
+
+derecho/intel/aux_cam: All PASS
+
+derecho/nvhpc/aux_cam:
+
+izumi/nag/aux_cam:
+  ERC_D_Ln9.f10_f10_mt232.FHIST_C5.izumi_nag.cam-outfrq3s_subcol (Overall: FAIL) details:
+    FAIL ERC_D_Ln9.f10_f10_mt232.FHIST_C5.izumi_nag.cam-outfrq3s_subcol COMPARE_base_rest
+  - pre-existing failure -- see https://github.com/ESCOMP/CAM/issues/1514
+
+izumi/gnu/aux_cam: All PASS
+
+Summarize any changes to answers: All B4B
+
+===============================================================
+
 Tag name: cam6_4_178
 Originator(s): jimmielin
 Date: June 1, 2026

--- a/doc/ChangeLog
+++ b/doc/ChangeLog
@@ -7,8 +7,8 @@ One-line Summary: Fix ZM downdraft term and atmos_phys update; moving mountain G
 Github PR URL: https://github.com/ESCOMP/CAM/pull/1568
 
 Purpose of changes (include the issue number and title text for each relevant GitHub issue):
-- Closes #1565
-- Closes ESCOMP/atmospheric_physics#404
+- Closes #1565 - moving mountain gravity wave scheme fails when ZM scheme is off
+- Closes ESCOMP/atmospheric_physics#404 - Potentially incorrect downdraft constituent flux calculation in ZM
 
 Describe any changes made to build system: N/A
 
@@ -39,7 +39,7 @@ appropriate machine below.  All failed tests must be justified.
 
 derecho/intel/aux_cam: All PASS
 
-derecho/nvhpc/aux_cam:
+derecho/nvhpc/aux_cam: All PASS
 
 izumi/nag/aux_cam:
   ERC_D_Ln9.f10_f10_mt232.FHIST_C5.izumi_nag.cam-outfrq3s_subcol (Overall: FAIL) details:

--- a/src/physics/cam/gw_drag_cam.F90
+++ b/src/physics/cam/gw_drag_cam.F90
@@ -552,15 +552,16 @@ subroutine gw_drag_cam_init()
      vpwp_clubb_gw_idx   = pbuf_get_index('VPWP_CLUBB_GW')
      wpthlp_clubb_gw_idx = pbuf_get_index('WPTHLP_CLUBB_GW')
      vort4gw_idx         = pbuf_get_index('VORT4GW')
-
-     ttend_dp_idx        = pbuf_get_index('TTEND_DP')
   endif
 
   if (use_gw_oro .or. use_gw_rdg_beta .or. use_gw_rdg_gamma) then
      sgh_idx = pbuf_get_index('SGH')
   endif
 
-  if (use_gw_convect_dp) ttend_dp_idx    = pbuf_get_index('TTEND_DP')
+  if (use_gw_convect_dp .or. use_gw_movmtn_pbl) then
+     ttend_dp_idx = pbuf_get_index('TTEND_DP',errflg)
+  end if
+
   if (use_gw_convect_sh) ttend_sh_idx    = pbuf_get_index('TTEND_SH')
 
   ! Output initialization status
@@ -1405,8 +1406,10 @@ subroutine gw_drag_cam_tend(state, pbuf, dt, ptend, cam_in, flx_heat)
   ttend_dp_arr(:,:) = 0._r8
   if(use_gw_movmtn_pbl .or. use_gw_convect_dp) then
     ! Set up heating
-    call pbuf_get_field(pbuf, ttend_dp_idx, ttend_dp)
-    ttend_dp_arr(:ncol, :pver) = ttend_dp(:ncol, :pver)
+    if (ttend_dp_idx > 0) then
+      call pbuf_get_field(pbuf, ttend_dp_idx, ttend_dp)
+      ttend_dp_arr(:ncol, :pver) = ttend_dp(:ncol, :pver)
+    end if
   endif
 
   if (use_gw_movmtn_pbl) then
@@ -1572,7 +1575,7 @@ subroutine gw_drag_cam_tend(state, pbuf, dt, ptend, cam_in, flx_heat)
     call outfld('VTGW_MOVMTN', vtgw, pcols, lchnk)
     call outfld('UTGW_MOVMTN', utgw, pcols, lchnk)
     call outfld('HDEPTH_MOVMTN', hdepth/1000._r8, pcols, lchnk)
-    call outfld('NETDT_MOVMTN', ttend_dp, pcols, lchnk)
+    call outfld('NETDT_MOVMTN', ttend_dp_arr, pcols, lchnk)
     call outfld('TTEND_CLUBB', ttend_clubb, pcols, lchnk)
     call outfld('THLP2_CLUBB_GW', thlp2_clubb_gw, pcols, lchnk)
     call outfld('WPTHLP_CLUBB_GW', wpthlp_clubb_gw, pcols, lchnk)


### PR DESCRIPTION
Closes https://github.com/ESCOMP/CAM/issues/1565
Closes https://github.com/ESCOMP/atmospheric_physics/issues/404