### PR TITLE
part of cam6_4_202: SE dycore vertical/tracer threading fixes

### DIFF
--- a/bld/configure
+++ b/bld/configure
@@ -634,7 +634,7 @@ if ($dyn_pkg eq 'fv3' and $spmd eq 'OFF') {
 }
 
 if ($dyn_pkg eq 'se' and $smp eq 'ON') {
-    die "CAM configure: ERROR: The SE dycore does not currently work with threading on. $eol";
+    warn "CAM configure: WARNING: Threading in the SE dycore is only tested for vertical & tracer threads at this time. $eol";
 }
 
 if ($print>=2) { print "Dynamics package: $dyn_pkg$eol"; }

--- a/src/dynamics/se/dycore/fvm_consistent_se_cslam.F90
+++ b/src/dynamics/se/dycore/fvm_consistent_se_cslam.F90
@@ -43,7 +43,7 @@ contains
     use hybvcoord_mod         , only: hvcoord_t
     use constituents          , only: qmin
     use dimensions_mod        , only: large_Courant_incr,irecons_tracer_lev
-    use thread_mod            , only: vert_num_threads, omp_set_nested
+    use thread_mod            , only: vert_num_threads, omp_set_max_active_levels
     implicit none
     type (element_t)      , intent(inout) :: elem(:)
     type (fvm_struct), target     , intent(inout) :: fvm(:)
@@ -88,10 +88,12 @@ contains
        region_num_threads = vert_num_threads
     endif
 
-    call omp_set_nested(.true.)
+    call omp_set_max_active_levels(2)
     !$OMP PARALLEL NUM_THREADS(region_num_threads), DEFAULT(SHARED), &
     !$OMP PRIVATE(hybridnew,kblk,ie,k,kmin,gspts,inv_dp_area,itr), &
-    !$OMP PRIVATE(kmin_jet_local,kmax,kmax_jet_local,kptr,q,ctracer,ActiveJetThread)
+    !$OMP PRIVATE(kmin_jet_local,kmax,kmax_jet_local,kptr,q,ctracer,ActiveJetThread), &
+    !$OMP PRIVATE(i,j,fcube,spherecentroid,gsweights,klev)
+
     call gauss_points(ngpc,gsweights,gspts) !set gauss points/weights
     gspts = 0.5_r8*(gspts+1.0_r8) !shift location so in [0:1] instead of [-1:1]
 
@@ -196,8 +198,9 @@ contains
     !
     if (large_Courant_incr) then
       if(FVM_TIMERS) call t_startf('fvm:fill_halo_fvm:large_Courant')
+      ! Every thread applies the increment to its own level block (kmin:kmax), so every thread is now active.
+      ActiveJetThread = .true.
       ! Determine the extent of the JET that is owned by this thread
-      ActiveJetThread = threadOwnsVertLevel(hybridnew,1) .or. threadOwnsVertLevel(hybridnew,nlev)
       kmin_jet_local = max(1,kmin)
       kmax_jet_local = min(nlev,kmax)
       klev = nlev
@@ -258,7 +261,7 @@ contains
       if(FVM_TIMERS) call t_stopf('fvm:cslam_q_filter')
     end if
     !$OMP END PARALLEL
-    call omp_set_nested(.false.)
+    call omp_set_max_active_levels(1)
   end subroutine run_consistent_se_cslam
 
   subroutine swept_flux(elem,fvm,ilev,ctracer,irecons_tracer_actual,gsweights,gspts)

--- a/src/dynamics/se/dycore/prim_advance_mod.F90
+++ b/src/dynamics/se/dycore/prim_advance_mod.F90
@@ -4,7 +4,7 @@ module prim_advance_mod
   use perf_mod,       only: t_startf, t_stopf, t_adj_detailf !, t_barrierf _EXTERNAL
   use cam_abortutils, only: endrun
   use parallel_mod,   only: parallel_t, HME_BNDRY_P2P!,HME_BNDRY_A2A
-  use thread_mod ,    only: horz_num_threads, vert_num_threads, omp_set_nested
+  use thread_mod ,    only: horz_num_threads, vert_num_threads, omp_set_max_active_levels
 
   implicit none
   private
@@ -110,7 +110,7 @@ contains
     !                 (K&G 2nd order method has CFL=4. tiny CFL improvement not worth 2nd order)
     !
 
-    call omp_set_nested(.true.)
+    call omp_set_max_active_levels(2)
 
     ! default weights for computing mean dynamics fluxes
     eta_ave_w = 1._r8/qsplit
@@ -262,7 +262,7 @@ contains
     end do
     tevolve=tevolve+dt
 
-    call omp_set_nested(.false.)
+    call omp_set_max_active_levels(1)
 
   end subroutine prim_advance_exp
 
@@ -672,7 +672,7 @@ contains
 
       call tot_energy_dyn(elem,fvm,nets,nete,nt,qn0,'dCH')
       do ie=nets,nete
-        !$omp parallel do num_threads(vert_num_threads), private(k,i,j,v1,v2,heating)
+        !$omp parallel do num_threads(vert_num_threads), private(k,i,j,v1,v2,v1new,v2new,heating)
         do k=sponge_del4_lev+2,nlev
           !
           ! only do "frictional heating" away from sponge
@@ -945,7 +945,7 @@ contains
           !
           ! no frictional heating for artificial sponge
           !
-          !$omp parallel do num_threads(vert_num_threads) private(k,i,j,v1,v2,v1new,v2new)
+          !$omp parallel do num_threads(vert_num_threads) private(k,i,j,v1,v2,v1new,v2new,heating)
           do k=1,ksponge_end
             !OMP_COLLAPSE_SIMD
             !DIR_VECTOR_ALIGNED

--- a/src/dynamics/se/dycore/prim_advection_mod.F90
+++ b/src/dynamics/se/dycore/prim_advection_mod.F90
@@ -954,7 +954,7 @@ contains
     use physconst,              only: pi
     use air_composition,        only: thermodynamic_active_species_idx_dycore
     use cam_thermo,             only: get_enthalpy, get_virtual_temp, get_dp, MASS_MIXING_RATIO
-    use thread_mod,             only: omp_set_nested
+    use thread_mod,             only: omp_set_max_active_levels
     use control_mod,            only: vert_remap_uvTq_alg
     type (hybrid_t),  intent(in)    :: hybrid  ! distributed parallel structure (shared)
     type(fvm_struct), intent(inout) :: fvm(:)
@@ -1094,14 +1094,14 @@ contains
           end do
         end do
         if(ntrac>tracer_num_threads) then
-          call omp_set_nested(.true.)
+          call omp_set_max_active_levels(2)
           !$OMP PARALLEL NUM_THREADS(tracer_num_threads), DEFAULT(SHARED), PRIVATE(hybridnew2,qbeg,qend)
           hybridnew2 = config_thread_region(hybrid,'ctracer')
           call get_loop_ranges(hybridnew2, qbeg=qbeg, qend=qend)
-          call remap1(fvm(ie)%c(1:nc,1:nc,:,1:ntrac),nc,qbeg,qend,ntrac,dpc_star, &
-                      fvm(ie)%dp_fvm(1:nc,1:nc,:),ptop,0,.false.,kord_tr_cslam)
+          call remap1(fvm(ie)%c(1:nc,1:nc,:,qbeg:qend),nc,1,qend-qbeg+1,qend-qbeg+1,dpc_star, &
+                      fvm(ie)%dp_fvm(1:nc,1:nc,:),ptop,0,.false.,kord_tr_cslam(qbeg:qend))
           !$OMP END PARALLEL
-          call omp_set_nested(.false.)
+          call omp_set_max_active_levels(1)
         else
           call remap1(fvm(ie)%c(1:nc,1:nc,:,1:ntrac),nc,1,ntrac,ntrac,dpc_star, &
                       fvm(ie)%dp_fvm(1:nc,1:nc,:),ptop,0,.false.,kord_tr_cslam)

--- a/src/dynamics/se/dycore/prim_driver_mod.F90
+++ b/src/dynamics/se/dycore/prim_driver_mod.F90
@@ -11,7 +11,7 @@ module prim_driver_mod
 
   use element_mod,            only: element_t, timelevels, allocate_element_desc
   use thread_mod ,            only: horz_num_threads, vert_num_threads, tracer_num_threads
-  use thread_mod ,            only: omp_set_nested
+  use thread_mod ,            only: omp_set_max_active_levels
   use perf_mod,               only: t_startf, t_stopf
   use prim_init,              only: gp, fvm_corners, fvm_points
 
@@ -547,7 +547,7 @@ contains
       else
         region_num_threads = tracer_num_threads
       end if
-      call omp_set_nested(.true.)
+      call omp_set_max_active_levels(2)
       !$OMP PARALLEL NUM_THREADS(region_num_threads), DEFAULT(SHARED), PRIVATE(hybridnew)
       if (use_cslam) then
         hybridnew = config_thread_region(hybrid,'serial')
@@ -556,7 +556,7 @@ contains
       end if
       call Prim_Advec_Tracers_remap(elem, deriv,hvcoord,hybridnew,dt_q,tl,nets,nete)
       !$OMP END PARALLEL
-      call omp_set_nested(.false.)
+      call omp_set_max_active_levels(1)
       call t_stopf('prim_advec_tracers_remap')
     end if
    if (use_cslam) then

--- a/src/dynamics/se/dycore/thread_mod.F90
+++ b/src/dynamics/se/dycore/thread_mod.F90
@@ -7,7 +7,8 @@ module thread_mod
        omp_get_max_threads, &
        omp_get_num_threads, &
        omp_get_nested,      &
-       omp_set_nested
+       omp_set_nested,      &
+       omp_set_max_active_levels
 #endif
   use cam_logfile,            only: iulog
   use spmd_utils,             only: masterproc
@@ -25,6 +26,7 @@ module thread_mod
   public :: omp_get_num_threads
   public :: omp_get_nested
   public :: omp_set_nested
+  public :: omp_set_max_active_levels
   public :: initomp
 contains
 
@@ -60,6 +62,10 @@ contains
   subroutine omp_set_nested(flag)
     logical :: flag
   end subroutine omp_set_nested
+
+  subroutine omp_set_max_active_levels(level)
+    integer :: level
+  end subroutine omp_set_max_active_levels
 
   subroutine initomp
     max_num_threads = 1

--- a/src/dynamics/se/dycore/vertremap_mod.F90
+++ b/src/dynamics/se/dycore/vertremap_mod.F90
@@ -63,7 +63,7 @@ module vertremap_mod
 
       if (any(kord(:) >= 0)) then
         if (.not.qdp_mass) then
-          do itrac=1,qsize
+          do itrac=qstart,qstop
             if (kord(itrac) >= 0) then
               Qdp(:,:,:,itrac) = Qdp(:,:,:,itrac)*dp1(:,:,:)
             end if
@@ -71,7 +71,7 @@ module vertremap_mod
         end if
         call remap_Q_ppm(qdp,nx,qstart,qstop,qsize,dp1,dp2,kord)
         if (.not.qdp_mass) then
-          do itrac=1,qsize
+          do itrac=qstart,qstop
             if (kord(itrac) >= 0) then
               Qdp(:,:,:,itrac) = Qdp(:,:,:,itrac)/dp2(:,:,:)
             end if
@@ -100,7 +100,7 @@ module vertremap_mod
         !
         if (qdp_mass) then
           inv_dp = 1.0_r8/dp1
-          do itrac=1,qsize
+          do itrac=qstart,qstop
             if (kord(itrac)<0) then
               Qdp(:,:,:,itrac) = Qdp(:,:,:,itrac)*inv_dp(:,:,:)
             end if
@@ -124,7 +124,7 @@ module vertremap_mod
               end do
             end do
 
-            do itrac=1,qsize
+            do itrac=qstart,qstop
               if (kord(itrac)<0) then
                 call map1_ppm( nlev, pe1(:,:),   Qdp(:,:,:,itrac),   gz,   &
                      nlev, pe2(:,:),    Qdp(:,:,:,itrac),               &
@@ -145,7 +145,7 @@ module vertremap_mod
               end do
             end do
             pe1(:,nlev+1) = pe2(:,nlev+1)
-            do itrac=1,qsize
+            do itrac=qstart,qstop
               if (kord(itrac)<0) then
                 call map1_ppm( nlev, pe1(:,:),   Qdp(:,:,:,itrac),   gz,   &!phl
                      nlev, pe2(:,:),    Qdp(:,:,:,itrac),               &
@@ -157,7 +157,7 @@ module vertremap_mod
           end do
         end if
         if (qdp_mass) then
-          do itrac=1,qsize
+          do itrac=qstart,qstop
             if (kord(itrac)<0) then
               Qdp(:,:,:,itrac) = Qdp(:,:,:,itrac)*dp2(:,:,:)
             end if

--- a/src/physics/rrtmgp/radiation.F90
+++ b/src/physics/rrtmgp/radiation.F90
@@ -152,13 +152,6 @@ logical :: spectralflux     = .false. ! calculate fluxes (up and down) per band.
 logical :: graupel_in_rad   = .false. ! graupel in radiation code
 logical :: use_rad_uniform_angle = .false. ! if true, use the namelist rad_uniform_angle for the coszrs calculation
 
-! Gathered indices of day and night columns
-integer :: nday           ! Number of daylight columns
-integer :: nnite          ! Number of night columns
-integer :: idxday(pcols)   ! chunk indices of daylight columns
-integer :: idxnite(pcols) ! chunk indices of night columns
-real(r8) :: coszrs(pcols)   ! Cosine solar zenith angle
-real(r8) :: eccf            ! Earth orbit eccentricity factor
 
 integer :: band2gpt_sw(2,nswbands)
 
@@ -881,6 +874,12 @@ subroutine radiation_tend( &
    real(r8) :: clat(pcols)     ! current latitudes(radians)
    real(r8) :: clon(pcols)     ! current longitudes(radians)
    real(r8) :: coszrs(pcols)   ! Cosine solar zenith angle
+
+   ! Gathered indices of day and night columns.  These are per-chunk and must be local to the function
+   integer  :: nday            ! Number of daylight columns
+   integer  :: nnite           ! Number of night columns
+   integer  :: idxday(pcols)   ! chunk indices of daylight columns
+   integer  :: idxnite(pcols)  ! chunk indices of night columns
 
    integer :: itim_old
    integer :: nextsw_nstep


### PR DESCRIPTION
This PR has multiple small changes to enable threading in the SE dycore again -- it fixes some race conditions, updates the OpenMP standard to 5.0 (circa 2018), and has been tested as bit-for-bit with 1-4 threads on the same MTt4s case.

Partial fix for #1650
