### PR TITLE
cam6_4_185: Upper boundary conditions of Q

### DIFF
--- a/bld/build-namelist
+++ b/bld/build-namelist
@@ -2962,9 +2962,17 @@ if ($maxzen>0.0) {
 # upper boundary specifier
 my $ubc_ver;
 if (($chem =~ /waccm_ma/ or $chem =~ /waccm_tsmlt/ or $chem =~ /waccm_t4ma/) and !$waccmx) {
-    $ubc_ver = 'waccmchem';
+    if ($phys =~ /cam7/) {
+	$ubc_ver = 'waccm7chem';
+    } else {
+	$ubc_ver = 'waccmchem';
+    }
 } elsif ($chem =~ /waccm_sc/ or ($model_top eq "ht" and $chem =~ /ghg_mam/)) {
-    $ubc_ver = 'waccmsc';
+    if ($phys =~ /cam7/) {
+	$ubc_ver = 'waccm7sc';
+    } else {
+	$ubc_ver = 'waccmsc';
+    }
 }
 if (defined $ubc_ver) {
     add_default($nl, 'ubc_specifier', 'ver'=>$ubc_ver);

--- a/bld/namelist_files/namelist_defaults_cam.xml
+++ b/bld/namelist_files/namelist_defaults_cam.xml
@@ -2098,6 +2098,13 @@
 <ubc_specifier ver="waccmsc">
   'T->MSIS','Q->2.d-8vmr','CH4->2.d-10vmr'
 </ubc_specifier>
+<!-- WACCM7 -- do not include water vapor for now -->
+<ubc_specifier ver="waccm7chem">
+  'T->MSIS','CH4->2.d-10vmr','F->1.0D-15mmr','HF->1.0D-15mmr','H->MSIS','N->MSIS','O->MSIS','O2->MSIS','H2->TGCM','NO->SNOE'
+</ubc_specifier>
+<ubc_specifier ver="waccm7sc">
+  'T->MSIS','CH4->2.d-10vmr'
+</ubc_specifier>
 
 <!-- Boundary data for Tropopheric Chemistry -->
 <fstrat_file    >atm/cam/chem/trop_mozart/ub/ubvals_b40.20th.track1_1996-2005_c110315.nc</fstrat_file>

--- a/bld/namelist_files/use_cases/1850_cam_lt.xml
+++ b/bld/namelist_files/use_cases/1850_cam_lt.xml
@@ -12,10 +12,12 @@
 <flbc_list>'CO2','CH4','N2O','CFC11','CFC12','CFC11eq'</flbc_list>
 
 <!-- Low top upper boundary conditions -->
+<!-- Remove for now
 <ubc_specifier>'Q:H2O->UBC_FILE'</ubc_specifier>
 <ubc_file_path>atm/cam/chem/ubc/b.e21.BWHIST.f09_g17.CMIP6-historical-WACCM.ensAvg123.cam.h0zm.H2O.1849-2014_c240604.nc</ubc_file_path>
 <ubc_file_input_type>CYCLICAL</ubc_file_input_type>
 <ubc_file_cycle_yr>1850</ubc_file_cycle_yr>
+ -->
 
 <!-- ozone data :  -->
 <prescribed_ozone_datapath>   'atm/cam/ozone_strataero'  </prescribed_ozone_datapath>

--- a/bld/namelist_files/use_cases/hist_cam_lt.xml
+++ b/bld/namelist_files/use_cases/hist_cam_lt.xml
@@ -11,9 +11,11 @@
 <flbc_list>'CO2','CH4','N2O','CFC11','CFC12','CFC11eq'</flbc_list>
 
 <!-- Low top upper boundary conditions -->
+<!-- Remove for now
 <ubc_specifier>'Q:H2O->UBC_FILE'</ubc_specifier>
 <ubc_file_path>atm/cam/chem/ubc/b.e21.BWHIST.f09_g17.CMIP6-historical-WACCM.ensAvg123.cam.h0zm.H2O.1849-2014_c240604.nc</ubc_file_path>
 <ubc_file_input_type>'SERIAL'</ubc_file_input_type>
+ -->
 
 <!-- ozone data -->
 <prescribed_ozone_datapath>   'atm/cam/ozone_strataero'                                                         </prescribed_ozone_datapath>

--- a/doc/ChangeLog
+++ b/doc/ChangeLog
@@ -50,12 +50,33 @@ then copy the lines from the td.*.status files for the failed tests to the
 appropriate machine below.  All failed tests must be justified.
 
 derecho/intel/aux_cam:
+  NLFAIL ERC_D_Ln9.mpasa120_mpasa120.FHISTC_LTso.derecho_intel.cam-outfrq9s_mpasa120
+  NLFAIL ERC_D_Ln9.ne30pg3_ne30pg3_mt232.F1850C_LTso.derecho_intel.cam-outfrq9s
+  NLFAIL ERI_D_Ln18.ne30pg3_ne30pg3_mt232.FHISTC_LTso.derecho_intel.cam-outfrq3s_eri
+  NLFAIL ERR_Ln9.ne16pg3_ne16pg3_mt232.FHISTC_LTso.derecho_intel.cam-outfrq9s_bwic
+  - remove UBC namelist settings for LTso compsets, otherwise bit-for-bit
+
+  NLFAIL ERP_Ld3.ne16pg3_ne16pg3_mg17.FHISTC_WAt1ma.derecho_intel.cam-reduced_hist1d
+  NLFAIL ERP_Ln9.ne30pg3_ne30pg3_mg17.FHISTC_WAma.derecho_intel.cam-outfrq9s
+  - remove Q from UBC specifier namelist setting for WACCM7 compsets, otherwise bit-for-bit
 
 derecho/nvhpc/aux_cam:
+  NLFAIL ERS_Ln9.ne30pg3_ne30pg3_mt232.FHISTC_LTso.derecho_nvhpc.cam-outfrq9s_gpu_default
+  - remove UBC namelist settings for LTso compsets, otherwise bit-for-bit
 
 izumi/nag/aux_cam:
+  FAIL ERC_D_Ln9.f10_f10_mt232.FHIST_C5.izumi_nag.cam-outfrq3s_subcol COMPARE_base_rest
+  - pre-existing failure -- see https://github.com/ESCOMP/CAM/issues/1514
+
+  NLFAIL ERC_D_Ln9.ne3pg3_ne3pg3_mt232.FHISTC_LTso.izumi_nag.cam-cosp_rad_diags
+  NLFAIL ERC_D_Ln9.ne3pg3_ne3pg3_mt232.FHISTC_LTso.izumi_nag.cam-outfrq9s_nochem
+ - remove UBC namelist settings for LTso compsets, otherwise bit-for-bit
 
 izumi/gnu/aux_cam:
+  NLFAIL ERC_D_Ln9.mpasa480_mpasa480_mt232.FHISTC_LTso.izumi_gnu.cam-outfrq9s_mpasa480
+  NLFAIL ERC_D_Ln9.ne3pg3_ne3pg3_mt232.FHISTC_LTso.izumi_gnu.cam-sat_lcltod
+  NLFAIL SMS_D_Ln3.ne3pg3_ne3pg3_mt232.PC7.izumi_gnu.cam-pc7_ne3pg3
+ - remove UBC namelist settings for LTso and PC7 compsets, otherwise bit-for-bit
 
 CAM tag used for the baseline comparison tests if different than previous
 tag:

--- a/doc/ChangeLog
+++ b/doc/ChangeLog
@@ -8,11 +8,15 @@ Github PR URL: https://github.com/ESCOMP/CAM/pull/1602
 
 Purpose of changes (include the issue number and title text for each relevant GitHub issue):
 
- In CAM7 physics registration of water vapor constituent (Q) omitted the
- fixed upper boundary concentration flag.  Thus the inclusion of Q in the upper
+ Registration of water vapor constituent (Q) omitted the fixed upper boundary
+ concentration flag in CAM7 physics.  Thus the inclusion of Q in the upper
  boundary namelist specifier had no effect in CAM7 LT and WA compsets.
  See issue #1601: Water vapor upper boundary conditions ignored in cam7
  (https://github.com/ESCOMP/CAM/issues/1601)
+
+ Here Q has been removed from the default UBC specifier namelist settings
+ for CAM7 LTso and WACCM7 compsets until further testing for including Q
+ UBCs has been tested.  Thus, this merge is bit-for-bit.
 
 Describe any changes made to build system: N/A
 
@@ -78,29 +82,7 @@ izumi/gnu/aux_cam:
   NLFAIL SMS_D_Ln3.ne3pg3_ne3pg3_mt232.PC7.izumi_gnu.cam-pc7_ne3pg3
  - remove UBC namelist settings for LTso and PC7 compsets, otherwise bit-for-bit
 
-CAM tag used for the baseline comparison tests if different than previous
-tag:
-
-Summarize any changes to answers, i.e.,
-- what code configurations:
-- what platforms/compilers:
-- nature of change (roundoff; larger than roundoff but same climate; new
-  climate):
-
-If bitwise differences were observed, how did you show they were no worse
-than roundoff?
-
-If this tag changes climate describe the run(s) done to evaluate the new
-climate in enough detail that it(they) could be reproduced, i.e.,
-- source tag (all code used must be in the repository):
-- platform/compilers:
-- configure commandline:
-- build-namelist command (or complete namelist):
-- MSS location of output:
-
-MSS location of control simulations used to validate new climate:
-
-URL for AMWG diagnostics output used to validate new climate:
+Summarize any changes to answers: bit-for-bit unchanged
 
 ===============================================================
 ===============================================================

--- a/doc/ChangeLog
+++ b/doc/ChangeLog
@@ -1,5 +1,89 @@
 ===============================================================
 
+Tag name: cam6_4_185
+Originator(s): fvitt
+Date: 29 Jun 2026
+One-line Summary: Fix bug in water vapor upper boundary
+Github PR URL: https://github.com/ESCOMP/CAM/pull/1602
+
+Purpose of changes (include the issue number and title text for each relevant GitHub issue):
+
+ In CAM7 physics registration of water vapor constituent (Q) omitted the
+ fixed upper boundary concentration flag.  Thus the inclusion of Q in the upper
+ boundary namelist specifier had no effect in CAM7 LT and WA compsets.
+ See issue #1601: Water vapor upper boundary conditions ignored in cam7
+ (https://github.com/ESCOMP/CAM/issues/1601)
+
+Describe any changes made to build system: N/A
+
+Describe any changes made to the namelist: N/A
+
+List any changes to the defaults for the boundary datasets: N/A
+
+Describe any substantial timing or memory changes: N/A
+
+Code reviewed by: cacraigucar
+
+List all files eliminated: N/A
+
+List all files added and what they do: N/A
+
+List all existing files that have been modified, and describe the changes:
+
+M       bld/build-namelist
+ - determine if cam7 physics for selection of default WACCM ubc_specifier
+
+M       bld/namelist_files/namelist_defaults_cam.xml
+ - default waccm7 ubc_specifier (does not include Q)
+
+M       bld/namelist_files/use_cases/1850_cam_lt.xml
+M       bld/namelist_files/use_cases/hist_cam_lt.xml
+ - remove Q upper boundary
+
+M       src/physics/cam7/physpkg.F90
+ - check for fixed upper boundary concentrations of Q
+ - invoke cnst_add with appropriate fixed_ubc flag setting
+
+If there were any failures reported from running test_driver.sh on any test
+platform, and checkin with these failures has been OK'd by the gatekeeper,
+then copy the lines from the td.*.status files for the failed tests to the
+appropriate machine below.  All failed tests must be justified.
+
+derecho/intel/aux_cam:
+
+derecho/nvhpc/aux_cam:
+
+izumi/nag/aux_cam:
+
+izumi/gnu/aux_cam:
+
+CAM tag used for the baseline comparison tests if different than previous
+tag:
+
+Summarize any changes to answers, i.e.,
+- what code configurations:
+- what platforms/compilers:
+- nature of change (roundoff; larger than roundoff but same climate; new
+  climate):
+
+If bitwise differences were observed, how did you show they were no worse
+than roundoff?
+
+If this tag changes climate describe the run(s) done to evaluate the new
+climate in enough detail that it(they) could be reproduced, i.e.,
+- source tag (all code used must be in the repository):
+- platform/compilers:
+- configure commandline:
+- build-namelist command (or complete namelist):
+- MSS location of output:
+
+MSS location of control simulations used to validate new climate:
+
+URL for AMWG diagnostics output used to validate new climate:
+
+===============================================================
+===============================================================
+
 Tag name: cam6_4_184
 Originator(s): jimmielin
 Date: 23 Jun 2026

--- a/doc/ChangeLog
+++ b/doc/ChangeLog
@@ -3,7 +3,7 @@
 Tag name: cam6_4_185
 Originator(s): fvitt
 Date: 29 Jun 2026
-One-line Summary: Fix bug in water vapor upper boundary
+One-line Summary: Fix water vapor upper boundary bug
 Github PR URL: https://github.com/ESCOMP/CAM/pull/1602
 
 Purpose of changes (include the issue number and title text for each relevant GitHub issue):
@@ -16,7 +16,7 @@ Purpose of changes (include the issue number and title text for each relevant Gi
 
  Here Q has been removed from the default UBC specifier namelist settings
  for CAM7 LTso and WACCM7 compsets until further testing for including Q
- UBCs has been tested.  Thus, this merge is bit-for-bit.
+ UBCs has been completed.  Thus, this tag is bit-for-bit.
 
 Describe any changes made to build system: N/A
 

--- a/src/physics/cam7/physpkg.F90
+++ b/src/physics/cam7/physpkg.F90
@@ -159,12 +159,14 @@ contains
     use surface_emissions_mod, only: surface_emissions_reg
     use elevated_emissions_mod, only: elevated_emissions_reg
     use ctem_diags_mod, only: ctem_diags_reg
+    use upper_bc,       only: ubc_fixed_conc
 
     !---------------------------Local variables-----------------------------
     !
     integer  :: m        ! loop index
     integer  :: mm       ! constituent index
     integer  :: nmodes
+    logical  :: has_fixed_ubc ! for upper bndy cond
     !-----------------------------------------------------------------------
 
     ! Get physics options
@@ -191,11 +193,12 @@ contains
     ! Register water vapor.
     ! ***** N.B. ***** This must be the first call to cnst_add so that
     !                  water vapor is constituent 1.
+    has_fixed_ubc = ubc_fixed_conc('Q') ! check for fixed concentration upper boundary condition
     if (moist_physics) then
-       call cnst_add('Q', mwh2o, cpwv, 1.E-12_r8, mm, &
+       call cnst_add('Q', mwh2o, cpwv, 1.E-12_r8, mm, fixed_ubc=has_fixed_ubc, &
             longname='Specific humidity', readiv=.true., is_convtran1=.true.)
     else
-       call cnst_add('Q', mwh2o, cpwv, 0.0_r8, mm, &
+       call cnst_add('Q', mwh2o, cpwv, 0.0_r8, mm, fixed_ubc=has_fixed_ubc, &
             longname='Specific humidity', readiv=.false., is_convtran1=.true.)
     end if
 


### PR DESCRIPTION
Fixes #1601 

In this PR, Q has been removed from the UBC specifier in CAM7 LT and WA compsets.  So all baseline tests will PASS.  This is a bit-for-bit merge.

After further testing has been completed Q may be added to the UBC specifier in CAM7 LT and WA compsets in a future PR.