### PR TITLE
Add COSP's EarthCARE lidar simulator to CAM output

### DIFF
--- a/bld/namelist_files/namelist_definition.xml
+++ b/bld/namelist_files/namelist_definition.xml
@@ -2425,7 +2425,14 @@ Default: FALSE
 
 <entry id="cosp_llidar_sim" type="logical"  category="cosp"
        group="cospsimulator_nl" valid_values="">
-If true, COSP lidar simulator will be run and all non-subcolumn output
+If true, COSP CALIPSO/CALIOP lidar simulator will be run and all non-subcolumn output
+will be saved
+Default: FALSE
+</entry>
+
+<entry id="cosp_latlid_sim" type="logical"  category="cosp"
+       group="cospsimulator_nl" valid_values="">
+If true, COSP EarthCARE/ATmospheric LIDar (ATLID) simulator will be run and all non-subcolumn output
 will be saved
 Default: FALSE
 </entry>

--- a/src/physics/cam/cospsimulator_intr.F90
+++ b/src/physics/cam/cospsimulator_intr.F90
@@ -921,6 +921,7 @@ CONTAINS
        call add_default('CLDHGH_ATLID',cosp_histfile_num,' ')
        call add_default('CLDTOT_ATLID',cosp_histfile_num,' ')
        call add_default('CLD_ATLID',cosp_histfile_num,' ')
+       call add_default('BETAMOL_ATLID',cosp_histfile_num,' ')
        call add_default('CFAD_SR355_ATLID',cosp_histfile_num,' ')
     end if
 
@@ -1119,7 +1120,7 @@ CONTAINS
        end if
 
        if (latlid_sim) then
-          call add_default('BETAMOL_ATLID',cosp_histfile_num,' ')
+          call add_default('BETATOT_ATLID',cosp_histfile_num,' ')
        end if
     end if
 
@@ -2451,7 +2452,7 @@ CONTAINS
     cospIN%cospswathsIN = cospswathsIN
     call t_stopf('construct_cospIN')
 
-    if (lradar_sim .or. (llidar_sim .or. (lisccp_sim .or. (lmisr_sim .or. lmodis_sim)))) then
+    if (lradar_sim .or. (llidar_sim .or. (lisccp_sim .or. (lmisr_sim .or. (lmodis_sim .or. latlid_sim))))) then
        call t_startf("subsample_and_optics")
        ! The arrays passed here contain only active columns and the limited vertical
        ! domain operated on by COSP.  Unsubscripted array arguments have already been

--- a/src/physics/cam/cospsimulator_intr.F90
+++ b/src/physics/cam/cospsimulator_intr.F90
@@ -642,7 +642,7 @@ CONTAINS
             bounds_name='cosp_tau_bnds', bounds=taulim_cosp)
     end if
 
-    if (lisccp_sim .or. llidar_sim .or. lradar_sim .or. lmisr_sim) then
+    if (lisccp_sim .or. llidar_sim .or. lradar_sim .or. lmisr_sim .or. latlid_sim) then
        call add_hist_coord('cosp_scol', nscol_cosp, 'COSP subcolumn',          &
             values=scol_cosp)
     end if
@@ -922,7 +922,6 @@ CONTAINS
        call add_default('CLDTOT_ATLID',cosp_histfile_num,' ')
        call add_default('CLD_ATLID',cosp_histfile_num,' ')
        call add_default('CFAD_SR355_ATLID',cosp_histfile_num,' ')
-       call add_default('BETAMOL_ATLID',cosp_histfile_num,' ')
     end if
 
     ! RADAR SIMULATOR OUTPUTS
@@ -1117,6 +1116,10 @@ CONTAINS
 
        if (lradar_sim) then
           call add_default('DBZE_CS',cosp_histfile_num,' ')
+       end if
+
+       if (latlid_sim) then
+          call add_default('BETAMOL_ATLID',cosp_histfile_num,' ')
        end if
     end if
 
@@ -3114,7 +3117,6 @@ CONTAINS
        end if
        call outfld('CLD_ATLID',        cld_atlid,       pcols,lchnk)
        call outfld('BETAMOL_ATLID',    betamol_atlid,   pcols,lchnk)
-       call outfld('BETATOT_ATLID',    betatot_atlid,   pcols,lchnk)
        
        if (cospIN%cospswathsIN(4)%N_inst_swaths < 1) then
           where (cfad_sr355_atlid(:ncol,:nht_cosp*nsr_cosp) == R_UNDEF)
@@ -3301,6 +3303,8 @@ CONTAINS
        if (lradar_sim) then
           call outfld('DBZE_CS',dbze_cs,pcols,lchnk) !! fails check_accum if 'A'
        end if
+       if (latlid_sim) then
+          call outfld('BETATOT_ATLID',betatot_atlid,pcols,lchnk)
     end if
     call t_stopf("writing_output")
 #endif

--- a/src/physics/cam/cospsimulator_intr.F90
+++ b/src/physics/cam/cospsimulator_intr.F90
@@ -161,7 +161,7 @@ module cospsimulator_intr
   logical :: llidar_sim       = .false.
   logical :: lparasol_sim     = .false.
   logical :: lgrLidar532      = .false.
-  logical :: latlid           = .false.
+  logical :: latlid_sim       = .false.
   logical :: lisccp_sim       = .false.
   logical :: lmisr_sim        = .false.
   logical :: lmodis_sim       = .false.
@@ -451,7 +451,7 @@ CONTAINS
        lparasol_sim = .true.
     end if
     if (cosp_latlid_sim) then
-       latlid = .true.
+       latlid_sim = .true.
     end if
     if (cosp_lisccp_sim) then
        lisccp_sim = .true.
@@ -528,7 +528,7 @@ CONTAINS
     end if
 
     !! if no simulators are turned on at all and docosp is, set cosp_amwg = .true.
-    if((docosp) .and. (.not.lradar_sim) .and. (.not.llidar_sim) .and. (.not.lisccp_sim) .and. &
+    if((docosp) .and. (.not.lradar_sim) .and. (.not.latlid_sim) .and. (.not.llidar_sim) .and. (.not.lisccp_sim) .and. &
          (.not.lmisr_sim) .and. (.not.lmodis_sim) .and. (.not.lrttov_sim)) then
        cosp_amwg = .true.
     end if
@@ -558,7 +558,7 @@ CONTAINS
           write(iulog,*)'  COSP frequency in radiation steps        = ', cosp_nradsteps
           write(iulog,*)'  Enable radar simulator                   = ', lradar_sim
           write(iulog,*)'  Enable calipso simulator                 = ', llidar_sim
-          write(iulog,*)'  Enable atlid simulator                   = ', latlid
+          write(iulog,*)'  Enable atlid simulator                   = ', latlid_sim
           write(iulog,*)'  Enable ISCCP simulator                   = ', lisccp_sim
           write(iulog,*)'  Enable MISR simulator                    = ', lmisr_sim
           write(iulog,*)'  Enable MODIS simulator                   = ', lmodis_sim
@@ -647,7 +647,7 @@ CONTAINS
             values=scol_cosp)
     end if
 
-    if (llidar_sim .or. lradar_sim .or. latlid) then
+    if (llidar_sim .or. lradar_sim .or. latlid_sim) then
        call add_hist_coord('cosp_ht', nht_cosp,                                &
             'COSP Mean Height for calipso, atlid and radar simulator outputs', 'm',   &
             htmid_cosp, bounds_name='cosp_ht_bnds', bounds=htlim_cosp,         &
@@ -660,7 +660,7 @@ CONTAINS
             srmid_cosp, bounds_name='cosp_sr_bnds', bounds=srlim_cosp)
     end if
 
-    if (latlid) then
+    if (latlid_sim) then
        call add_hist_coord('cosp_355sr', nsr_cosp,                             &
             'COSP Mean Scattering Ratio for ATLID simulator CFAD output', '1', &
             srmid_cosp, bounds_name='cosp_355sr_bnds', bounds=srlim_cosp)
@@ -898,7 +898,7 @@ CONTAINS
     end if
 
     ! ATLID (355nm) SIMULATOR OUTPUTS
-    if (latlid) then
+    if (latlid_sim) then
        call addfld('CLDLOW_ATLID', horiz_only, 'A', 'percent', &
             'ATLID Low-level Cloud Fraction (355 nm)', flag_xyfill=.true., fill_value=R_UNDEF)
        call addfld('CLDMED_ATLID', horiz_only, 'A', 'percent', &
@@ -1372,7 +1372,7 @@ CONTAINS
     unitn = getunit()
 
     call COSP_INIT(Lisccp_sim, Lmodis_sim, Lmisr_sim, Lradar_sim, Llidar_sim, LgrLidar532,  &
-         Latlid, Lparasol_sim, Lrttov_sim, radar_freq, k2, use_gas_abs, do_ray,             &
+         Latlid_sim, Lparasol_sim, Lrttov_sim, radar_freq, k2, use_gas_abs, do_ray,             &
          isccp_topheight, isccp_topheight_direction, surface_radar, rcfg_cloudsat,          &
          use_vgrid, csat_vgrid, Nlr, nlay, cloudsat_micro_scheme,                           &
          rttov_Ninstruments, rttov_instrument_namelists_final, rttov_configs,unitn=unitn)
@@ -2717,7 +2717,7 @@ CONTAINS
     endif
 
     ! ATLID (355nm) SIMULATOR OUTPUTS
-    if (latlid) then
+    if (latlid_sim) then
        if (associated(cospOUT%atlid_beta_mol)) then
           betamol_atlid(1:ncol,1:nlay) = cospOUT%atlid_beta_mol
        endif
@@ -2860,7 +2860,7 @@ CONTAINS
           end do
        endif
 
-       if (latlid) then
+       if (latlid_sim) then
           do ih=1,nht_cosp
              do is=1,nsr_cosp
                 ihs=(ih-1)*nsr_cosp+is
@@ -3106,7 +3106,7 @@ CONTAINS
     end if
 
     ! ATLID (355nm) SIMULATOR OUTPUTS
-    if (latlid) then
+    if (latlid_sim) then
        if (cospIN%cospswathsIN(4)%N_inst_swaths < 1) then
           where (cld_atlid(:ncol,:nht_cosp) == R_UNDEF)
              cld_atlid(:ncol,:nht_cosp) = 0.0_r8
@@ -3685,7 +3685,7 @@ CONTAINS
     ! ATLID (355nm) Optics
     !%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
     call t_startf("atlid_optics")
-    if (Latlid) then
+    if (Latlid_sim) then
        ReffTemp = ReffIN
        call lidar_optics(nPoints,nColumns,nLevels,5,lidar_ice_type,355,                    &
                          mr_hydro(1:nPoints,1:nColumns,1:nLevels,I_LSCLIQ),              &
@@ -3704,13 +3704,8 @@ CONTAINS
                          cospIN%beta_mol_atlid(1:nPoints,1:nLevels),                     &
                          cospIN%betatot_atlid(1:nPoints,1:nColumns,1:nLevels),           &
                          cospIN%tau_mol_atlid(1:nPoints,1:nLevels),                      &
-                         cospIN%tautot_atlid(1:nPoints,1:nColumns,1:nLevels),            &
-                         cospIN%tautot_S_liq_atlid(1:nPoints,1:nColumns),                &
-                         cospIN%tautot_S_ice_atlid(1:nPoints,1:nColumns),                &
-                         cospIN%betatot_ice_atlid(1:nPoints,1:nColumns,1:nLevels),       &
-                         cospIN%betatot_liq_atlid(1:nPoints,1:nColumns,1:nLevels),       &
-                         cospIN%tautot_ice_atlid(1:nPoints,1:nColumns,1:nLevels),        &
-                         cospIN%tautot_liq_atlid(1:nPoints,1:nColumns,1:nLevels))
+                         cospIN%tautot_atlid(1:nPoints,1:nColumns,1:nLevels))
+
     endif
     call t_stopf("atlid_optics")
 
@@ -3842,29 +3837,53 @@ CONTAINS
     y%Ninst_rttov = Ninst_rttov
     y%Npart       = 4
     y%Nrefl       = PARASOL_NREFL
+    allocate(y%frac_out(npoints,ncolumns,nlevels))
 
     if (present(emis_grey)) y%emis_grey => emis_grey
 
-    allocate(y%tau_067(            npoints, ncolumns, nlevels),&
-             y%emiss_11(           npoints, ncolumns, nlevels),&
-             y%frac_out(           npoints, ncolumns, nlevels),&
-             y%betatot_calipso(    npoints, ncolumns, nlevels),&
-             y%betatot_ice_calipso(npoints, ncolumns, nlevels),&
-             y%fracLiq(            npoints, ncolumns, nlevels),&
-             y%betatot_liq_calipso(npoints, ncolumns, nlevels),&
-             y%tautot_calipso(     npoints, ncolumns, nlevels),&
-             y%tautot_ice_calipso( npoints, ncolumns, nlevels),&
-             y%tautot_liq_calipso( npoints, ncolumns, nlevels),&
-             y%z_vol_cloudsat(     npoints, ncolumns, nlevels),&
-             y%kr_vol_cloudsat(    npoints, ncolumns, nlevels),&
-             y%g_vol_cloudsat(     npoints, ncolumns, nlevels),&
-             y%asym(               npoints, ncolumns, nlevels),&
-             y%ss_alb(             npoints, ncolumns, nlevels),&
-             y%beta_mol_calipso(   npoints,           nlevels),&
-             y%tau_mol_calipso(    npoints,           nlevels),&
-             y%tautot_S_ice(       npoints, ncolumns         ),&
-             y%tautot_S_liq(       npoints, ncolumns)         ,&
-             y%fracPrecipIce(npoints,   ncolumns), stat=istat)
+    if (Lisccp_sim .or. Lmisr_sim .or. Lmodis_sim) then
+       allocate(y%tau_067(npoints,        ncolumns,nlevels),&
+                y%emiss_11(npoints,       ncolumns,nlevels), stat=istat)
+    endif
+    if (Llidar_sim) then
+       allocate(y%betatot_calipso(npoints,        ncolumns,nlevels),&
+                y%betatot_ice_calipso(npoints,    ncolumns,nlevels),&
+                y%betatot_liq_calipso(npoints,    ncolumns,nlevels),&
+                y%tautot_calipso(npoints,         ncolumns,nlevels),&
+                y%tautot_ice_calipso(npoints,     ncolumns,nlevels),&
+                y%tautot_liq_calipso(npoints,     ncolumns,nlevels),&
+                y%beta_mol_calipso(npoints,                nlevels),&
+                y%tau_mol_calipso(npoints,                 nlevels),&
+                y%tautot_S_ice(npoints,   ncolumns        ),&
+                y%tautot_S_liq(npoints,   ncolumns        ), stat=istat)
+    endif
+
+    if (LgrLidar532) then
+       allocate(y%beta_mol_grLidar532(npoints,          nlevels),& 
+                y%betatot_grLidar532(npoints,  ncolumns,nlevels),& 
+                y%tau_mol_grLidar532(npoints,           nlevels),& 
+                y%tautot_grLidar532(npoints,   ncolumns,nlevels), stat=istat) 
+    endif
+
+    if (Latlid_sim) then
+       allocate(y%beta_mol_atlid(npoints,             nlevels),& 
+                y%betatot_atlid(npoints,     ncolumns,nlevels),& 
+                y%tau_mol_atlid(npoints,              nlevels),& 
+                y%tautot_atlid(npoints,      ncolumns,nlevels), stat=istat)
+    endif 
+
+    if (Lradar_sim) then
+       allocate(y%z_vol_cloudsat(npoints,  ncolumns,nlevels),&
+                y%kr_vol_cloudsat(npoints, ncolumns,nlevels),&
+                y%g_vol_cloudsat(npoints,  ncolumns,nlevels),&
+                y%fracPrecipIce(npoints,   ncolumns), stat=istat)
+    endif
+    if (Lmodis_sim) then
+       allocate(y%fracLiq(npoints,        ncolumns,nlevels),&
+                y%asym(npoints,           ncolumns,nlevels),&
+                y%ss_alb(npoints,         ncolumns,nlevels), stat=istat)
+    endif
+
     call handle_allocate_error(istat, sub, 'tau_067,..,fracPrecipIce')
 
     ! Initialize pointers
@@ -4064,6 +4083,16 @@ CONTAINS
              stat=istat)
        endif
        call handle_allocate_error(istat, sub, 'cloudsat_precip_*')
+    endif
+
+    ! ATLID
+    if (latlid_sim) then
+       allocate( &
+          x%atlid_beta_mol(Npoints,Nlevels),             &
+          x%atlid_beta_tot(Npoints,Ncolumns,Nlevels),    &
+          x%atlid_cfad_sr(Npoints,SR_BINS,Nlvgrid),      &
+          x%atlid_lidarcld(Npoints,Nlvgrid),             &
+          x%atlid_cldlayer(Npoints,LIDAR_NCAT))
     endif
 
     ! RTTOV - Allocate output for multiple instruments

--- a/src/physics/cam/cospsimulator_intr.F90
+++ b/src/physics/cam/cospsimulator_intr.F90
@@ -147,6 +147,7 @@ module cospsimulator_intr
   logical :: cosp_lisccp_sim       = .false.
   logical :: cosp_lmisr_sim        = .false.
   logical :: cosp_lmodis_sim       = .false.
+  logical :: cosp_latlid_sim       = .false.
   logical :: cosp_lrttov_sim       = .false.
   logical :: cosp_histfile_aux     = .false.
   logical :: cosp_lfrac_out        = .false.
@@ -344,16 +345,16 @@ CONTAINS
 #ifdef USE_COSP
 !!! this list should include any variable that you might want to include in the namelist
 !!! philosophy is to not include COSP output flags but just important COSP settings and cfmip controls.
-    namelist /cospsimulator_nl/ docosp, cosp_active, cosp_amwg, &
-         cosp_histfile_num, cosp_histfile_aux, cosp_histfile_aux_num, cosp_isccp, cosp_lfrac_out, &
-         cosp_lite, cosp_lradar_sim, cosp_llidar_sim, cosp_lisccp_sim,  cosp_lmisr_sim, cosp_lmodis_sim, cosp_lrttov_sim, &
-         cosp_ncolumns, cosp_nradsteps, cosp_passive, cosp_runall,                         &
-         cosp_rttov_Ninstruments, cosp_rttov_instrument_namelists,                         &
-         COSP_N_SWATHS_ISCCP, COSP_SWATH_LOCALTIMES_ISCCP, COSP_SWATH_WIDTHS_ISCCP, COSP_N_SWATHS_MISR,        &
-         COSP_SWATH_LOCALTIMES_MISR, COSP_SWATH_WIDTHS_MISR, COSP_N_SWATHS_MODIS, COSP_SWATH_LOCALTIMES_MODIS, &
-         COSP_SWATH_WIDTHS_MODIS, COSP_N_SWATHS_PARASOL, COSP_SWATH_LOCALTIMES_PARASOL,                   &
-         COSP_SWATH_WIDTHS_PARASOL, COSP_N_SWATHS_CSCAL, COSP_SWATH_LOCALTIMES_CSCAL,                     &
-         COSP_SWATH_WIDTHS_CSCAL, COSP_N_SWATHS_ATLID, COSP_SWATH_LOCALTIMES_ATLID, COSP_SWATH_WIDTHS_ATLID
+     namelist /cospsimulator_nl/ docosp, cosp_active, cosp_amwg, &
+          cosp_histfile_num, cosp_histfile_aux, cosp_histfile_aux_num, cosp_isccp, cosp_lfrac_out, &
+          cosp_lite, cosp_lradar_sim, cosp_llidar_sim, cosp_latlid_sim, cosp_lisccp_sim,  cosp_lmisr_sim, cosp_lmodis_sim, cosp_lrttov_sim, &
+          cosp_ncolumns, cosp_nradsteps, cosp_passive, cosp_runall,                         &
+          cosp_rttov_Ninstruments, cosp_rttov_instrument_namelists,                         &
+          COSP_N_SWATHS_ISCCP, COSP_SWATH_LOCALTIMES_ISCCP, COSP_SWATH_WIDTHS_ISCCP, COSP_N_SWATHS_MISR,        &
+          COSP_SWATH_LOCALTIMES_MISR, COSP_SWATH_WIDTHS_MISR, COSP_N_SWATHS_MODIS, COSP_SWATH_LOCALTIMES_MODIS, &
+          COSP_SWATH_WIDTHS_MODIS, COSP_N_SWATHS_PARASOL, COSP_SWATH_LOCALTIMES_PARASOL,                   &
+          COSP_SWATH_WIDTHS_PARASOL, COSP_N_SWATHS_CSCAL, COSP_SWATH_LOCALTIMES_CSCAL,                     &
+          COSP_SWATH_WIDTHS_CSCAL, COSP_N_SWATHS_ATLID, COSP_SWATH_LOCALTIMES_ATLID, COSP_SWATH_WIDTHS_ATLID
 
     !! read in the namelist
     if (masterproc) then
@@ -421,6 +422,7 @@ CONTAINS
     call mpibcast(cosp_lfrac_out,       1,  mpilog, 0, mpicom)
     call mpibcast(cosp_lradar_sim,      1,  mpilog, 0, mpicom)
     call mpibcast(cosp_llidar_sim,      1,  mpilog, 0, mpicom)
+    call mpibcast(cosp_latlid_sim,      1,  mpilog, 0, mpicom)
     call mpibcast(cosp_lisccp_sim,      1,  mpilog, 0, mpicom)
     call mpibcast(cosp_lmisr_sim,       1,  mpilog, 0, mpicom)
     call mpibcast(cosp_lmodis_sim,      1,  mpilog, 0, mpicom)
@@ -447,6 +449,9 @@ CONTAINS
     if (cosp_llidar_sim) then
        llidar_sim = .true.
        lparasol_sim = .true.
+    end if
+    if (cosp_latlid_sim) then
+       latlid = .true.
     end if
     if (cosp_lisccp_sim) then
        lisccp_sim = .true.
@@ -553,6 +558,7 @@ CONTAINS
           write(iulog,*)'  COSP frequency in radiation steps        = ', cosp_nradsteps
           write(iulog,*)'  Enable radar simulator                   = ', lradar_sim
           write(iulog,*)'  Enable calipso simulator                 = ', llidar_sim
+          write(iulog,*)'  Enable atlid simulator                   = ', latlid
           write(iulog,*)'  Enable ISCCP simulator                   = ', lisccp_sim
           write(iulog,*)'  Enable MISR simulator                    = ', lmisr_sim
           write(iulog,*)'  Enable MODIS simulator                   = ', lmodis_sim
@@ -641,9 +647,9 @@ CONTAINS
             values=scol_cosp)
     end if
 
-    if (llidar_sim .or. lradar_sim) then
+    if (llidar_sim .or. lradar_sim .or. latlid) then
        call add_hist_coord('cosp_ht', nht_cosp,                                &
-            'COSP Mean Height for calipso and radar simulator outputs', 'm',   &
+            'COSP Mean Height for calipso, atlid and radar simulator outputs', 'm',   &
             htmid_cosp, bounds_name='cosp_ht_bnds', bounds=htlim_cosp,         &
             vertical_coord=.true.)
     end if
@@ -652,6 +658,12 @@ CONTAINS
        call add_hist_coord('cosp_sr', nsr_cosp,                                &
             'COSP Mean Scattering Ratio for calipso simulator CFAD output', '1', &
             srmid_cosp, bounds_name='cosp_sr_bnds', bounds=srlim_cosp)
+    end if
+
+    if (latlid) then
+       call add_hist_coord('cosp_355sr', nsr_cosp,                             &
+            'COSP Mean Scattering Ratio for ATLID simulator CFAD output', '1', &
+            srmid_cosp, bounds_name='cosp_355sr_bnds', bounds=srlim_cosp)
     end if
 
     if (llidar_sim) then
@@ -883,6 +895,34 @@ CONTAINS
             .and. (.not.cosp_isccp)) then
           call add_default('MOL532_CAL',cosp_histfile_num,' ')
        end if
+    end if
+
+    ! ATLID (355nm) SIMULATOR OUTPUTS
+    if (latlid) then
+       call addfld('CLDLOW_ATLID', horiz_only, 'A', 'percent', &
+            'ATLID Low-level Cloud Fraction (355 nm)', flag_xyfill=.true., fill_value=R_UNDEF)
+       call addfld('CLDMED_ATLID', horiz_only, 'A', 'percent', &
+            'ATLID Mid-level Cloud Fraction (355 nm)', flag_xyfill=.true., fill_value=R_UNDEF)
+       call addfld('CLDHGH_ATLID', horiz_only, 'A', 'percent', &
+            'ATLID High-level Cloud Fraction (355 nm)', flag_xyfill=.true., fill_value=R_UNDEF)
+       call addfld('CLDTOT_ATLID', horiz_only, 'A', 'percent', &
+            'ATLID Total Cloud Fraction (355 nm)', flag_xyfill=.true., fill_value=R_UNDEF)
+       call addfld('CLD_ATLID', (/'cosp_ht'/), 'A', 'percent', &
+            'ATLID Cloud Fraction (355 nm)', flag_xyfill=.true., fill_value=R_UNDEF)
+       call addfld('CFAD_SR355_ATLID', (/'cosp_355sr','cosp_ht'/), 'A', 'fraction', &
+            'ATLID Scattering Ratio CFAD (355 nm)', flag_xyfill=.true., fill_value=R_UNDEF)
+       call addfld('BETAMOL_ATLID', (/'cosp_ht'/), 'A', 'm-1 sr-1', &
+            'ATLID Molecular Backscatter (355 nm)', flag_xyfill=.true., fill_value=R_UNDEF)
+       call addfld('BETATOT_ATLID', (/'cosp_scol','cosp_ht'/), 'I', 'm-1 sr-1', &
+            'ATLID Total Backscatter (355 nm) in each Subcolumn', flag_xyfill=.true., fill_value=R_UNDEF)
+
+       call add_default('CLDLOW_ATLID',cosp_histfile_num,' ')
+       call add_default('CLDMED_ATLID',cosp_histfile_num,' ')
+       call add_default('CLDHGH_ATLID',cosp_histfile_num,' ')
+       call add_default('CLDTOT_ATLID',cosp_histfile_num,' ')
+       call add_default('CLD_ATLID',cosp_histfile_num,' ')
+       call add_default('CFAD_SR355_ATLID',cosp_histfile_num,' ')
+       call add_default('BETAMOL_ATLID',cosp_histfile_num,' ')
     end if
 
     ! RADAR SIMULATOR OUTPUTS
@@ -1713,6 +1753,15 @@ CONTAINS
     real(r8) :: cld_cal_notcs(pcols,nht_cosp)
     real(r8) :: atb532_cal(pcols,nlay*nscol_cosp)
     real(r8) :: mol532_cal(pcols,nlay)
+    ! ATLID (355nm) simulator outputs
+    real(r8) :: betatot_atlid(pcols,nscol_cosp,nlay)
+    real(r8) :: betamol_atlid(pcols,nlay)
+    real(r8) :: cfad_sr355_atlid(pcols,nht_cosp*nsr_cosp)
+    real(r8) :: cld_atlid(pcols,nht_cosp)
+    real(r8) :: cldlow_atlid(pcols)
+    real(r8) :: cldmed_atlid(pcols)
+    real(r8) :: cldhgh_atlid(pcols)
+    real(r8) :: cldtot_atlid(pcols)
     real(r8) :: cld_misr(pcols,nhtmisr_cosp*ntau_cosp)
     real(r8) :: refl_parasol(pcols,nsza_cosp)
     real(r8) :: scops_out(pcols,nlay*nscol_cosp)
@@ -1914,6 +1963,15 @@ CONTAINS
     cld_cal_notcs(1:pcols,1:nht_cosp)                = R_UNDEF
     atb532_cal(1:pcols,1:nlay*nscol_cosp)            = R_UNDEF
     mol532_cal(1:pcols,1:nlay)                       = R_UNDEF
+    ! ATLID (355nm) outputs
+    betatot_atlid(1:pcols,1:nscol_cosp,1:nlay)       = R_UNDEF
+    betamol_atlid(1:pcols,1:nlay)                    = R_UNDEF
+    cfad_sr355_atlid(1:pcols,1:nht_cosp*nsr_cosp)    = R_UNDEF
+    cld_atlid(1:pcols,1:nht_cosp)                    = R_UNDEF
+    cldlow_atlid(1:pcols)                            = R_UNDEF
+    cldmed_atlid(1:pcols)                            = R_UNDEF
+    cldhgh_atlid(1:pcols)                            = R_UNDEF
+    cldtot_atlid(1:pcols)                            = R_UNDEF
     cld_misr(1:pcols,1:nhtmisr_cosp*ntau_cosp)       = R_UNDEF
     refl_parasol(1:pcols,1:nsza_cosp)                = R_UNDEF
     scops_out(1:pcols,1:nlay*nscol_cosp)             = R_UNDEF
@@ -2658,6 +2716,29 @@ CONTAINS
        opacity_cal_2d(1:ncol,1:nht_cosp)  = cospOUT%calipso_lidarcldtype(:,:,4)
     endif
 
+    ! ATLID (355nm) SIMULATOR OUTPUTS
+    if (latlid) then
+       if (associated(cospOUT%atlid_beta_mol)) then
+          betamol_atlid(1:ncol,1:nlay) = cospOUT%atlid_beta_mol
+       endif
+       if (associated(cospOUT%atlid_beta_tot)) then
+          betatot_atlid(1:ncol,1:nscol_cosp,1:nlay) = cospOUT%atlid_beta_tot
+       endif
+       if (associated(cospOUT%atlid_cfad_sr)) then
+          cfad_sr355_atlid(1:ncol,1:nht_cosp*nsr_cosp) = reshape(cospOUT%atlid_cfad_sr, &
+                                                           shape=[ncol, nht_cosp*nsr_cosp])
+       endif
+       if (associated(cospOUT%atlid_lidarcld)) then
+          cld_atlid(1:ncol,1:nht_cosp) = cospOUT%atlid_lidarcld
+       endif
+       if (associated(cospOUT%atlid_cldlayer)) then
+          cldlow_atlid(1:ncol)  = cospOUT%atlid_cldlayer(:,1)
+          cldmed_atlid(1:ncol)  = cospOUT%atlid_cldlayer(:,2)
+          cldhgh_atlid(1:ncol)  = cospOUT%atlid_cldlayer(:,3)
+          cldtot_atlid(1:ncol)  = cospOUT%atlid_cldlayer(:,4)
+       endif
+    endif
+
     ! ISCCP
     if (lisccp_sim) then
        clisccp2(1:ncol,1:ntau_cosp,1:nprs_cosp) = cospOUT%isccp_fq
@@ -2775,6 +2856,15 @@ CONTAINS
              do isc=1,nscol_cosp
                 ihsc=(ihml-1)*nscol_cosp+isc
                 atb532_cal(i,ihsc) = atb532(i,isc,ihml)
+             end do
+          end do
+       endif
+
+       if (latlid) then
+          do ih=1,nht_cosp
+             do is=1,nsr_cosp
+                ihs=(ih-1)*nsr_cosp+is
+                cfad_sr355_atlid(i,ihs) = cfad_sr355_atlid(i,ihs)  ! Already reshaped from cospOUT? Check
              end do
           end do
        endif
@@ -3013,6 +3103,29 @@ CONTAINS
        call outfld('CS_WR_CFODD_REFF_SMALL', cfodd_ntotal_small_cs, pcols, lchnk)
        call outfld('CS_WR_CFODD_REFF_MEDIUM',cfodd_ntotal_medium_cs,pcols, lchnk)
        call outfld('CS_WR_CFODD_REFF_LARGE', cfodd_ntotal_large_cs, pcols, lchnk)
+    end if
+
+    ! ATLID (355nm) SIMULATOR OUTPUTS
+    if (latlid) then
+       if (cospIN%cospswathsIN(4)%N_inst_swaths < 1) then
+          where (cld_atlid(:ncol,:nht_cosp) == R_UNDEF)
+             cld_atlid(:ncol,:nht_cosp) = 0.0_r8
+          end where
+       end if
+       call outfld('CLD_ATLID',        cld_atlid,       pcols,lchnk)
+       call outfld('BETAMOL_ATLID',    betamol_atlid,   pcols,lchnk)
+       call outfld('BETATOT_ATLID',    betatot_atlid,   pcols,lchnk)
+       
+       if (cospIN%cospswathsIN(4)%N_inst_swaths < 1) then
+          where (cfad_sr355_atlid(:ncol,:nht_cosp*nsr_cosp) == R_UNDEF)
+             cfad_sr355_atlid(:ncol,:nht_cosp*nsr_cosp) = 0.0_r8
+          end where
+       end if
+       call outfld('CFAD_SR355_ATLID', cfad_sr355_atlid, pcols,lchnk)
+       call outfld('CLDLOW_ATLID',     cldlow_atlid,    pcols,lchnk)
+       call outfld('CLDMED_ATLID',     cldmed_atlid,    pcols,lchnk)
+       call outfld('CLDHGH_ATLID',     cldhgh_atlid,    pcols,lchnk)
+       call outfld('CLDTOT_ATLID',     cldtot_atlid,    pcols,lchnk)
     end if
 
     ! MISR SIMULATOR OUTPUTS
@@ -3542,7 +3655,7 @@ CONTAINS
     call t_startf("calipso_optics")
     if (Llidar_sim) then
        ReffTemp = ReffIN
-       call lidar_optics(nPoints,nColumns,nLevels,5,lidar_ice_type,                      &
+       call lidar_optics(nPoints,nColumns,nLevels,5,lidar_ice_type,532,                    &
                          mr_hydro(1:nPoints,1:nColumns,1:nLevels,I_LSCLIQ),              &
                          mr_hydro(1:nPoints,1:nColumns,1:nLevels,I_LSCICE),              &
                          mr_hydro(1:nPoints,1:nColumns,1:nLevels,I_CVCLIQ),              &
@@ -3568,6 +3681,38 @@ CONTAINS
                          cospIN%tautot_liq_calipso(1:nPoints,1:nColumns,1:nLevels))
     endif
     call t_stopf("calipso_optics")
+
+    ! ATLID (355nm) Optics
+    !%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+    call t_startf("atlid_optics")
+    if (Latlid) then
+       ReffTemp = ReffIN
+       call lidar_optics(nPoints,nColumns,nLevels,5,lidar_ice_type,355,                    &
+                         mr_hydro(1:nPoints,1:nColumns,1:nLevels,I_LSCLIQ),              &
+                         mr_hydro(1:nPoints,1:nColumns,1:nLevels,I_LSCICE),              &
+                         mr_hydro(1:nPoints,1:nColumns,1:nLevels,I_CVCLIQ),              &
+                         mr_hydro(1:nPoints,1:nColumns,1:nLevels,I_CVCICE),              &
+                         mr_hydro(1:nPoints,1:nColumns,1:nLevels,I_LSSNOW),              &
+                         ReffTemp(1:nPoints,1:nLevels,I_LSCLIQ),                         &
+                         ReffTemp(1:nPoints,1:nLevels,I_LSCICE),                         &
+                         ReffTemp(1:nPoints,1:nLevels,I_CVCLIQ),                         &
+                         ReffTemp(1:nPoints,1:nLevels,I_CVCICE),                         &
+                         ReffTemp(1:nPoints,1:nLevels,I_LSSNOW),                         &
+                         cospstateIN%pfull(1:nPoints,1:nLevels),                         &
+                         cospstateIN%phalf(1:nPoints,1:nLevels+1),                       &
+                         cospstateIN%at(1:nPoints,1:nLevels),                            &
+                         cospIN%beta_mol_atlid(1:nPoints,1:nLevels),                     &
+                         cospIN%betatot_atlid(1:nPoints,1:nColumns,1:nLevels),           &
+                         cospIN%tau_mol_atlid(1:nPoints,1:nLevels),                      &
+                         cospIN%tautot_atlid(1:nPoints,1:nColumns,1:nLevels),            &
+                         cospIN%tautot_S_liq_atlid(1:nPoints,1:nColumns),                &
+                         cospIN%tautot_S_ice_atlid(1:nPoints,1:nColumns),                &
+                         cospIN%betatot_ice_atlid(1:nPoints,1:nColumns,1:nLevels),       &
+                         cospIN%betatot_liq_atlid(1:nPoints,1:nColumns,1:nLevels),       &
+                         cospIN%tautot_ice_atlid(1:nPoints,1:nColumns,1:nLevels),        &
+                         cospIN%tautot_liq_atlid(1:nPoints,1:nColumns,1:nLevels))
+    endif
+    call t_stopf("atlid_optics")
 
 
     !%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/src/physics/cam/cospsimulator_intr.F90
+++ b/src/physics/cam/cospsimulator_intr.F90
@@ -3305,6 +3305,7 @@ CONTAINS
        end if
        if (latlid_sim) then
           call outfld('BETATOT_ATLID',betatot_atlid,pcols,lchnk)
+       end if
     end if
     call t_stopf("writing_output")
 #endif

--- a/src/physics/cam/cospsimulator_intr.F90
+++ b/src/physics/cam/cospsimulator_intr.F90
@@ -345,16 +345,16 @@ CONTAINS
 #ifdef USE_COSP
 !!! this list should include any variable that you might want to include in the namelist
 !!! philosophy is to not include COSP output flags but just important COSP settings and cfmip controls.
-     namelist /cospsimulator_nl/ docosp, cosp_active, cosp_amwg, &
-          cosp_histfile_num, cosp_histfile_aux, cosp_histfile_aux_num, cosp_isccp, cosp_lfrac_out, &
-          cosp_lite, cosp_lradar_sim, cosp_llidar_sim, cosp_latlid_sim, cosp_lisccp_sim,  cosp_lmisr_sim, cosp_lmodis_sim, cosp_lrttov_sim, &
-          cosp_ncolumns, cosp_nradsteps, cosp_passive, cosp_runall,                         &
-          cosp_rttov_Ninstruments, cosp_rttov_instrument_namelists,                         &
-          COSP_N_SWATHS_ISCCP, COSP_SWATH_LOCALTIMES_ISCCP, COSP_SWATH_WIDTHS_ISCCP, COSP_N_SWATHS_MISR,        &
-          COSP_SWATH_LOCALTIMES_MISR, COSP_SWATH_WIDTHS_MISR, COSP_N_SWATHS_MODIS, COSP_SWATH_LOCALTIMES_MODIS, &
-          COSP_SWATH_WIDTHS_MODIS, COSP_N_SWATHS_PARASOL, COSP_SWATH_LOCALTIMES_PARASOL,                   &
-          COSP_SWATH_WIDTHS_PARASOL, COSP_N_SWATHS_CSCAL, COSP_SWATH_LOCALTIMES_CSCAL,                     &
-          COSP_SWATH_WIDTHS_CSCAL, COSP_N_SWATHS_ATLID, COSP_SWATH_LOCALTIMES_ATLID, COSP_SWATH_WIDTHS_ATLID
+				namelist /cospsimulator_nl/ docosp, cosp_active, cosp_amwg, &
+										cosp_histfile_num, cosp_histfile_aux, cosp_histfile_aux_num, cosp_isccp, cosp_lfrac_out, &
+										cosp_lite, cosp_lradar_sim, cosp_llidar_sim, cosp_latlid_sim, cosp_lisccp_sim,  cosp_lmisr_sim, cosp_lmodis_sim, cosp_lrttov_sim, &
+										cosp_ncolumns, cosp_nradsteps, cosp_passive, cosp_runall,                         &
+										cosp_rttov_Ninstruments, cosp_rttov_instrument_namelists,                         &
+										COSP_N_SWATHS_ISCCP, COSP_SWATH_LOCALTIMES_ISCCP, COSP_SWATH_WIDTHS_ISCCP, COSP_N_SWATHS_MISR,        &
+										COSP_SWATH_LOCALTIMES_MISR, COSP_SWATH_WIDTHS_MISR, COSP_N_SWATHS_MODIS, COSP_SWATH_LOCALTIMES_MODIS, &
+										COSP_SWATH_WIDTHS_MODIS, COSP_N_SWATHS_PARASOL, COSP_SWATH_LOCALTIMES_PARASOL,                   &
+										COSP_SWATH_WIDTHS_PARASOL, COSP_N_SWATHS_CSCAL, COSP_SWATH_LOCALTIMES_CSCAL,                     &
+										COSP_SWATH_WIDTHS_CSCAL, COSP_N_SWATHS_ATLID, COSP_SWATH_LOCALTIMES_ATLID, COSP_SWATH_WIDTHS_ATLID
 
     !! read in the namelist
     if (masterproc) then

--- a/src/physics/cam/cospsimulator_intr.F90
+++ b/src/physics/cam/cospsimulator_intr.F90
@@ -345,16 +345,16 @@ CONTAINS
 #ifdef USE_COSP
 !!! this list should include any variable that you might want to include in the namelist
 !!! philosophy is to not include COSP output flags but just important COSP settings and cfmip controls.
-				namelist /cospsimulator_nl/ docosp, cosp_active, cosp_amwg, &
-										cosp_histfile_num, cosp_histfile_aux, cosp_histfile_aux_num, cosp_isccp, cosp_lfrac_out, &
-										cosp_lite, cosp_lradar_sim, cosp_llidar_sim, cosp_latlid_sim, cosp_lisccp_sim,  cosp_lmisr_sim, cosp_lmodis_sim, cosp_lrttov_sim, &
-										cosp_ncolumns, cosp_nradsteps, cosp_passive, cosp_runall,                         &
-										cosp_rttov_Ninstruments, cosp_rttov_instrument_namelists,                         &
-										COSP_N_SWATHS_ISCCP, COSP_SWATH_LOCALTIMES_ISCCP, COSP_SWATH_WIDTHS_ISCCP, COSP_N_SWATHS_MISR,        &
-										COSP_SWATH_LOCALTIMES_MISR, COSP_SWATH_WIDTHS_MISR, COSP_N_SWATHS_MODIS, COSP_SWATH_LOCALTIMES_MODIS, &
-										COSP_SWATH_WIDTHS_MODIS, COSP_N_SWATHS_PARASOL, COSP_SWATH_LOCALTIMES_PARASOL,                   &
-										COSP_SWATH_WIDTHS_PARASOL, COSP_N_SWATHS_CSCAL, COSP_SWATH_LOCALTIMES_CSCAL,                     &
-										COSP_SWATH_WIDTHS_CSCAL, COSP_N_SWATHS_ATLID, COSP_SWATH_LOCALTIMES_ATLID, COSP_SWATH_WIDTHS_ATLID
+    namelist /cospsimulator_nl/ docosp, cosp_active, cosp_amwg, &
+            cosp_histfile_num, cosp_histfile_aux, cosp_histfile_aux_num, cosp_isccp, cosp_lfrac_out, &
+            cosp_lite, cosp_lradar_sim, cosp_llidar_sim, cosp_latlid_sim, cosp_lisccp_sim,  cosp_lmisr_sim, cosp_lmodis_sim, cosp_lrttov_sim, &
+            cosp_ncolumns, cosp_nradsteps, cosp_passive, cosp_runall,                         &
+            cosp_rttov_Ninstruments, cosp_rttov_instrument_namelists,                         &
+            COSP_N_SWATHS_ISCCP, COSP_SWATH_LOCALTIMES_ISCCP, COSP_SWATH_WIDTHS_ISCCP, COSP_N_SWATHS_MISR,        &
+            COSP_SWATH_LOCALTIMES_MISR, COSP_SWATH_WIDTHS_MISR, COSP_N_SWATHS_MODIS, COSP_SWATH_LOCALTIMES_MODIS, &
+            COSP_SWATH_WIDTHS_MODIS, COSP_N_SWATHS_PARASOL, COSP_SWATH_LOCALTIMES_PARASOL,                   &
+            COSP_SWATH_WIDTHS_PARASOL, COSP_N_SWATHS_CSCAL, COSP_SWATH_LOCALTIMES_CSCAL,                     &
+            COSP_SWATH_WIDTHS_CSCAL, COSP_N_SWATHS_ATLID, COSP_SWATH_LOCALTIMES_ATLID, COSP_SWATH_WIDTHS_ATLID
 
     !! read in the namelist
     if (masterproc) then

--- a/src/physics/cam/cospsimulator_intr.F90
+++ b/src/physics/cam/cospsimulator_intr.F90
@@ -2860,15 +2860,6 @@ CONTAINS
           end do
        endif
 
-       if (latlid) then
-          do ih=1,nht_cosp
-             do is=1,nsr_cosp
-                ihs=(ih-1)*nsr_cosp+is
-                cfad_sr355_atlid(i,ihs) = cfad_sr355_atlid(i,ihs)  ! Already reshaped from cospOUT? Check
-             end do
-          end do
-       endif
-
        if (lmisr_sim) then
           do ihm=1,nhtmisr_cosp
              do it=1,ntau_cosp

--- a/src/physics/cosp2/optics/cosp_optics.F90
+++ b/src/physics/cosp2/optics/cosp_optics.F90
@@ -242,13 +242,13 @@ contains
     ! ####################################################################################
     
     ! INPUTS
-     INTEGER,intent(in) :: & 
-          npoints,      & ! Number of gridpoints
-          ncolumns,     & ! Number of subcolumns
-          nlev,         & ! Number of levels
-          npart,        & ! Number of cloud meteors (stratiform_liq, stratiform_ice, conv_liq, conv_ice). 
-          ice_type,     & ! Ice particle shape hypothesis (0 for spheres, 1 for non-spherical)
-          lidar_freq      ! Lidar frequency (nm). Use to change between lidar platforms
+    INTEGER,intent(in) :: & 
+         npoints,      & ! Number of gridpoints
+         ncolumns,     & ! Number of subcolumns
+         nlev,         & ! Number of levels
+         npart,        & ! Number of cloud meteors (stratiform_liq, stratiform_ice, conv_liq, conv_ice). 
+         ice_type,     & ! Ice particle shape hypothesis (0 for spheres, 1 for non-spherical)
+         lidar_freq      ! Lidar frequency (nm). Use to change between lidar platforms
     REAL(WP),intent(in),dimension(npoints,nlev) :: &
          temp,         & ! Temperature of layer k
          pres,         & ! Pressure at full levels
@@ -292,14 +292,14 @@ contains
 
     INTEGER                                         :: i,k,icol
     
-     ! Local data
-     REAL(WP),PARAMETER :: rhoice         = 0.5e+03    ! Density of ice (kg/m3) 
-     REAL(WP),PARAMETER :: Cmol_532nm     = 6.2446e-32 ! Wavelength dependent at 532nm
-     REAL(WP),PARAMETER :: Cmol_355nm     = 3.2662e-31 ! Wavelength dependent at 355nm
-     REAL(WP),PARAMETER :: rdiffm_532nm   = 0.7_wp     ! Multiple scattering correction at 532nm
-     REAL(WP),PARAMETER :: rdiffm_355nm   = 0.6_wp     ! Multiple scattering correction at 355nm
-     REAL(WP) :: Cmol, rdiffm              ! Runtime-selected values based on lidar_freq
-     REAL(WP),PARAMETER :: Qscat          = 2.0_wp     ! Particle scattering efficiency at 532 nm
+    ! Local data
+    REAL(WP),PARAMETER :: rhoice         = 0.5e+03    ! Density of ice (kg/m3) 
+    REAL(WP),PARAMETER :: Cmol_532nm     = 6.2446e-32 ! Wavelength dependent at 532nm
+    REAL(WP),PARAMETER :: Cmol_355nm     = 3.2662e-31 ! Wavelength dependent at 355nm
+    REAL(WP),PARAMETER :: rdiffm_532nm   = 0.7_wp     ! Multiple scattering correction at 532nm
+    REAL(WP),PARAMETER :: rdiffm_355nm   = 0.6_wp     ! Multiple scattering correction at 355nm
+    REAL(WP) :: Cmol, rdiffm              ! Runtime-selected values based on lidar_freq
+    REAL(WP),PARAMETER :: Qscat          = 2.0_wp     ! Particle scattering efficiency at 532 nm
     ! Local indicies for large-scale and convective ice and liquid 
     INTEGER,PARAMETER  :: INDX_LSLIQ  = 1
     INTEGER,PARAMETER  :: INDX_LSICE  = 2
@@ -321,19 +321,19 @@ contains
          polpartCVICE1 = (/ 1.3615e-8_wp, -2.04206e-6_wp, 7.51799e-5_wp, 0.00078213_wp, 0.0182131_wp/), &
          polpartLSICE1 = (/ 1.3615e-8_wp, -2.04206e-6_wp, 7.51799e-5_wp, 0.00078213_wp, 0.0182131_wp/), &
          polpartLSSNOW = (/ 1.3615e-8_wp, -2.04206e-6_wp, 7.51799e-5_wp, 0.00078213_wp, 0.0182131_wp/)
-     ! ##############################################################################
+    ! ##############################################################################
+    
+    ! Which LIDAR frequency are we using?
+    if (lidar_freq .eq. 355) then
+       Cmol   = Cmol_355nm
+       rdiffm = rdiffm_355nm
+    endif
+    if (lidar_freq .eq. 532) then
+       Cmol   = Cmol_532nm
+       rdiffm = rdiffm_532nm
+    endif
      
-     ! Which LIDAR frequency are we using?
-     if (lidar_freq .eq. 355) then
-        Cmol   = Cmol_355nm
-        rdiffm = rdiffm_355nm
-     endif
-     if (lidar_freq .eq. 532) then
-        Cmol   = Cmol_532nm
-        rdiffm = rdiffm_532nm
-     endif
-     
-     ! Liquid/ice particles
+    ! Liquid/ice particles
     rhopart(INDX_LSLIQ)  = rholiq
     rhopart(INDX_LSICE)  = rhoice
     rhopart(INDX_CVLIQ)  = rholiq

--- a/src/physics/cosp2/optics/cosp_optics.F90
+++ b/src/physics/cosp2/optics/cosp_optics.F90
@@ -279,7 +279,7 @@ contains
     REAL(WP),intent(out),dimension(npoints,nlev) :: &
          beta_mol,       & ! Molecular backscatter coefficient
          tau_mol           ! Molecular optical depth
-    REAL(WP),intent(out),dimension(npoints,ncolumns) :: &
+    REAL(WP),optional,intent(out),dimension(npoints,ncolumns) :: &
          tautot_S_liq,   & ! TOA optical depth for liquid
          tautot_S_ice      ! TOA optical depth for ice
     
@@ -291,6 +291,7 @@ contains
     REAL(WP),dimension(npoints,nlev,npart)          :: rad_part,kp_part,qpart,alpha_part,tau_part
 
     INTEGER                                         :: i,k,icol
+    logical                                         :: lparasol,lphaseoptics
     
     ! Local data
     REAL(WP),PARAMETER :: rhoice         = 0.5e+03    ! Density of ice (kg/m3) 
@@ -332,7 +333,16 @@ contains
        Cmol   = Cmol_532nm
        rdiffm = rdiffm_532nm
     endif
-     
+
+    ! Do we need to generate optical inputs for Parasol simulator?
+    lparasol = .false.
+    if (present(tautot_S_liq) .and. present(tautot_S_ice)) lparasol = .true.
+    
+    ! Are optical-depths and backscatter coefficients for ice and liquid requested?
+    lphaseoptics=.false.
+    if (present(betatot_ice) .and. present(betatot_liq) .and. present(tautot_liq) .and. &
+         present(tautot_ice)) lphaseoptics=.true.
+
     ! Liquid/ice particles
     rhopart(INDX_LSLIQ)  = rholiq
     rhopart(INDX_LSICE)  = rhoice
@@ -393,10 +403,13 @@ contains
 
     betatot    (1:npoints,1:ncolumns,1:nlev) = spread(beta_mol(1:npoints,1:nlev), dim=2, NCOPIES=ncolumns)
     tautot     (1:npoints,1:ncolumns,1:nlev) = spread(tau_mol (1:npoints,1:nlev), dim=2, NCOPIES=ncolumns)
-    betatot_liq(1:npoints,1:ncolumns,1:nlev) = betatot(1:npoints,1:ncolumns,1:nlev)
-    betatot_ice(1:npoints,1:ncolumns,1:nlev) = betatot(1:npoints,1:ncolumns,1:nlev)
-    tautot_liq (1:npoints,1:ncolumns,1:nlev) = tautot(1:npoints,1:ncolumns,1:nlev)
-    tautot_ice (1:npoints,1:ncolumns,1:nlev) = tautot(1:npoints,1:ncolumns,1:nlev)      
+
+    if (lphaseoptics) then
+       betatot_liq(1:npoints,1:ncolumns,1:nlev) = betatot(1:npoints,1:ncolumns,1:nlev)
+       betatot_ice(1:npoints,1:ncolumns,1:nlev) = betatot(1:npoints,1:ncolumns,1:nlev)
+       tautot_liq (1:npoints,1:ncolumns,1:nlev) = tautot(1:npoints,1:ncolumns,1:nlev)
+       tautot_ice (1:npoints,1:ncolumns,1:nlev) = tautot(1:npoints,1:ncolumns,1:nlev)
+    endif
     
     ! ##############################################################################
     ! *) Particles alpha, beta and optical thickness
@@ -414,10 +427,14 @@ contains
           kp_part(1:npoints,1:nlev,i) = 0._wp
        endwhere
     enddo    
-    
+
+    ! Initialize (if necessary)
+    if (lparasol) then
+       tautot_S_liq(1:npoints,1:ncolumns) = 0._wp
+       tautot_S_ice(1:npoints,1:ncolumns) = 0._wp
+    endif
+
     ! Loop over all subcolumns
-    tautot_S_liq(1:npoints,1:ncolumns) = 0._wp
-    tautot_S_ice(1:npoints,1:ncolumns) = 0._wp
     do icol=1,ncolumns
        ! ##############################################################################
        ! Mixing ratio particles in each subcolum
@@ -473,29 +490,32 @@ contains
        ! ##############################################################################
        ! Beta and optical thickness (liquid/ice)
        ! ##############################################################################
+       if (lphaseoptics) then
        ! Ice
-       betatot_ice(1:npoints,icol,1:nlev) = betatot_ice(1:npoints,icol,1:nlev)+ &
-            kp_part(1:npoints,1:nlev,INDX_LSICE)*alpha_part(1:npoints,1:nlev,INDX_LSICE)+ &
-            kp_part(1:npoints,1:nlev,INDX_CVICE)*alpha_part(1:npoints,1:nlev,INDX_CVICE)+ &
-            kp_part(1:npoints,1:nlev,INDX_LSSNOW)*alpha_part(1:npoints,1:nlev,INDX_LSSNOW)
-       tautot_ice(1:npoints,icol,1:nlev) = tautot_ice(1:npoints,icol,1:nlev)  + &
-            tau_part(1:npoints,1:nlev,INDX_LSICE) + &
-            tau_part(1:npoints,1:nlev,INDX_CVICE) + &
-            tau_part(1:npoints,1:nlev,INDX_LSSNOW)
+          betatot_ice(1:npoints,icol,1:nlev) = betatot_ice(1:npoints,icol,1:nlev)+ &
+                kp_part(1:npoints,1:nlev,INDX_LSICE)*alpha_part(1:npoints,1:nlev,INDX_LSICE)+ &
+                kp_part(1:npoints,1:nlev,INDX_CVICE)*alpha_part(1:npoints,1:nlev,INDX_CVICE)+ &
+                kp_part(1:npoints,1:nlev,INDX_LSSNOW)*alpha_part(1:npoints,1:nlev,INDX_LSSNOW)
+          tautot_ice(1:npoints,icol,1:nlev) = tautot_ice(1:npoints,icol,1:nlev)  + &
+                tau_part(1:npoints,1:nlev,INDX_LSICE) + &
+                tau_part(1:npoints,1:nlev,INDX_CVICE) + &
+                tau_part(1:npoints,1:nlev,INDX_LSSNOW)
 
-       ! Liquid
-       betatot_liq(1:npoints,icol,1:nlev) = betatot_liq(1:npoints,icol,1:nlev)+ &
-            kp_part(1:npoints,1:nlev,INDX_LSLIQ)*alpha_part(1:npoints,1:nlev,INDX_LSLIQ)+ &
-            kp_part(1:npoints,1:nlev,INDX_CVLIQ)*alpha_part(1:npoints,1:nlev,INDX_CVLIQ)
-       tautot_liq(1:npoints,icol,1:nlev) = tautot_liq(1:npoints,icol,1:nlev)  + &
-            tau_part(1:npoints,1:nlev,INDX_LSLIQ) + &
-            tau_part(1:npoints,1:nlev,INDX_CVLIQ)
-            
+          ! Liquid
+          betatot_liq(1:npoints,icol,1:nlev) = betatot_liq(1:npoints,icol,1:nlev)+ &
+                kp_part(1:npoints,1:nlev,INDX_LSLIQ)*alpha_part(1:npoints,1:nlev,INDX_LSLIQ)+ &
+                kp_part(1:npoints,1:nlev,INDX_CVLIQ)*alpha_part(1:npoints,1:nlev,INDX_CVLIQ)
+          tautot_liq(1:npoints,icol,1:nlev) = tautot_liq(1:npoints,icol,1:nlev)  + &
+                tau_part(1:npoints,1:nlev,INDX_LSLIQ) + &
+                tau_part(1:npoints,1:nlev,INDX_CVLIQ)
+       endif
        ! ##############################################################################    
        ! Optical depths used by the PARASOL simulator
        ! ##############################################################################             
-       tautot_S_liq(:,icol) = tau_part(:,nlev,1)+tau_part(:,nlev,3)
-       tautot_S_ice(:,icol) = tau_part(:,nlev,2)+tau_part(:,nlev,4)+tau_part(:,nlev,5)               
+       if (lparasol) then
+          tautot_S_liq(:,icol) = tau_part(:,nlev,1)+tau_part(:,nlev,3)
+          tautot_S_ice(:,icol) = tau_part(:,nlev,2)+tau_part(:,nlev,4)+tau_part(:,nlev,5)
+       endif
     enddo
     
   end subroutine lidar_optics

--- a/src/physics/cosp2/optics/cosp_optics.F90
+++ b/src/physics/cosp2/optics/cosp_optics.F90
@@ -229,7 +229,7 @@ contains
   ! ######################################################################################
   ! SUBROUTINE lidar_optics
   ! ######################################################################################
-  subroutine lidar_optics(npoints,ncolumns,nlev,npart,ice_type,q_lsliq,q_lsice,q_cvliq, &
+  subroutine lidar_optics(npoints,ncolumns,nlev,npart,ice_type,lidar_freq,q_lsliq,q_lsice,q_cvliq, &
                           q_cvice,q_lssnow,ls_radliq,ls_radice,cv_radliq,cv_radice,ls_radsnow,  &
                           pres,presf,temp,beta_mol,betatot,tau_mol,tautot,  &
                           tautot_S_liq,tautot_S_ice,betatot_ice,betatot_liq,         &
@@ -242,12 +242,13 @@ contains
     ! ####################################################################################
     
     ! INPUTS
-    INTEGER,intent(in) :: & 
-         npoints,      & ! Number of gridpoints
-         ncolumns,     & ! Number of subcolumns
-         nlev,         & ! Number of levels
-         npart,        & ! Number of cloud meteors (stratiform_liq, stratiform_ice, conv_liq, conv_ice). 
-         ice_type        ! Ice particle shape hypothesis (0 for spheres, 1 for non-spherical)
+     INTEGER,intent(in) :: & 
+          npoints,      & ! Number of gridpoints
+          ncolumns,     & ! Number of subcolumns
+          nlev,         & ! Number of levels
+          npart,        & ! Number of cloud meteors (stratiform_liq, stratiform_ice, conv_liq, conv_ice). 
+          ice_type,     & ! Ice particle shape hypothesis (0 for spheres, 1 for non-spherical)
+          lidar_freq      ! Lidar frequency (nm). Use to change between lidar platforms
     REAL(WP),intent(in),dimension(npoints,nlev) :: &
          temp,         & ! Temperature of layer k
          pres,         & ! Pressure at full levels
@@ -291,11 +292,14 @@ contains
 
     INTEGER                                         :: i,k,icol
     
-    ! Local data
-    REAL(WP),PARAMETER :: rhoice     = 0.5e+03    ! Density of ice (kg/m3) 
-    REAL(WP),PARAMETER :: Cmol       = 6.2446e-32 ! Wavelength dependent
-    REAL(WP),PARAMETER :: rdiffm     = 0.7_wp     ! Multiple scattering correction parameter
-    REAL(WP),PARAMETER :: Qscat      = 2.0_wp     ! Particle scattering efficiency at 532 nm
+     ! Local data
+     REAL(WP),PARAMETER :: rhoice         = 0.5e+03    ! Density of ice (kg/m3) 
+     REAL(WP),PARAMETER :: Cmol_532nm     = 6.2446e-32 ! Wavelength dependent at 532nm
+     REAL(WP),PARAMETER :: Cmol_355nm     = 3.2662e-31 ! Wavelength dependent at 355nm
+     REAL(WP),PARAMETER :: rdiffm_532nm   = 0.7_wp     ! Multiple scattering correction at 532nm
+     REAL(WP),PARAMETER :: rdiffm_355nm   = 0.6_wp     ! Multiple scattering correction at 355nm
+     REAL(WP) :: Cmol, rdiffm              ! Runtime-selected values based on lidar_freq
+     REAL(WP),PARAMETER :: Qscat          = 2.0_wp     ! Particle scattering efficiency at 532 nm
     ! Local indicies for large-scale and convective ice and liquid 
     INTEGER,PARAMETER  :: INDX_LSLIQ  = 1
     INTEGER,PARAMETER  :: INDX_LSICE  = 2
@@ -317,9 +321,19 @@ contains
          polpartCVICE1 = (/ 1.3615e-8_wp, -2.04206e-6_wp, 7.51799e-5_wp, 0.00078213_wp, 0.0182131_wp/), &
          polpartLSICE1 = (/ 1.3615e-8_wp, -2.04206e-6_wp, 7.51799e-5_wp, 0.00078213_wp, 0.0182131_wp/), &
          polpartLSSNOW = (/ 1.3615e-8_wp, -2.04206e-6_wp, 7.51799e-5_wp, 0.00078213_wp, 0.0182131_wp/)
-    ! ##############################################################################
-    
-    ! Liquid/ice particles
+     ! ##############################################################################
+     
+     ! Which LIDAR frequency are we using?
+     if (lidar_freq .eq. 355) then
+        Cmol   = Cmol_355nm
+        rdiffm = rdiffm_355nm
+     endif
+     if (lidar_freq .eq. 532) then
+        Cmol   = Cmol_532nm
+        rdiffm = rdiffm_532nm
+     endif
+     
+     ! Liquid/ice particles
     rhopart(INDX_LSLIQ)  = rholiq
     rhopart(INDX_LSICE)  = rhoice
     rhopart(INDX_CVLIQ)  = rholiq

--- a/src/physics/cosp2/optics/cosp_optics.F90
+++ b/src/physics/cosp2/optics/cosp_optics.F90
@@ -324,11 +324,11 @@ contains
     ! ##############################################################################
     
     ! Which LIDAR frequency are we using?
-    if (lidar_freq .eq. 355) then
+    if (lidar_freq == 355) then
        Cmol   = Cmol_355nm
        rdiffm = rdiffm_355nm
     endif
-    if (lidar_freq .eq. 532) then
+    if (lidar_freq == 532) then
        Cmol   = Cmol_532nm
        rdiffm = rdiffm_532nm
     endif


### PR DESCRIPTION
COSP2 includes a lidar simulator for the new ESA EarthCARE satellite (ATLID) (https://agupubs.onlinelibrary.wiley.com/doi/10.1002/2015JD023919). This simulator package makes use of existing COSP features for the CALIPSO/CALIOP simulator with some additional changes. With EarthCARE recently launched and additional work to develop the ATLID simulator ongoing, I believe that adding this capability to CAM will be of significant value to the broader community.

CAM's coupler currently does not support ATLID outputs for a few reasons:
1. ATLID inputs, outputs, dimensions, etc are not read into the standard COSP DDTs in cospsimulator_intr.F90
2. There is not a namelist field to enable ATLID outputs analogously to other COSP simulators.
3. The lidar_optics routine in CAM is hardcoded for the CALIOP wavelengths, whereas the updated version in COSP can accomodate both CALIOP and ATLID by supplying the wavelength as an additional input. Additionally, the CAM code now includes radiatively-active snow in lidar_optics whereas I believe COSP does not. These diverging changes should be reconciled.

This was initially a *draft* PR to resolve these issues. It was tested it in more detail (specifically make sure that lidar_optics issues with snow and wavelength are reconciled correctly), but wanted to open this PR now to gauge feedback. @brianpm