### PR TITLE
Remove incorrect use of CASEROOT in 'bld/configure'

### DIFF
--- a/bld/configure
+++ b/bld/configure
@@ -2037,10 +2037,6 @@ sub write_filepath
         }
     }
 
-    # CESM has a standard source mods location.
-    my $CASEROOT = "$ENV{'CASEROOT'}";
-    print $fh "$CASEROOT/SourceMods/src.cam\n";
-
     # offline unit driver (defaults to stub)
     print $fh "$camsrcdir/src/unit_drivers\n";
     print $fh "$camsrcdir/src/unit_drivers/${offline_drv}\n";


### PR DESCRIPTION
This is a pretty unimportant change, but jumped out when looking at build warnings (which it doesn't actually change).

I noticed that the include path had "-I/SourceMods/sr.c.cam" on it, which turned out to be because of a _failed expansion_ of CASEROOT, since it's a _CIME_ variable, not an environment variable, so it $ENV{'CASEROOT'} expands to an emptry string.

The actual SourceMods/src.cam directory is included via the 'usr_src' bit, which is why everything still works.

Since all of this goes away with CAM-SIMA, if it's not worth merging now I understand, especially this close to release.  I have some other PRs that will greatly reduce warnings that are reported on builds, but they go into other repos.