### PR TITLE
refactor(utils): allow optional errmsg in handle_allocate_error

### DIFF
--- a/src/utils/cam_abortutils.F90
+++ b/src/utils/cam_abortutils.F90
@@ -12,19 +12,25 @@ module cam_abortutils
 
 CONTAINS
 
-   subroutine handle_allocate_error(retval, subname, fieldname)
+   subroutine handle_allocate_error(retval, subname, fieldname, errmsg)
       ! if <retval> is not zero, generate an error message and abort
       ! Dummy arguments
       integer,          intent(in) :: retval
       character(len=*), intent(in) :: subname
       character(len=*), intent(in) :: fieldname
+      character(len=*), optional, intent(in) :: errmsg
+
       ! Local variable
-      character(len=SHR_KIND_CL)   :: errmsg
+      character(len=SHR_KIND_CL)   :: abort_msg
 
       if (retval /= 0) then
-         write(errmsg, '(4a,i0)') trim(subname), ' error allocating ',        &
+         write(abort_msg, '(4a,i0)') trim(subname), ' error allocating ',      &
               trim(fieldname), ', error = ', retval
-         call endrun(errmsg)
+         if (present(errmsg)) then
+            abort_msg = trim(abort_msg) // new_line('a') // &
+                        "Allocation failed with: " // trim(errmsg)
+         end if
+         call endrun(abort_msg)
       end if
    end subroutine handle_allocate_error
 


### PR DESCRIPTION
### Description of Changes

Add optional `errmsg` param to `handle_allocate_error` in `src/utils/cam_abortutils.F90` 

Mirrors the fix in [ESCOMP/CAM-SIMA#311](https://github.com/ESCOMP/CAM-SIMA/pull/311).

### Linked Issues

Fixes [ESCOMP/CAM#1322](https://github.com/ESCOMP/CAM/issues/1322)

### Description of Generative AI Usage

Google Antigravity was used to write the code and tests, followed by human-guided verification.

### Answer-Changing & Restart Compatibility

- **Answer Impact**: Bit-for-Bit (B4B). Adds a new optional parameter that nobody uses yet, and which defaults to a no-op.
- **Restart Space**: No restart file or state variable impact.

### Verification Performed

- AI built some adhoc tests to verify behavior with and without errmsg.  Felt a little heavyweight to submit but they do pass. 