### PR TITLE
part of cam6_4_202: Moves pointers to local vs module-level (makes them private to threads)

### DIFF
--- a/src/physics/cam/gw_drag_cam.F90
+++ b/src/physics/cam/gw_drag_cam.F90
@@ -151,13 +151,6 @@ module gw_drag_cam
   integer :: pgwv_long = -1
   real(r8) :: gw_dc_long = unset_r8
 
-  !  New couplings from CLUBB
-  real(r8), pointer :: ttend_clubb(:,:)
-  real(r8), pointer :: thlp2_clubb_gw(:,:)
-  real(r8), pointer :: wpthlp_clubb_gw(:,:)
-  real(r8), pointer :: upwp_clubb_gw(:,:)
-  real(r8), pointer :: vpwp_clubb_gw(:,:)
-  real(r8), pointer :: vort4gw(:,:)
 
   ! Gravity wave Ridge scheme namelist
   logical  :: gw_rdg_do_divstream, gw_rdg_do_smooth_regimes, gw_rdg_do_adjust_tauoro, &
@@ -1280,10 +1273,17 @@ subroutine gw_drag_cam_tend(state, pbuf, dt, ptend, cam_in, flx_heat)
 
   integer :: i, k, m
 
+  !  New couplings from CLUBB
+  real(r8), pointer :: ttend_clubb(:,:)
+  real(r8), pointer :: thlp2_clubb_gw(:,:)
+  real(r8), pointer :: wpthlp_clubb_gw(:,:)
+  real(r8), pointer :: upwp_clubb_gw(:,:)
+  real(r8), pointer :: vpwp_clubb_gw(:,:)
+  real(r8), pointer :: vort4gw(:,:)
+
   ! Temperature tendencies from diffusion and kinetic energy.
   real(r8) :: dttdf(pcols,pver)
   real(r8) :: dttke(pcols,pver)
-
   ! pbuf fields
   ! Molecular diffusivity
   real(r8), pointer :: kvt_in(:,:)


### PR DESCRIPTION
This seemed like a simpler choice than declaring them threadprivate.

I have not run the CAM test suite, just a single FHISTC_MTt4s case that I'm benchmarking threads in.  There will be a few more PRs related to threading incoming, and I figure we can test them all together, as each is pretty small.  My test against an unchanged CAM was bit-for-bit.

Partially address #1650 

Once all are in, we can close the issue.